### PR TITLE
feat: 통합 및 인수테스트 격리 틀 세팅 구현

### DIFF
--- a/src/main/java/mocacong/server/domain/Score.java
+++ b/src/main/java/mocacong/server/domain/Score.java
@@ -16,6 +16,7 @@ public class Score {
     private static final int MINIMUM_SCORE = 1;
 
     @Id
+    @Column(name = "score_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/test/java/mocacong/server/acceptance/AcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/AcceptanceTest.java
@@ -1,11 +1,14 @@
 package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
+import mocacong.server.support.DatabaseCleanerCallback;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(DatabaseCleanerCallback.class)
 public class AcceptanceTest {
 
     @LocalServerPort

--- a/src/test/java/mocacong/server/service/AuthServiceTest.java
+++ b/src/test/java/mocacong/server/service/AuthServiceTest.java
@@ -5,18 +5,16 @@ import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.repository.MemberRepository;
-import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@SpringBootTest
+@ServiceTest
 class AuthServiceTest {
+
     @Autowired
     private MemberRepository memberRepository;
     @Autowired
@@ -24,15 +22,8 @@ class AuthServiceTest {
     @Autowired
     private AuthService authService;
 
-
-    @BeforeEach
-    void setUp() {
-        // TODO: 스프링 빈 초기화 시 DB Truncate 하는 로직 작성하기
-        memberRepository.deleteAll();
-    }
-
-    @DisplayName("회원 로그인 요청이 옳다면 토큰을 발급한다")
     @Test
+    @DisplayName("회원 로그인 요청이 옳다면 토큰을 발급한다")
     void login() {
         String email = "kth990303@naver.com";
         String password = "1234";
@@ -46,8 +37,8 @@ class AuthServiceTest {
         assertNotNull(tokenResponse.getToken());
     }
 
-    @DisplayName("회원 로그인 요청이 올바르지 않다면 예외가 발생한다")
     @Test
+    @DisplayName("회원 로그인 요청이 올바르지 않다면 예외가 발생한다")
     void loginWithException() {
         String email = "kth990303@naver.com";
         String password = "1234";

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -8,14 +8,12 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@SpringBootTest
+@ServiceTest
 class MemberServiceTest {
 
     @Autowired
@@ -24,15 +22,6 @@ class MemberServiceTest {
     private MemberService memberService;
     @Autowired
     private PasswordEncoder passwordEncoder;
-
-    MemberServiceTest() {
-    }
-
-    @BeforeEach
-    void setUp() {
-        // TODO: 스프링 빈 초기화 시 DB Truncate 하는 로직 작성하기
-        memberRepository.deleteAll();
-    }
 
     @Test
     @DisplayName("회원을 정상적으로 가입한다")

--- a/src/test/java/mocacong/server/service/ServiceTest.java
+++ b/src/test/java/mocacong/server/service/ServiceTest.java
@@ -1,0 +1,16 @@
+package mocacong.server.service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import mocacong.server.support.DatabaseCleanerCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(DatabaseCleanerCallback.class)
+public @interface ServiceTest {
+}

--- a/src/test/java/mocacong/server/support/DatabaseCleaner.java
+++ b/src/test/java/mocacong/server/support/DatabaseCleaner.java
@@ -2,16 +2,16 @@ package mocacong.server.support;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Table;
 import javax.persistence.metamodel.Type;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-public class DatabaseCleaner implements InitializingBean {
+public class DatabaseCleaner {
 
     private static final String FOREIGN_KEY_RULE_UPDATE_FORMAT = "SET REFERENTIAL_INTEGRITY %s";
     private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
@@ -22,8 +22,8 @@ public class DatabaseCleaner implements InitializingBean {
 
     private List<String> tableNames;
 
-    @Override
-    public void afterPropertiesSet() {
+    @PostConstruct
+    public void findTableNames() {
         this.tableNames = entityManager.getMetamodel()
                 .getEntities()
                 .stream()

--- a/src/test/java/mocacong/server/support/DatabaseCleaner.java
+++ b/src/test/java/mocacong/server/support/DatabaseCleaner.java
@@ -1,0 +1,48 @@
+package mocacong.server.support;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Table;
+import javax.persistence.metamodel.Type;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    private static final String FOREIGN_KEY_RULE_UPDATE_FORMAT = "SET REFERENTIAL_INTEGRITY %s";
+    private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
+    private static final String ID_RESET_FORMAT = "ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1";
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        this.tableNames = entityManager.getMetamodel()
+                .getEntities()
+                .stream()
+                .map(Type::getJavaType)
+                .map(javaType -> javaType.getAnnotation(Table.class))
+                .map(Table::name)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_RULE_UPDATE_FORMAT, "FALSE"))
+                .executeUpdate();
+        for (final String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
+            entityManager.createNativeQuery(String.format(ID_RESET_FORMAT, tableName, tableName)).executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_RULE_UPDATE_FORMAT, "TRUE"))
+                .executeUpdate();
+    }
+}

--- a/src/test/java/mocacong/server/support/DatabaseCleanerCallback.java
+++ b/src/test/java/mocacong/server/support/DatabaseCleanerCallback.java
@@ -1,0 +1,15 @@
+package mocacong.server.support;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerCallback implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        SpringExtension.getApplicationContext(context)
+                .getBean(DatabaseCleaner.class)
+                .execute();
+    }
+}


### PR DESCRIPTION
## 개요
- 통합테스트와 인수테스트에서 `SpringBootTest.WebEnvironment.RANDOM_PORT` 환경을 사용하므로 `@Transactional`이 의도대로 동작하지 않아 테스트 격리가 되지 않습니다. `@DirtiesContext`를 이용한 애플리케이션 컨텍스트 재생성은 굉장히 느리다는 단점이 존재합니다. (참고: https://kth990303.tistory.com/371) 

## 작업사항
- 스프링 빈 초기화 콜백 시에 truncate 및 id restart 1 조건을 설정하여 격리시켜주었습니다. `deleteAll()`방법으로도 db를 비워줄 수 있지만, id 값이 1 로 초기화되지 않아 완전한 격리라 보기 어려워서 해당 pr을 날리게 됐습니다.
- 인수테스트에서는 AcceptanceTest 상속만으로, 통합테스트(service Test)에서는 `@ServiceTest` 어노테이션만으로 구축이 가능합니다.

## 주의사항
- 스프링 빈 초기화 콜백 및 빈 사이클에 대한 이해도가 필요한 PR입니다.
- 각 엔티티의 id 컬럼명은 반드시 `{TableName}_id`로, 각 엔티티에는 `@Table` 어노테이션이 있어야 올바르게 동작합니다.
- #8 pr에 테스트가 추가될 경우 Git 충돌이 날 수 있습니다. 머지 순서를 명확하게 정해야 좋을 듯합니다.
