### PR TITLE
feat: 회원가입 시 중복체크 api 구현

### DIFF
--- a/src/main/java/mocacong/server/config/AuthConfig.java
+++ b/src/main/java/mocacong/server/config/AuthConfig.java
@@ -1,6 +1,5 @@
 package mocacong.server.config;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.security.auth.AuthenticationPrincipalArgumentResolver;
 import mocacong.server.security.auth.LoginInterceptor;
@@ -8,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -20,7 +21,7 @@ public class AuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
-                .excludePathPatterns("/members", "/login");
+                .excludePathPatterns("/members", "/login", "/members/check-duplicate/email");
     }
 
     @Override

--- a/src/main/java/mocacong/server/config/AuthConfig.java
+++ b/src/main/java/mocacong/server/config/AuthConfig.java
@@ -21,7 +21,7 @@ public class AuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
-                .excludePathPatterns("/members", "/login", "/members/check-duplicate/email");
+                .excludePathPatterns("/members", "/login", "/members/check-duplicate/email", "/members/check-duplicate/nickname");
     }
 
     @Override

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.IsDuplicateEmailResponse;
+import mocacong.server.dto.response.IsDuplicateNicknameResponse;
 import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
@@ -30,14 +32,16 @@ public class MemberController {
 
     @Operation(summary = "회원가입 이메일 중복체크")
     @GetMapping("/check-duplicate/email")
-    public boolean checkDuplicateEmail(@RequestParam String value) {
-        return memberService.isDuplicateEmail(value);
+    public ResponseEntity<IsDuplicateEmailResponse> checkDuplicateEmail(@RequestParam String value) {
+        IsDuplicateEmailResponse response = memberService.isDuplicateEmail(value);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "회원가입 닉네임 중복체크")
     @GetMapping("/check-duplicate/nickname")
-    public boolean checkDuplicateNickname(@RequestParam String value) {
-        return memberService.isDuplicateNickname(value);
+    public ResponseEntity<IsDuplicateNicknameResponse> checkDuplicateNickname(@RequestParam String value) {
+        IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(value);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "회원탈퇴")

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -30,8 +30,8 @@ public class MemberController {
 
     @Operation(summary = "회원가입 이메일 중복체크")
     @GetMapping("/check-duplicate/email")
-    public boolean checkDuplicateEmail(@RequestParam String email) {
-        return memberService.isDuplicateEmail(email);
+    public boolean checkDuplicateEmail(@RequestParam String value) {
+        return memberService.isDuplicateEmail(value);
     }
 
     @Operation(summary = "회원탈퇴")

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -3,14 +3,15 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.MemberSignUpResponse;
+import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -25,6 +26,12 @@ public class MemberController {
     public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody @Valid MemberSignUpRequest request) {
         MemberSignUpResponse response = memberService.signUp(request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "회원가입 이메일 중복체크")
+    @GetMapping("/check-duplicate/email")
+    public boolean checkDuplicateEmail(@RequestParam String email) {
+        return memberService.isDuplicateEmail(email);
     }
 
     @Operation(summary = "회원탈퇴")

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -34,6 +34,12 @@ public class MemberController {
         return memberService.isDuplicateEmail(value);
     }
 
+    @Operation(summary = "회원가입 닉네임 중복체크")
+    @GetMapping("/check-duplicate/nickname")
+    public boolean checkDuplicateNickname(@RequestParam String value) {
+        return memberService.isDuplicateNickname(value);
+    }
+
     @Operation(summary = "회원탈퇴")
     @SecurityRequirement(name = "JWT")
     @DeleteMapping

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class IsDuplicateEmailResponse {
 
-    private Boolean result;
+    private boolean result;
 }

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
@@ -1,9 +1,6 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,4 +8,8 @@ import lombok.NoArgsConstructor;
 public class IsDuplicateEmailResponse {
 
     private boolean result;
+
+    public boolean isDuplicate() {
+        return result;
+    }
 }

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
@@ -1,0 +1,14 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class IsDuplicateEmailResponse {
+
+    private Boolean result;
+}

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
@@ -11,4 +11,8 @@ import lombok.NoArgsConstructor;
 public class IsDuplicateNicknameResponse {
 
     private boolean result;
+
+    public boolean isDuplicate() {
+        return result;
+    }
 }

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class IsDuplicateNicknameResponse {
 
-    private Boolean result;
+    private boolean result;
 }

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
@@ -1,0 +1,14 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class IsDuplicateNicknameResponse {
+
+    private Boolean result;
+}

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidEmailException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidEmailException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class InvalidEmailException extends BadRequestException {
+
+    public InvalidEmailException() {
+        super("이메일 형식이 올바르지 않습니다.", 1006);
+    }
+}

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package mocacong.server.repository;
 
-import java.util.Optional;
 import mocacong.server.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -3,6 +3,8 @@ package mocacong.server.service;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.IsDuplicateEmailResponse;
+import mocacong.server.dto.response.IsDuplicateNicknameResponse;
 import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
@@ -51,16 +53,16 @@ public class MemberService {
         memberRepository.delete(findMember);
     }
 
-    public boolean isDuplicateEmail(String email) {
+    public IsDuplicateEmailResponse isDuplicateEmail(String email) {
         Optional<Member> findMember = memberRepository.findByEmail(email);
-        return findMember.isPresent();
+        return new IsDuplicateEmailResponse(findMember.isPresent());
     }
 
-    public boolean isDuplicateNickname(String nickname) {
+    public IsDuplicateNicknameResponse isDuplicateNickname(String nickname) {
         if (nickname == null || nickname.length() == 0) {
             throw new InvalidNicknameException();
         }
         Optional<Member> findMember = memberRepository.findByNickname(nickname);
-        return findMember.isPresent();
+        return new IsDuplicateNicknameResponse(findMember.isPresent());
     }
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -5,6 +5,7 @@ import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
+import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPasswordException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
@@ -55,5 +56,11 @@ public class MemberService {
         return findMember.isPresent();
     }
 
-
+    public boolean isDuplicateNickname(String nickname) {
+        if (nickname == null || nickname.length() == 0) {
+            throw new InvalidNicknameException();
+        }
+        Optional<Member> findMember = memberRepository.findByNickname(nickname);
+        return findMember.isPresent();
+    }
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -17,7 +17,6 @@ import java.util.regex.Pattern;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-
     private static final Pattern PASSWORD_REGEX = Pattern.compile("^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,20}$");
 
     private final MemberRepository memberRepository;

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -64,7 +64,7 @@ public class MemberService {
     public IsDuplicateNicknameResponse isDuplicateNickname(String nickname) {
         validateNickname(nickname);
 
-        Optional<Member> findMember = memberRepository.findByEmail(nickname);
+        Optional<Member> findMember = memberRepository.findByNickname(nickname);
         return new IsDuplicateNicknameResponse(findMember.isPresent());
     }
 

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -7,6 +7,7 @@ import mocacong.server.dto.response.IsDuplicateEmailResponse;
 import mocacong.server.dto.response.IsDuplicateNicknameResponse;
 import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
+import mocacong.server.exception.badrequest.InvalidEmailException;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPasswordException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
@@ -54,15 +55,28 @@ public class MemberService {
     }
 
     public IsDuplicateEmailResponse isDuplicateEmail(String email) {
+        validateEmail(email);
+
         Optional<Member> findMember = memberRepository.findByEmail(email);
         return new IsDuplicateEmailResponse(findMember.isPresent());
     }
 
     public IsDuplicateNicknameResponse isDuplicateNickname(String nickname) {
-        if (nickname == null || nickname.length() == 0) {
+        validateNickname(nickname);
+
+        Optional<Member> findMember = memberRepository.findByEmail(nickname);
+        return new IsDuplicateNicknameResponse(findMember.isPresent());
+    }
+
+    public void validateEmail(String email) {
+        if (email.isBlank()) {
+            throw new InvalidEmailException();
+        }
+    }
+
+    public void validateNickname(String nickname) {
+        if (nickname.isBlank()) {
             throw new InvalidNicknameException();
         }
-        Optional<Member> findMember = memberRepository.findByNickname(nickname);
-        return new IsDuplicateNicknameResponse(findMember.isPresent());
     }
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -61,6 +61,12 @@ public class MemberService {
         return new IsDuplicateEmailResponse(findMember.isPresent());
     }
 
+    private void validateEmail(String email) {
+        if (email.isBlank()) {
+            throw new InvalidEmailException();
+        }
+    }
+
     public IsDuplicateNicknameResponse isDuplicateNickname(String nickname) {
         validateNickname(nickname);
 
@@ -68,13 +74,7 @@ public class MemberService {
         return new IsDuplicateNicknameResponse(findMember.isPresent());
     }
 
-    public void validateEmail(String email) {
-        if (email.isBlank()) {
-            throw new InvalidEmailException();
-        }
-    }
-
-    public void validateNickname(String nickname) {
+    private void validateNickname(String nickname) {
         if (nickname.isBlank()) {
             throw new InvalidNicknameException();
         }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -1,6 +1,5 @@
 package mocacong.server.service;
 
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
@@ -11,6 +10,9 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -48,4 +50,11 @@ public class MemberService {
                 .orElseThrow(NotFoundMemberException::new);
         memberRepository.delete(findMember);
     }
+
+    public boolean isDuplicateEmail(String email) {
+        Optional<Member> findMember = memberRepository.findByEmail(email);
+        return findMember.isPresent();
+    }
+
+
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import static mocacong.server.acceptance.AcceptanceFixtures.로그인_토큰_발급;
 import static mocacong.server.acceptance.AcceptanceFixtures.회원_가입;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class MemberAcceptanceTest extends AcceptanceTest {
@@ -53,5 +54,35 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .as(ErrorResponse.class);
 
         assertThat(response.getCode()).isEqualTo(1007);
+    }
+
+    @Test
+    @DisplayName("가입되어 있지 않은 이메일은 이메일 중복검사에서 걸리지 않는다")
+    void isDuplicateWithNonExistingEmail(){
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("value", request.getEmail())
+                .when().get("/members/check-duplicate/email")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .body(equalTo("false"));
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일은 이메일 중복검사에서 걸린다")
+    void isDuplicateWithExistingEmail(){
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+
+        회원_가입(request);
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("value", request.getEmail())
+                .when().get("/members/check-duplicate/email")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .body(equalTo("true"));
     }
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -85,4 +85,62 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .body(equalTo("true"));
     }
+
+    @Test
+    @DisplayName("존재하지 않는 닉네임은 닉네임 중복검사에서 걸리지 않는다")
+    void isDuplicateWithNonExistingNickname() {
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("value", request.getNickname())
+                .when().get("/members/check-duplicate/nickname")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .body(equalTo("false"));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임은 닉네임 중복검사에서 걸린다")
+    void isDuplicateWithExistingNickname() {
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("value", request.getNickname())
+                .when().get("/members/check-duplicate/nickname")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .body(equalTo("false"));
+    }
+
+    @Test
+    @DisplayName("null인 닉네임은 닉네임 중복검사에서 예외를 던진다")
+    void nicknameIsNullReturnException() {
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", null, "010-1234-5678");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("value", request.getNickname())
+                .when().get("/members/check-duplicate/nickname")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("code", equalTo(1009))
+                .body("message", equalTo("닉네임은 영어, 한글로만 구성된 2~6자여야 합니다."));
+    }
+
+    @Test
+    @DisplayName("길이가 0인 닉네임은 닉네임 중복검사에서 예외를 던진다")
+    void nicknameLengthIs0ReturnException() {
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "", "010-1234-5678");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("value", request.getNickname())
+                .when().get("/members/check-duplicate/nickname")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("code", equalTo(1009))
+                .body("message", equalTo("닉네임은 영어, 한글로만 구성된 2~6자여야 합니다."));
+    }
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -67,7 +67,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .when().get("/members/check-duplicate/email")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .body(equalTo("false"));
+                .extract();
     }
 
     @Test
@@ -83,7 +83,21 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .when().get("/members/check-duplicate/email")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .body(equalTo("true"));
+                .extract();
+    }
+
+    @Test
+    @DisplayName("길이가 0인 이메일은 이메일 중복검사에서 예외를 던진다")
+    void emailLengthIs0ReturnException() {
+        MemberSignUpRequest request = new MemberSignUpRequest("", "a1b2c3d4", "메리", "010-1234-5678");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("value", request.getEmail())
+                .when().get("/members/check-duplicate/email")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("code", equalTo(1006));
     }
 
     @Test
@@ -97,7 +111,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .when().get("/members/check-duplicate/nickname")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .body(equalTo("false"));
+                .extract();
     }
 
     @Test
@@ -111,22 +125,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .when().get("/members/check-duplicate/nickname")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .body(equalTo("false"));
-    }
-
-    @Test
-    @DisplayName("null인 닉네임은 닉네임 중복검사에서 예외를 던진다")
-    void nicknameIsNullReturnException() {
-        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", null, "010-1234-5678");
-
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .queryParam("value", request.getNickname())
-                .when().get("/members/check-duplicate/nickname")
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("code", equalTo(1009))
-                .body("message", equalTo("닉네임은 영어, 한글로만 구성된 2~6자여야 합니다."));
+                .extract();
     }
 
     @Test
@@ -140,7 +139,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .when().get("/members/check-duplicate/nickname")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("code", equalTo(1009))
-                .body("message", equalTo("닉네임은 영어, 한글로만 구성된 2~6자여야 합니다."));
+                .body("code", equalTo(1009));
     }
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -1,16 +1,17 @@
 package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
-import static mocacong.server.acceptance.AcceptanceFixtures.로그인_토큰_발급;
-import static mocacong.server.acceptance.AcceptanceFixtures.회원_가입;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.ErrorResponse;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import static mocacong.server.acceptance.AcceptanceFixtures.로그인_토큰_발급;
+import static mocacong.server.acceptance.AcceptanceFixtures.회원_가입;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class MemberAcceptanceTest extends AcceptanceTest {

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -3,6 +3,7 @@ package mocacong.server.service;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
+import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPasswordException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
@@ -80,7 +81,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("중복되는 이메일인 경우 TRUE를 반환한다")
+    @DisplayName("이미 존재하는 이메일인 경우 True를 반환한다")
     void isDuplicateEmailReturnTrue(){
         String email = "dlawotn3@naver.com";
         MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
@@ -92,13 +93,49 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("중복되지 않은 이메일인 경우 FALSE를 반환한다")
+    @DisplayName("존재하지 않는 이메일인 경우 False를 반환한다")
     void isDuplicateEmailReturnFail(){
         String email = "dlawotn3@naver.com";
 
         Boolean result = memberService.isDuplicateEmail(email);
 
         assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임인 경우 True를 반환한다")
+    void isDuplicateNicknameReturnTrue() {
+        String existingNickname = "메리";
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", existingNickname, "010-1234-5678");
+        memberService.signUp(request);
+
+        Boolean result = memberService.isDuplicateNickname(existingNickname);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 닉네임인 경우 False를 반환한다")
+    void isDuplicateNicknameReturnFalse() {
+        String nickname = "메리";
+
+        Boolean result = memberService.isDuplicateNickname(nickname);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("닉네임이 null인 경우 예외를 던진다")
+    void nicknameIsNullReturnException(){
+        assertThatThrownBy(() -> memberService.isDuplicateNickname(null))
+                .isInstanceOf(InvalidNicknameException.class);
+    }
+
+    @Test
+    @DisplayName("닉네임의 길이가 0인 경우 예외를 던진다")
+    void nicknameLengthIs0ReturnException(){
+        assertThatThrownBy(() -> memberService.isDuplicateNickname(""))
+                .isInstanceOf(InvalidNicknameException.class);
     }
 
     @Test

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -2,6 +2,8 @@ package mocacong.server.service;
 
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.IsDuplicateEmailResponse;
+import mocacong.server.dto.response.IsDuplicateNicknameResponse;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPasswordException;
@@ -87,9 +89,9 @@ class MemberServiceTest {
         MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
         memberService.signUp(request);
 
-        Boolean result = memberService.isDuplicateEmail(email);
+        IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(result).isTrue();
+        assertThat(response.getResult()).isTrue();
     }
 
     @Test
@@ -97,21 +99,21 @@ class MemberServiceTest {
     void isDuplicateEmailReturnFail(){
         String email = "dlawotn3@naver.com";
 
-        Boolean result = memberService.isDuplicateEmail(email);
+        IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(result).isFalse();
+        assertThat(response.getResult()).isFalse();
     }
 
     @Test
     @DisplayName("이미 존재하는 닉네임인 경우 True를 반환한다")
     void isDuplicateNicknameReturnTrue() {
-        String existingNickname = "메리";
-        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", existingNickname, "010-1234-5678");
+        String nickname = "메리";
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", nickname, "010-1234-5678");
         memberService.signUp(request);
 
-        Boolean result = memberService.isDuplicateNickname(existingNickname);
+        IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
 
-        assertThat(result).isTrue();
+        assertThat(response.getResult()).isTrue();
     }
 
     @Test
@@ -119,16 +121,9 @@ class MemberServiceTest {
     void isDuplicateNicknameReturnFalse() {
         String nickname = "메리";
 
-        Boolean result = memberService.isDuplicateNickname(nickname);
+        IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
 
-        assertThat(result).isFalse();
-    }
-
-    @Test
-    @DisplayName("닉네임이 null인 경우 예외를 던진다")
-    void nicknameIsNullReturnException(){
-        assertThatThrownBy(() -> memberService.isDuplicateNickname(null))
-                .isInstanceOf(InvalidNicknameException.class);
+        assertThat(response.getResult()).isFalse();
     }
 
     @Test

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -91,17 +91,17 @@ class MemberServiceTest {
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(response.getResult()).isTrue();
+        assertThat(response.isDuplicate()).isTrue();
     }
 
     @Test
     @DisplayName("존재하지 않는 이메일인 경우 False를 반환한다")
-    void isDuplicateEmailReturnFail(){
+    void isDuplicateEmailReturnFalse(){
         String email = "dlawotn3@naver.com";
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(response.getResult()).isFalse();
+        assertThat(response.isDuplicate()).isFalse();
     }
 
     @Test
@@ -113,7 +113,7 @@ class MemberServiceTest {
 
         IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
 
-        assertThat(response.getResult()).isTrue();
+        assertThat(response.isDuplicate()).isTrue();
     }
 
     @Test
@@ -123,7 +123,7 @@ class MemberServiceTest {
 
         IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
 
-        assertThat(response.getResult()).isFalse();
+        assertThat(response.isDuplicate()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## 개요
- 이메일과 닉네임 중복체크 기능 구현 및 이메일과 닉네임 중복 체크 테스트 코드 작성했습니다.

## 작업사항
- 이메일 중복체크 기능을 구현했습니다.
- 이메일 중복체크 인수 테스트 코드를 작성했습니다.
- 닉네임 중복체크 기능을 구현했습니다.
- 닉네임 중복체크 인수 테스트 코드를 작성했습니다.

## 주의사항
- 잘못된 로직의 테스트 코드가 있는지 확인해주세요
- 누락된 테스트 코드가 있는지 확인해주세요
- 내용에 오타가 있는지 확인해주세요
