### PR TITLE
feat: 회원 전체조회 api 구현

### DIFF
--- a/src/main/java/mocacong/server/config/AuthConfig.java
+++ b/src/main/java/mocacong/server/config/AuthConfig.java
@@ -21,7 +21,7 @@ public class AuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
-                .excludePathPatterns("/members", "/login", "/members/check-duplicate/email", "/members/check-duplicate/nickname");
+                .excludePathPatterns("/members", "/login", "/members/check-duplicate/email", "/members/check-duplicate/nickname", "/members/all");
     }
 
     @Override

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.MemberGetResponse;
 import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
@@ -12,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -34,6 +38,17 @@ public class MemberController {
     public ResponseEntity<Void> delete(@LoginUserEmail String email) {
         memberService.delete(email);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원전체조회")
+    @GetMapping
+    public ResponseEntity<List<MemberGetResponse>> getAllMembers() {
+        List<Member> members = memberService.getAllMembers();
+        List<MemberGetResponse> response = members.stream()
+                .map(member -> new MemberGetResponse(member.getId(), member.getEmail(),
+                        member.getNickname(), member.getPhone()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok().body(response);
     }
 
 

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -3,14 +3,15 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.MemberSignUpResponse;
+import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -34,4 +35,6 @@ public class MemberController {
         memberService.delete(email);
         return ResponseEntity.ok().build();
     }
+
+
 }

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -5,14 +5,16 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.MemberSignUpRequest;
-import mocacong.server.dto.response.*;
+import mocacong.server.dto.response.IsDuplicateEmailResponse;
+import mocacong.server.dto.response.IsDuplicateNicknameResponse;
+import mocacong.server.dto.response.MemberGetAllResponse;
+import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -54,7 +56,6 @@ public class MemberController {
     @Operation(summary = "회원전체조회")
     @GetMapping("/all")
     public MemberGetAllResponse getAllMembers() {
-        List<MemberGetResponse> memberList = memberService.getAllMembers();
-        return new MemberGetAllResponse(memberList);
+        return memberService.getAllMembers();
     }
 }

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -41,15 +41,13 @@ public class MemberController {
     }
 
     @Operation(summary = "회원전체조회")
-    @GetMapping
+    @GetMapping("/get")
     public ResponseEntity<List<MemberGetResponse>> getAllMembers() {
-        List<Member> members = memberService.getAllMembers();
+        List<Member> members = memberService.getMembers();
         List<MemberGetResponse> response = members.stream()
                 .map(member -> new MemberGetResponse(member.getId(), member.getEmail(),
                         member.getNickname(), member.getPhone()))
                 .collect(Collectors.toList());
         return ResponseEntity.ok().body(response);
     }
-
-
 }

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -4,13 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-
-import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
-import mocacong.server.dto.response.MemberGetResponse;
-import mocacong.server.dto.response.IsDuplicateEmailResponse;
-import mocacong.server.dto.response.IsDuplicateNicknameResponse;
-import mocacong.server.dto.response.MemberSignUpResponse;
+import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -58,13 +52,9 @@ public class MemberController {
     }
 
     @Operation(summary = "회원전체조회")
-    @GetMapping("/get")
-    public ResponseEntity<List<MemberGetResponse>> getAllMembers() {
-        List<Member> members = memberService.getMembers();
-        List<MemberGetResponse> response = members.stream()
-                .map(member -> new MemberGetResponse(member.getId(), member.getEmail(),
-                        member.getNickname(), member.getPhone()))
-                .collect(Collectors.toList());
-        return ResponseEntity.ok().body(response);
+    @GetMapping("/all")
+    public MemberGetAllResponse getAllMembers() {
+        List<MemberGetResponse> memberList = memberService.getAllMembers();
+        return new MemberGetAllResponse(memberList);
     }
 }

--- a/src/main/java/mocacong/server/dto/response/MemberGetAllResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberGetAllResponse.java
@@ -1,0 +1,15 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberGetAllResponse {
+    private List<MemberGetResponse> members;
+}

--- a/src/main/java/mocacong/server/dto/response/MemberGetAllResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberGetAllResponse.java
@@ -1,0 +1,17 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberGetAllResponse {
+    
+    private Long id;
+    private String email;
+    private String nickname;
+    private String phone;
+}

--- a/src/main/java/mocacong/server/dto/response/MemberGetResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberGetResponse.java
@@ -8,8 +8,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class MemberGetAllResponse {
-    
+public class MemberGetResponse {
+
     private Long id;
     private String email;
     private String nickname;

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -3,10 +3,7 @@ package mocacong.server.service;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
-import mocacong.server.dto.response.IsDuplicateEmailResponse;
-import mocacong.server.dto.response.IsDuplicateNicknameResponse;
-import mocacong.server.dto.response.MemberGetResponse;
-import mocacong.server.dto.response.MemberSignUpResponse;
+import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.InvalidEmailException;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
@@ -57,12 +54,13 @@ public class MemberService {
         memberRepository.delete(findMember);
     }
 
-    public List<MemberGetResponse> getAllMembers() {
+    public MemberGetAllResponse getAllMembers() {
         List<Member> members = memberRepository.findAll();
-        return members.stream()
+        List<MemberGetResponse> memberGetResponses = members.stream()
                 .map(member -> new MemberGetResponse(member.getId(), member.getEmail(),
                         member.getNickname(), member.getPhone()))
                 .collect(Collectors.toList());
+        return new MemberGetAllResponse(memberGetResponses);
     }
 
     public IsDuplicateEmailResponse isDuplicateEmail(String email) {

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -51,8 +51,7 @@ public class MemberService {
         memberRepository.delete(findMember);
     }
 
-    public List<Member> getAllMembers() {
+    public List<Member> getMembers() {
         return memberRepository.findAll();
     }
-
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -1,6 +1,5 @@
 package mocacong.server.service;
 
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
@@ -11,6 +10,9 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -48,4 +50,9 @@ public class MemberService {
                 .orElseThrow(NotFoundMemberException::new);
         memberRepository.delete(findMember);
     }
+
+    public List<Member> getAllMembers() {
+        return memberRepository.findAll();
+    }
+
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -5,6 +5,7 @@ import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.IsDuplicateEmailResponse;
 import mocacong.server.dto.response.IsDuplicateNicknameResponse;
+import mocacong.server.dto.response.MemberGetResponse;
 import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.InvalidEmailException;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -55,8 +57,12 @@ public class MemberService {
         memberRepository.delete(findMember);
     }
 
-    public List<Member> getMembers() {
-        return memberRepository.findAll();
+    public List<MemberGetResponse> getAllMembers() {
+        List<Member> members = memberRepository.findAll();
+        return members.stream()
+                .map(member -> new MemberGetResponse(member.getId(), member.getEmail(),
+                        member.getNickname(), member.getPhone()))
+                .collect(Collectors.toList());
     }
 
     public IsDuplicateEmailResponse isDuplicateEmail(String email) {

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -141,4 +141,14 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("code", equalTo(1009));
     }
+
+    @Test
+    @DisplayName("회원을 전체 조회한다")
+    void getAllMembers() {
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/members/all")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -145,10 +145,17 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원을 전체 조회한다")
     void getAllMembers() {
+        MemberSignUpRequest request1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(request1);
+        MemberSignUpRequest request2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
+        회원_가입(request2);
+
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/members/all")
                 .then().log().all()
-                .statusCode(HttpStatus.OK.value());
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body();
     }
 }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -1,20 +1,23 @@
 package mocacong.server.service;
 
-import java.util.List;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.InvalidPasswordException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ServiceTest
 class MemberServiceTest {
@@ -69,7 +72,7 @@ class MemberServiceTest {
     @Test
     @DisplayName("회원을 정상적으로 탈퇴한다")
     void delete() {
-        Member savedMember = memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678"));
+        Member savedMember = memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678"));
 
         memberService.delete(savedMember.getEmail());
 
@@ -93,5 +96,16 @@ class MemberServiceTest {
 
         Boolean matches = passwordEncoder.matches(rawPassword, encryptedPassword);
         assertThat(matches).isTrue();
+    }
+
+    @Test
+    @DisplayName("회원을 전체 조회한다")
+    public void getAllMembers() {
+        memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678"));
+        memberRepository.save(new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678"));
+
+        List<Member> members = memberRepository.findAll();
+
+        assertEquals(2, members.size());
     }
 }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ServiceTest
 class MemberServiceTest {
@@ -160,6 +159,6 @@ class MemberServiceTest {
 
         List<Member> members = memberRepository.findAll();
 
-        assertEquals(2, members.size());
+        assertThat(members).hasSize(2);
     }
 }


### PR DESCRIPTION
## 개요
- 회원 전체 조회 기능 구현 및 회원 전체 조회 테스트 코드를 작성했습니다.

## 작업사항
- 회원 전체 조회 기능을 구현했습니다.
- 회원 전체 조회 테스트 코드를 작성했습니다.

## 주의사항
- 해당 기능은 프론트의 편의를 위해 개발한 기능이므로 인수테스트는 필요없다고 생각하여 생략했습니다
  - 필요하다면 추가로 넣겠습니다 
- 누락된 테스트 코드가 있는지 확인해주세요
- 내용에 오타가 있는지 확인해주세요