### PR TITLE
feat: swagger 환경설정 및 api 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/mocacong/server/config/SwaggerConfig.java
+++ b/src/main/java/mocacong/server/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package mocacong.server.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "모카콩(mocacong) 백엔드 API 명세",
+                description = "springdoc을 이용한 Swagger API 문서입니다.",
+                version = "1.0",
+                contact = @Contact(
+                        name = "springdoc 공식문서",
+                        url = "https://springdoc.org/"
+                )
+        )
+)
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("JWT", bearerAuth()));
+    }
+
+    public SecurityScheme bearerAuth() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+    }
+}

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -1,5 +1,7 @@
 package mocacong.server.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.MemberSignUpResponse;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Members", description = "회원")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
@@ -17,6 +20,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @Operation(summary = "회원가입")
     @PostMapping
     public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody MemberSignUpRequest request) {
         MemberSignUpResponse response = memberService.signUp(request);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,13 @@ spring:
   h2:
     console:
       enabled: true
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha


### PR DESCRIPTION
## 개요
- 프론트 측에서 백엔드 API를 postman 없이 UI 상에서 편리하게 이용할 수 있도록 Swagger를 세팅했습니다.
<img width="679" alt="image" src="https://user-images.githubusercontent.com/57135043/227469197-95b60b3c-31ae-461c-ba04-5f2ef2dc5f71.png">


## 작업사항
- Swagger 세팅 및 API에 적용 
- api response code가 200 아니면 400번대 500번대이기 때문에 `@ApiResponses`는 사용하지 않았습니다.

## 주의사항
- 애플리케이션 실행 후 `swagger-ui/index.html`로 접속해서 실행이 잘 되는지 확인해주세요.
- 추가적으로 원하는 스웨거 설정이 있다면 편하게 얘기해주세요.
