### PR TITLE
feat: 카페에 대한 리뷰 작성 api 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.CafeRegisterRequest;
+import mocacong.server.dto.request.CafeReviewRequest;
+import mocacong.server.dto.response.CafeReviewResponse;
 import mocacong.server.dto.response.FindCafeResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.CafeService;
@@ -35,6 +37,18 @@ public class CafeController {
             @PathVariable String mapId
     ) {
         FindCafeResponse response = cafeService.findCafeByMapId(email, mapId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "특정 카페 리뷰 작성")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping("/{mapId}")
+    public ResponseEntity<CafeReviewResponse> saveCafeReview(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @RequestBody CafeReviewRequest request
+    ) {
+        CafeReviewResponse response = cafeService.saveCafeReview(email, mapId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/mocacong/server/domain/StudyType.java
+++ b/src/main/java/mocacong/server/domain/StudyType.java
@@ -35,8 +35,10 @@ public class StudyType {
         this.member = member;
         this.cafe = cafe;
         this.cafe.addStudyType(this);
-        validateValue(studyTypeValue);
-        this.studyTypeValue = studyTypeValue;
+
+        String lowerCaseStudyTypeValue = studyTypeValue.toLowerCase();
+        validateValue(lowerCaseStudyTypeValue);
+        this.studyTypeValue = lowerCaseStudyTypeValue;
     }
 
     private void validateValue(String studyTypeValue) {

--- a/src/main/java/mocacong/server/domain/cafedetail/Desk.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Desk.java
@@ -3,11 +3,13 @@ package mocacong.server.domain.cafedetail;
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidDeskException;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public enum Desk {
 
     COMFORTABLE("편해요"),

--- a/src/main/java/mocacong/server/domain/cafedetail/Parking.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Parking.java
@@ -3,11 +3,13 @@ package mocacong.server.domain.cafedetail;
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidParkingException;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public enum Parking {
 
     COMFORTABLE("여유로워요"),

--- a/src/main/java/mocacong/server/domain/cafedetail/Power.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Power.java
@@ -3,11 +3,13 @@ package mocacong.server.domain.cafedetail;
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidPowerException;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public enum Power {
 
     MANY("충분해요"),

--- a/src/main/java/mocacong/server/domain/cafedetail/Sound.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Sound.java
@@ -3,11 +3,13 @@ package mocacong.server.domain.cafedetail;
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidSoundException;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public enum Sound {
 
     QUIET("조용해요"),

--- a/src/main/java/mocacong/server/domain/cafedetail/Toilet.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Toilet.java
@@ -3,11 +3,13 @@ package mocacong.server.domain.cafedetail;
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidToiletException;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public enum Toilet {
 
     CLEAN("깨끗해요"),

--- a/src/main/java/mocacong/server/domain/cafedetail/Wifi.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Wifi.java
@@ -3,11 +3,13 @@ package mocacong.server.domain.cafedetail;
 import java.util.Arrays;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidWifiException;
 
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public enum Wifi {
 
     FAST("빵빵해요"),

--- a/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
@@ -1,0 +1,23 @@
+package mocacong.server.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CafeReviewRequest {
+
+    @NotBlank(message = "3009:공백일 수 없습니다.")
+    private int myScore;
+    private String myStudyType;
+    private String myWifi;
+    private String myParking;
+    private String myToilet;
+    private String myPower;
+    private String mySound;
+    private String myDesk;
+}

--- a/src/main/java/mocacong/server/dto/response/CafeReviewResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeReviewResponse.java
@@ -1,0 +1,37 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.CafeDetail;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CafeReviewResponse {
+
+    private double score;
+    private String studyType;
+    private String wifi;
+    private String parking;
+    private String toilet;
+    private String power;
+    private String sound;
+    private String desk;
+
+    public static CafeReviewResponse of(double score, String studyType, Cafe cafe) {
+        CafeDetail cafeDetail = cafe.getCafeDetail();
+        return new CafeReviewResponse(
+                score,
+                studyType,
+                cafeDetail.getWifi().getValue(),
+                cafeDetail.getParking().getValue(),
+                cafeDetail.getToilet().getValue(),
+                cafeDetail.getPower().getValue(),
+                cafeDetail.getSound().getValue(),
+                cafeDetail.getDesk().getValue()
+        );
+    }
+}

--- a/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsCafeReview.java
+++ b/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsCafeReview.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class AlreadyExistsCafeReview extends BadRequestException {
+
+    public AlreadyExistsCafeReview() {
+        super("이미 리뷰를 등록했습니다.", 3010);
+    }
+}

--- a/src/main/java/mocacong/server/repository/ReviewRepository.java
+++ b/src/main/java/mocacong/server/repository/ReviewRepository.java
@@ -3,7 +3,13 @@ package mocacong.server.repository;
 import java.util.Optional;
 import mocacong.server.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    Optional<Review> findByCafeIdAndMemberId(Long cafeId, Long memberId);
+    @Query("select r.id " +
+            "from Review r " +
+            "join r.cafe c " +
+            "join r.member m " +
+            "where c.id = :cafeId and m.id = :memberId")
+    Optional<Long> findIdByCafeIdAndMemberId(Long cafeId, Long memberId);
 }

--- a/src/main/java/mocacong/server/repository/ReviewRepository.java
+++ b/src/main/java/mocacong/server/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package mocacong.server.repository;
+
+import java.util.Optional;
+import mocacong.server.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Optional<Review> findByCafeIdAndMemberId(Long cafeId, Long memberId);
+}

--- a/src/main/java/mocacong/server/repository/StudyTypeRepository.java
+++ b/src/main/java/mocacong/server/repository/StudyTypeRepository.java
@@ -3,7 +3,12 @@ package mocacong.server.repository;
 import java.util.List;
 import mocacong.server.domain.StudyType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StudyTypeRepository extends JpaRepository<StudyType, Long> {
-    List<StudyType> findAllByCafeIdAndStudyTypeValue(Long cafeId, String studyTypeValue);
+    @Query("select s.studyTypeValue " +
+            "from StudyType s " +
+            "join s.cafe c " +
+            "where c.id = :cafeId and s.studyTypeValue = :studyTypeValue")
+    List<String> findAllByCafeIdAndStudyTypeValue(Long cafeId, String studyTypeValue);
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -93,24 +93,24 @@ public class CafeService {
     }
 
     private String findMostFrequentStudyTypes(Long cafeId) {
-        List<StudyType> soloStudyTypes = studyTypeRepository.findAllByCafeIdAndStudyTypeValue(cafeId, SOLO_STUDY_TYPE);
-        List<StudyType> groupStudyTypes = studyTypeRepository.findAllByCafeIdAndStudyTypeValue(cafeId, GROUP_STUDY_TYPE);
+        List<String> soloStudyTypeValues = studyTypeRepository.findAllByCafeIdAndStudyTypeValue(cafeId, SOLO_STUDY_TYPE);
+        List<String> groupStudyTypeValues = studyTypeRepository.findAllByCafeIdAndStudyTypeValue(cafeId, GROUP_STUDY_TYPE);
 
-        if (isEmptyStudyTypes(soloStudyTypes, groupStudyTypes)) {
+        if (isEmptyStudyTypes(soloStudyTypeValues, groupStudyTypeValues)) {
             return null;
         }
 
-        if (soloStudyTypes.size() > groupStudyTypes.size()) {
+        if (soloStudyTypeValues.size() > groupStudyTypeValues.size()) {
             return SOLO_STUDY_TYPE;
         }
-        if (soloStudyTypes.size() < groupStudyTypes.size()) {
+        if (soloStudyTypeValues.size() < groupStudyTypeValues.size()) {
             return GROUP_STUDY_TYPE;
         }
         return BOTH_STUDY_TYPE;
     }
 
-    private boolean isEmptyStudyTypes(List<StudyType> soloStudyTypes, List<StudyType> groupStudyTypes) {
-        return soloStudyTypes.isEmpty() && groupStudyTypes.isEmpty();
+    private boolean isEmptyStudyTypes(List<String> soloStudyTypeValues, List<String> groupStudyTypeValues) {
+        return soloStudyTypeValues.isEmpty() && groupStudyTypeValues.isEmpty();
     }
 
     private void saveCafeDetails(CafeReviewRequest request, Cafe cafe, Member member) {

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -86,7 +86,7 @@ public class CafeService {
     }
 
     private void checkAlreadySaveCafeReview(Cafe cafe, Member member) {
-        reviewRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
+        reviewRepository.findIdByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .ifPresent(review -> {
                     throw new AlreadyExistsCafeReview();
                 });

--- a/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
+++ b/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
@@ -5,6 +5,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
+import mocacong.server.dto.request.CafeReviewRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.TokenResponse;
 import org.springframework.http.HttpStatus;
@@ -48,6 +49,17 @@ public class AcceptanceFixtures {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .when().get("/cafes/" + mapId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 카페_리뷰_작성(String token, String mapId, CafeReviewRequest request) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .body(request)
+                .when().post("/cafes/" + mapId)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
@@ -3,7 +3,11 @@ package mocacong.server.acceptance;
 import io.restassured.RestAssured;
 import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import mocacong.server.dto.request.CafeRegisterRequest;
+import mocacong.server.dto.request.CafeReviewRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.CafeReviewResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -42,5 +46,55 @@ public class CafeAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
+    }
+
+    @Test
+    @DisplayName("카페에 대한 리뷰를 작성한다")
+    void saveCafeReview() {
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        CafeReviewRequest request = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
+                "깨끗해요", "충분해요", "조용해요", "편해요");
+
+        CafeReviewResponse actual = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .body(request)
+                .when().post("/cafes/" + mapId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(CafeReviewResponse.class);
+        assertAll(
+                () -> assertThat(actual.getScore()).isEqualTo(4),
+                () -> assertThat(actual.getStudyType()).isEqualTo("solo")
+        );
+    }
+
+    @Test
+    @DisplayName("카페에 대한 리뷰를 다시 작성할 수 없다")
+    void saveCafeReviewManyTimes() {
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        CafeReviewRequest request = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
+                "깨끗해요", "충분해요", "조용해요", "편해요");
+
+        카페_리뷰_작성(token, mapId, request);
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .body(request)
+                .when().post("/cafes/" + mapId)
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/mocacong/server/domain/StudyTypeTest.java
+++ b/src/test/java/mocacong/server/domain/StudyTypeTest.java
@@ -1,6 +1,7 @@
 package mocacong.server.domain;
 
 import mocacong.server.exception.badrequest.InvalidStudyTypeException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,5 +15,16 @@ class StudyTypeTest {
         Cafe cafe = new Cafe("1", "케이카페");
         assertThatThrownBy(() -> new StudyType(member, cafe, "invalid"))
                 .isInstanceOf(InvalidStudyTypeException.class);
+    }
+
+    @Test
+    @DisplayName("타입에 대문자가 들어오더라도 소문자로 처리돼서 저장된다")
+    void studyTypeToLowerCase() {
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Cafe cafe = new Cafe("1", "케이카페");
+
+        StudyType studyType = new StudyType(member, cafe, "SoLo");
+
+        assertThat(studyType.getStudyTypeValue()).isEqualTo("solo");
     }
 }

--- a/src/test/java/mocacong/server/repository/ReviewRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/ReviewRepositoryTest.java
@@ -1,0 +1,38 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.*;
+import mocacong.server.domain.cafedetail.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ReviewRepositoryTest {
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+    @Autowired
+    private StudyTypeRepository studyTypeRepository;
+
+    @Test
+    @DisplayName("카페 id, 멤버 id로 해당 멤버가 특정 카페에 작성한 리뷰의 id를 조회한다")
+    void findIdByCafeIdAndMemberId() {
+        Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
+        Member savedMember = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        StudyType savedStudyType = studyTypeRepository.save(new StudyType(savedMember, savedCafe, "solo"));
+        CafeDetail cafeDetail = new CafeDetail(Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.COMFORTABLE, Power.MANY, Sound.LOUD);
+        Review savedReview = reviewRepository.save(new Review(savedMember, savedCafe, savedStudyType, cafeDetail));
+
+        Long actual = reviewRepository.findIdByCafeIdAndMemberId(savedCafe.getId(), savedMember.getId())
+                .orElseThrow();
+
+        assertThat(actual).isEqualTo(savedReview.getId());
+    }
+}

--- a/src/test/java/mocacong/server/repository/StudyTypeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/StudyTypeRepositoryTest.java
@@ -1,0 +1,59 @@
+package mocacong.server.repository;
+
+import java.util.List;
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Member;
+import mocacong.server.domain.StudyType;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class StudyTypeRepositoryTest {
+
+    @Autowired
+    private StudyTypeRepository studyTypeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("특정 카페의 모든 solo 타입 studyTypeValue 를 조회한다")
+    void findAllByCafeIdAndSolo() {
+        Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
+        Member savedMember1 = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케일", "010-1234-5671"));
+        Member savedMember2 = memberRepository.save(new Member("kth2@naver.com", "abcd1234", "케이", "010-1234-5672"));
+        Member savedMember3 = memberRepository.save(new Member("kth3@naver.com", "abcd1234", "케삼", "010-1234-5673"));
+        Member savedMember4 = memberRepository.save(new Member("kth4@naver.com", "abcd1234", "케사", "010-1234-5674"));
+        studyTypeRepository.save(new StudyType(savedMember1, savedCafe, "solo"));
+        studyTypeRepository.save(new StudyType(savedMember2, savedCafe, "solo"));
+        studyTypeRepository.save(new StudyType(savedMember3, savedCafe, "solo"));
+        studyTypeRepository.save(new StudyType(savedMember4, savedCafe, "group"));
+
+        List<String> actual = studyTypeRepository.findAllByCafeIdAndStudyTypeValue(savedCafe.getId(), "solo");
+
+        assertThat(actual).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("특정 카페의 모든 group 타입 studyTypeValue 를 조회한다")
+    void findAllByCafeIdAndGroup() {
+        Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
+        Member savedMember1 = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케일", "010-1234-5671"));
+        Member savedMember2 = memberRepository.save(new Member("kth2@naver.com", "abcd1234", "케이", "010-1234-5672"));
+        Member savedMember3 = memberRepository.save(new Member("kth3@naver.com", "abcd1234", "케삼", "010-1234-5673"));
+        Member savedMember4 = memberRepository.save(new Member("kth4@naver.com", "abcd1234", "케사", "010-1234-5674"));
+        studyTypeRepository.save(new StudyType(savedMember1, savedCafe, "solo"));
+        studyTypeRepository.save(new StudyType(savedMember2, savedCafe, "solo"));
+        studyTypeRepository.save(new StudyType(savedMember3, savedCafe, "group"));
+        studyTypeRepository.save(new StudyType(savedMember4, savedCafe, "group"));
+
+        List<String> actual = studyTypeRepository.findAllByCafeIdAndStudyTypeValue(savedCafe.getId(), "group");
+
+        assertThat(actual).hasSize(2);
+    }
+}

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -5,11 +5,15 @@ import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Score;
 import mocacong.server.dto.request.CafeRegisterRequest;
+import mocacong.server.dto.request.CafeReviewRequest;
+import mocacong.server.dto.response.CafeReviewResponse;
 import mocacong.server.dto.response.FindCafeResponse;
+import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.repository.ScoreRepository;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -99,5 +103,74 @@ class CafeServiceTest {
         );
     }
 
-    // TODO: 리뷰, 코멘트 기능 추가되면 조회 테스트 추가할 것
+    @Test
+    @DisplayName("카페에 대한 리뷰를 작성하면 해당 카페 평점과 세부정보가 갱신된다")
+    void saveCafeReview() {
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member1);
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        cafeService.saveCafeReview(member1.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
+                        "깨끗해요", "충분해요", "조용해요", "편해요"));
+
+        CafeReviewResponse actual = cafeService.saveCafeReview(member2.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(2, "solo", "빵빵해요", "협소해요",
+                        "깨끗해요", "충분해요", "적당해요", "편해요"));
+
+        assertAll(
+                () -> assertThat(actual.getScore()).isEqualTo(3.0),
+                () -> assertThat(actual.getStudyType()).isEqualTo("solo"),
+                () -> assertThat(actual.getWifi()).isEqualTo("빵빵해요"),
+                // `여유로워요`, `협소해요` 둘 중 무엇을 반환해도 괜찮지만 `없어요`는 불가능
+                () -> assertThat(actual.getParking()).isNotEqualTo("없어요"),
+                () -> assertThat(actual.getToilet()).isEqualTo("깨끗해요"),
+                () -> assertThat(actual.getPower()).isEqualTo("충분해요"),
+                () -> assertThat(actual.getSound()).isNotEqualTo("북적북적해요"),
+                () -> assertThat(actual.getDesk()).isEqualTo("편해요")
+        );
+    }
+
+    @Test
+    @DisplayName("카페 리뷰 작성 후 studyType의 타입 개수가 동일하면 both를 반환한다")
+    void saveCafeAndStudyTypesEquals() {
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member1);
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+
+        cafeService.saveCafeReview(member1.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
+                        "깨끗해요", "충분해요", "조용해요", "편해요"));
+        CafeReviewResponse actual = cafeService.saveCafeReview(member2.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(2, "group", "빵빵해요", "협소해요",
+                        "깨끗해요", "충분해요", "적당해요", "편해요"));
+
+        assertThat(actual.getStudyType()).isEqualTo("both");
+    }
+
+    @Test
+    @DisplayName("이미 리뷰를 작성했으면 수정만 가능하고 새로 작성은 불가능하다")
+    void cannotSaveManyReviews() {
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member1);
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        cafeService.saveCafeReview(member1.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
+                        "깨끗해요", "충분해요", "조용해요", "편해요"));
+
+        assertThatThrownBy(() -> cafeService.saveCafeReview(member1.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(2, "group", "빵빵해요", "협소해요",
+                        "깨끗해요", "충분해요", "적당해요", "편해요")))
+                .isInstanceOf(AlreadyExistsCafeReview.class);
+    }
+
+    // TODO: 코멘트 기능 추가되면 조회 테스트 추가할 것
 }


### PR DESCRIPTION
## 개요
- 카페에 대한 리뷰(세부정보, 평점, 카페 스터디타입)를 작성하는 api 구현

## 작업사항
- 카페에 대한 리뷰를 작성하는 비즈니스 로직 및 api를 구현했습니다.
  - 이미 리뷰를 작성한 사람은 재작성 불가하게 처리했습니다. (수정은 가능) 
- 카페에 대한 studyType을 갱신하는 과정이 느리다고 생각해서 쿼리튜닝 및 리팩터링 작업을 했습니다. 
  - 참고: https://clean-nutria-44b.notion.site/8027dd8392d34889a66ef0a8d301c36d
    - 다음 스프린트 전까지 해당 내용 위키 작성 예정 

## 주의사항
- 전파 범위가 가장 큰 로직 중 하나입니다. (카페가 중심인 이상 어쩔 수 없는듯) 따라서 양이 많으니 감안해서 봐주세요.
- 기획 이슈에 위반되는 것이 있는지 확인해주세요.
  - studyType이 solo, group 중 동점인 경우 -> both 반환
  - 카페 세부정보 request, response가 api spec과 일치하는지 (ex. 콘센트: `충분해요`, `적당해요`, `없어요` 여야 함.) 
  - 그 외 이상하다고 생각되는 기획적 처리 로직
- request 크기가 커서 입력할 내용이 많다보니 swagger 상에서 아래 에러 발생 가능성이 존재합니다.
```
Illegal unquoted character ((CTRL-CHAR, code 8)): 
has to be escaped using backslash to be included in string value
``` 
위와 같은 에러는 서버 쪽 에러가 아닌 request json 형태가 이상해서 발생하는 것입니다. json 값을 아예 reset한 후에 다시 입력하면 됩니다.