### PR TITLE
fix: 중복체크 api의 잘못된 response spec을 `api docs`와 통일

### DIFF
--- a/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
@@ -1,6 +1,9 @@
 package mocacong.server.dto.response;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -8,8 +11,4 @@ import lombok.*;
 public class IsDuplicateEmailResponse {
 
     private boolean result;
-
-    public boolean isDuplicate() {
-        return result;
-    }
 }

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
@@ -11,8 +11,4 @@ import lombok.NoArgsConstructor;
 public class IsDuplicateNicknameResponse {
 
     private boolean result;
-
-    public boolean isDuplicate() {
-        return result;
-    }
 }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package mocacong.server.service;
 
+import java.util.List;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.IsDuplicateEmailResponse;
@@ -9,17 +10,14 @@ import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPasswordException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ServiceTest
 class MemberServiceTest {
@@ -84,24 +82,24 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("이미 존재하는 이메일인 경우 True를 반환한다")
-    void isDuplicateEmailReturnTrue(){
+    void isDuplicateEmailReturnTrue() {
         String email = "dlawotn3@naver.com";
         MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
         memberService.signUp(request);
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(response.isDuplicate()).isTrue();
+        assertThat(response.isResult()).isTrue();
     }
 
     @Test
     @DisplayName("존재하지 않는 이메일인 경우 False를 반환한다")
-    void isDuplicateEmailReturnFalse(){
+    void isDuplicateEmailReturnFalse() {
         String email = "dlawotn3@naver.com";
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
 
-        assertThat(response.isDuplicate()).isFalse();
+        assertThat(response.isResult()).isFalse();
     }
 
     @Test
@@ -113,7 +111,7 @@ class MemberServiceTest {
 
         IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
 
-        assertThat(response.isDuplicate()).isTrue();
+        assertThat(response.isResult()).isTrue();
     }
 
     @Test
@@ -123,12 +121,12 @@ class MemberServiceTest {
 
         IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
 
-        assertThat(response.isDuplicate()).isFalse();
+        assertThat(response.isResult()).isFalse();
     }
 
     @Test
     @DisplayName("닉네임의 길이가 0인 경우 예외를 던진다")
-    void nicknameLengthIs0ReturnException(){
+    void nicknameLengthIs0ReturnException() {
         assertThatThrownBy(() -> memberService.isDuplicateNickname(""))
                 .isInstanceOf(InvalidNicknameException.class);
     }


### PR DESCRIPTION
## 개요
- `isDuplicate()` 메서드로 인한 api response spec 변경이 발생했습니다.
<img width="458" alt="image" src="https://user-images.githubusercontent.com/57135043/228394299-bb2e63e2-2343-4002-b1e3-635799e90e1f.png">
- boolean 값은 getXXX()가 아닌 isXXX() 메서드로 변환됩니다. 별도의 getter 메서드를 구현하지 않아도 됩니다. 

## 작업사항
- 해당 메서드 삭제
<img width="417" alt="image" src="https://user-images.githubusercontent.com/57135043/228394740-880f3d48-d091-41cd-be06-26d5db1a1479.png">

## 주의사항
- 스프링 Jackson library에 대한 이해가 필요한 PR입니다. [해당 글](https://www.baeldung.com/jackson-booleans-as-integers)을 참고하시면 됩니다.
