### PR TITLE
feat: 회원가입 POST api 구현 및 엔티티 컬럼 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.rest-assured:rest-assured'
 }
 
 tasks.named('test') {

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -1,0 +1,25 @@
+package mocacong.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.MemberSignUpResponse;
+import mocacong.server.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody MemberSignUpRequest request) {
+        MemberSignUpResponse response = memberService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -25,10 +25,14 @@ public class Member {
     @Column(name = "nickname", nullable = false)
     private String nickname;
 
-    public Member(String email, String password, String nickname) {
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    public Member(String email, String password, String nickname, String phone) {
         // TODO: 검증 로직 프론트와 회의 후 작성하기
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+        this.phone = phone;
     }
 }

--- a/src/main/java/mocacong/server/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/mocacong/server/dto/request/MemberSignUpRequest.java
@@ -13,4 +13,5 @@ public class MemberSignUpRequest {
     private String email;
     private String password;
     private String nickname;
+    private String phone;
 }

--- a/src/main/java/mocacong/server/dto/response/MemberSignUpResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberSignUpResponse.java
@@ -1,0 +1,14 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberSignUpResponse {
+
+    private Long id;
+}

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -8,7 +8,6 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +20,7 @@ public class MemberService {
         validateDuplicateMember(request);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
-        Member member = new Member(request.getEmail(), encodedPassword, request.getNickname());
+        Member member = new Member(request.getEmail(), encodedPassword, request.getNickname(), request.getPhone());
         return memberRepository.save(member)
                 .getId();
     }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -3,6 +3,7 @@ package mocacong.server.service;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
@@ -16,13 +17,12 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public Long signUp(MemberSignUpRequest request) {
+    public MemberSignUpResponse signUp(MemberSignUpRequest request) {
         validateDuplicateMember(request);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         Member member = new Member(request.getEmail(), encodedPassword, request.getNickname(), request.getPhone());
-        return memberRepository.save(member)
-                .getId();
+        return new MemberSignUpResponse(memberRepository.save(member).getId());
     }
 
     private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {

--- a/src/test/java/mocacong/server/acceptance/AcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/AcceptanceTest.java
@@ -1,0 +1,18 @@
+package mocacong.server.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUP() {
+        RestAssured.port = port;
+    }
+}

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,31 @@
+package mocacong.server.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import mocacong.server.dto.request.MemberSignUpRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("회원을 정상적으로 가입한다")
+    void signUp() {
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "1234", "케이", "010-1234-5678");
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/members")
+                .then().log().all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -38,7 +38,7 @@ class MemberServiceTest {
     @DisplayName("회원을 정상적으로 가입한다")
     void signUp() {
         String expected = "kth990303@naver.com";
-        MemberSignUpRequest request = new MemberSignUpRequest(expected, "1234", "케이");
+        MemberSignUpRequest request = new MemberSignUpRequest(expected, "1234", "케이", "010-1234-5678");
 
         memberService.signUp(request);
 
@@ -51,8 +51,8 @@ class MemberServiceTest {
     @DisplayName("이미 가입된 회원이 존재하면 회원 가입 시에 예외를 반환한다")
     void signUpByDuplicateMember() {
         String expected = "kth990303@naver.com";
-        MemberSignUpRequest request = new MemberSignUpRequest(expected, "1234", "케이");
-        memberRepository.save(new Member(expected, "1234", "케이"));
+        MemberSignUpRequest request = new MemberSignUpRequest(expected, "1234", "케이", "010-1234-5678");
+        memberRepository.save(new Member(expected, "1234", "케이", "010-1234-5678"));
 
         assertThatThrownBy(() -> memberService.signUp(request))
                 .isInstanceOf(DuplicateMemberException.class);
@@ -61,7 +61,7 @@ class MemberServiceTest {
     @Test
     @DisplayName("회원을 정상적으로 탈퇴한다")
     void delete() {
-        Member savedMember = memberRepository.save(new Member("kth990303@naver.com", "1234", "케이"));
+        Member savedMember = memberRepository.save(new Member("kth990303@naver.com", "1234", "케이", "010-1234-5678"));
 
         memberService.delete(savedMember.getId());
 
@@ -78,7 +78,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원 비밀번호를 정상적으로 암호화한다")
-    void encryptPassword(){
+    void encryptPassword() {
         String rawPassword = "1234";
 
         String encryptedPassword = passwordEncoder.encode(rawPassword);


### PR DESCRIPTION
## 개요
- 회원가입 POST API 작성 및 Member 엔티티 변경

## 작업사항
- 회원가입 api를 담당하는 MemberController를 생성했습니다.
- 인수테스트 틀을 작성했습니다.
  - 인수테스트에서 status code만 확인하고 있는데, 이후에 다른 api가 추가되면 조회 api로 정말 회원가입이 됐는지도 추가확인할 예정입니다. 
  - 아직 테스트 격리 틀은 따로 짜지 않았습니다.  
- api 스펙 변경으로 인해 phone 컬럼을 추가했습니다.

## 주의사항
- 인수테스트에서 `RestAssured`를 사용합니다. 참고해주세요.
