### PR TITLE
feat: 카페 댓글 작성 기능 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CommentController.java
+++ b/src/main/java/mocacong/server/controller/CommentController.java
@@ -1,0 +1,33 @@
+package mocacong.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import mocacong.server.dto.request.CommentSaveRequest;
+import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.security.auth.LoginUserEmail;
+import mocacong.server.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Comments", description = "댓글")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cafes/{mapId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "카페 코멘트 작성")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping
+    public ResponseEntity<CommentSaveResponse> saveCafeReview(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @RequestBody CommentSaveRequest request
+    ) {
+        CommentSaveResponse response = commentService.save(email, mapId, request.getContent());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -4,6 +4,7 @@ import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mocacong.server.exception.badrequest.ExceedCommentLengthException;
 
 @Entity
 @Table(name = "comment")
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
 
+    private static final int MAXIMUM_COMMENT_LENGTH = 200;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
@@ -20,6 +22,23 @@ public class Comment {
     @JoinColumn(name = "cafe_id")
     private Cafe cafe;
 
-    @Column(name = "content", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "content", nullable = false, length = 200)
     private String content;
+
+    public Comment(Cafe cafe, Member member, String content) {
+        this.cafe = cafe;
+        this.member = member;
+        validateCommentLength(content);
+        this.content = content;
+    }
+
+    private void validateCommentLength(String content) {
+        if (content.length() > MAXIMUM_COMMENT_LENGTH) {
+            throw new ExceedCommentLengthException();
+        }
+    }
 }

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -41,4 +41,12 @@ public class Comment {
             throw new ExceedCommentLengthException();
         }
     }
+
+    public String getWriterNickname() {
+        return this.member.getNickname();
+    }
+
+    public boolean isWrittenByMember(Member member) {
+        return this.member.equals(member);
+    }
 }

--- a/src/main/java/mocacong/server/dto/request/CommentSaveRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CommentSaveRequest.java
@@ -1,0 +1,16 @@
+package mocacong.server.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CommentSaveRequest {
+
+    @NotBlank(message = "4002:공백일 수 없습니다.")
+    private String content;
+}

--- a/src/main/java/mocacong/server/dto/response/CommentResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentResponse.java
@@ -13,5 +13,5 @@ public class CommentResponse {
     private String imgUrl;
     private String nickname;
     private String content;
-    private boolean isMe;
+    private Boolean isMe;
 }

--- a/src/main/java/mocacong/server/dto/response/CommentSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentSaveResponse.java
@@ -1,0 +1,14 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CommentSaveResponse {
+
+    private Long id;
+}

--- a/src/main/java/mocacong/server/exception/badrequest/ExceedCommentLengthException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/ExceedCommentLengthException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class ExceedCommentLengthException extends BadRequestException {
+
+    public ExceedCommentLengthException() {
+        super("코멘트 글자 수 제한을 초과했습니다.", 4003);
+    }
+}

--- a/src/main/java/mocacong/server/exception/notfound/NotFoundCommentException.java
+++ b/src/main/java/mocacong/server/exception/notfound/NotFoundCommentException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.notfound;
+
+public class NotFoundCommentException extends NotFoundException {
+
+    public NotFoundCommentException() {
+        super("존재하지 않는 코멘트입니다.", 4001);
+    }
+}

--- a/src/main/java/mocacong/server/repository/CommentRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -76,6 +76,7 @@ public class CafeService {
         return cafe.getComments()
                 .stream()
                 .map(comment -> {
+                    // TODO: imgUrl 추가되면 해당 로직 변경할 것
                     if (comment.isWrittenByMember(member)) {
                         return new CommentResponse("", member.getNickname(), comment.getContent(), true);
                     } else {

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -1,0 +1,34 @@
+package mocacong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Comment;
+import mocacong.server.domain.Member;
+import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.exception.notfound.NotFoundCafeException;
+import mocacong.server.exception.notfound.NotFoundMemberException;
+import mocacong.server.repository.CafeRepository;
+import mocacong.server.repository.CommentRepository;
+import mocacong.server.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+    private final MemberRepository memberRepository;
+    private final CafeRepository cafeRepository;
+    private final CommentRepository commentRepository;
+
+    public CommentSaveResponse save(String email, String mapId, String content) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Comment comment = new Comment(cafe, member, content);
+
+        return new CommentSaveResponse(commentRepository.save(comment).getId());
+    }
+}

--- a/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
+++ b/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
@@ -3,10 +3,7 @@ package mocacong.server.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import mocacong.server.dto.request.AuthLoginRequest;
-import mocacong.server.dto.request.CafeRegisterRequest;
-import mocacong.server.dto.request.CafeReviewRequest;
-import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.TokenResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -60,6 +57,17 @@ public class AcceptanceFixtures {
                 .auth().oauth2(token)
                 .body(request)
                 .when().post("/cafes/" + mapId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 카페_코멘트_작성(String token, String mapId, CommentSaveRequest request) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .body(request)
+                .when().post("/cafes/" + mapId + "/comments")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
@@ -1,0 +1,46 @@
+package mocacong.server.acceptance;
+
+import io.restassured.RestAssured;
+import java.util.List;
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
+import mocacong.server.dto.request.CafeRegisterRequest;
+import mocacong.server.dto.request.CommentSaveRequest;
+import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.CommentResponse;
+import mocacong.server.dto.response.FindCafeResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class CommentAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("카페에 코멘트를 작성한다")
+    void saveComment() {
+        String expected = "공부하기 좋아요~🥰";
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        CommentSaveRequest request = new CommentSaveRequest(expected);
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .body(request)
+                .when().post("/cafes/" + mapId + "/comments")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+        List<CommentResponse> comments = 카페_조회(token, mapId)
+                .as(FindCafeResponse.class)
+                .getComments();
+        assertThat(comments).hasSize(1);
+        assertThat(comments.get(0).getContent()).isEqualTo(expected);
+    }
+}

--- a/src/test/java/mocacong/server/domain/CommentTest.java
+++ b/src/test/java/mocacong/server/domain/CommentTest.java
@@ -1,7 +1,9 @@
 package mocacong.server.domain;
 
 import mocacong.server.exception.badrequest.ExceedCommentLengthException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -22,5 +24,29 @@ class CommentTest {
             comment.append("a");
         }
         return comment.toString();
+    }
+
+    @Test
+    @DisplayName("댓글 작성자 닉네임을 반환한다")
+    void getWriterNickname() {
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Cafe cafe = new Cafe("1", "케이카페");
+        Comment comment = new Comment(cafe, member, "안녕하세요");
+
+        assertThat(comment.getWriterNickname()).isEqualTo(member.getNickname());
+    }
+
+    @Test
+    @DisplayName("코멘트가 해당 회원이 작성한 게 맞는지 여부를 반환한다")
+    void isWrittenByMember() {
+        Member member1 = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member2 = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Cafe cafe = new Cafe("1", "케이카페");
+        Comment comment = new Comment(cafe, member1, "안녕하세요");
+
+        assertAll(
+                () -> assertThat(comment.isWrittenByMember(member1)).isTrue(),
+                () -> assertThat(comment.isWrittenByMember(member2)).isFalse()
+        );
     }
 }

--- a/src/test/java/mocacong/server/domain/CommentTest.java
+++ b/src/test/java/mocacong/server/domain/CommentTest.java
@@ -1,0 +1,26 @@
+package mocacong.server.domain;
+
+import mocacong.server.exception.badrequest.ExceedCommentLengthException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommentTest {
+
+    @Test
+    @DisplayName("코멘트 길이가 200자를 초과하면 예외를 반환한다")
+    void validateCommentLength() {
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Cafe cafe = new Cafe("1", "케이카페");
+        assertThatThrownBy(() -> new Comment(cafe, member, createLongComment(201)))
+                .isInstanceOf(ExceedCommentLengthException.class);
+    }
+
+    private String createLongComment(int length) {
+        StringBuilder comment = new StringBuilder();
+        while (comment.length() < length) {
+            comment.append("a");
+        }
+        return comment.toString();
+    }
+}

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -2,6 +2,7 @@ package mocacong.server.service;
 
 import java.util.List;
 import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Comment;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Score;
 import mocacong.server.dto.request.CafeRegisterRequest;
@@ -10,6 +11,7 @@ import mocacong.server.dto.response.CafeReviewResponse;
 import mocacong.server.dto.response.FindCafeResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
 import mocacong.server.repository.CafeRepository;
+import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.repository.ScoreRepository;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +32,8 @@ class CafeServiceTest {
     private MemberRepository memberRepository;
     @Autowired
     private ScoreRepository scoreRepository;
+    @Autowired
+    private CommentRepository commentRepository;
 
     @Test
     @DisplayName("등록되지 않은 카페를 성공적으로 등록한다")
@@ -96,10 +100,46 @@ class CafeServiceTest {
                 () -> assertThat(actual.getScore()).isEqualTo(4.5),
                 () -> assertThat(actual.getMyScore()).isEqualTo(score1.getScore()),
                 () -> assertThat(actual.getStudyType()).isNull(),
-                () -> assertThat(actual.getCommentsCount()).isEqualTo(0),
+                () -> assertThat(actual.getReviewsCount()).isEqualTo(0),
                 () -> assertThat(actual.getReviews()).isEmpty(),
                 () -> assertThat(actual.getCommentsCount()).isEqualTo(0),
                 () -> assertThat(actual.getComments()).isEmpty()
+        );
+    }
+
+    @Test
+    @DisplayName("평점, 리뷰, 코멘트가 모두 존재하는 카페를 조회한다")
+    void findCafeWithAll() {
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member1);
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        cafeService.saveCafeReview(member1.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(1, "group", "느려요", "없어요",
+                        "불편해요", "없어요", "북적북적해요", "불편해요"));
+        cafeService.saveCafeReview(member2.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(2, "group", "느려요", "없어요",
+                        "깨끗해요", "없어요", null, "보통이에요"));
+        Comment comment1 = new Comment(cafe, member1, "이 카페 조금 아쉬운 점이 많아요 ㅠㅠ");
+        commentRepository.save(comment1);
+        Comment comment2 = new Comment(cafe, member2, "와이파이가 왜케 느릴까요...");
+        commentRepository.save(comment2);
+        Comment comment3 = new Comment(cafe, member1, "다시 와봐도 똑같네요. 리뷰 수정할까 하다가 그대로 남겨요..");
+        commentRepository.save(comment3);
+
+        FindCafeResponse actual = cafeService.findCafeByMapId(member1.getEmail(), cafe.getMapId());
+
+        assertAll(
+                () -> assertThat(actual.getScore()).isEqualTo(1.5),
+                () -> assertThat(actual.getMyScore()).isEqualTo(1),
+                () -> assertThat(actual.getStudyType()).isEqualTo("group"),
+                () -> assertThat(actual.getReviewsCount()).isEqualTo(2),
+                () -> assertThat(actual.getCommentsCount()).isEqualTo(3),
+                () -> assertThat(actual.getComments())
+                        .extracting("nickname")
+                        .containsExactlyInAnyOrder("케이", "메리", "케이")
         );
     }
 
@@ -171,6 +211,4 @@ class CafeServiceTest {
                         "깨끗해요", "충분해요", "적당해요", "편해요")))
                 .isInstanceOf(AlreadyExistsCafeReview.class);
     }
-
-    // TODO: 코멘트 기능 추가되면 조회 테스트 추가할 것
 }

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -1,0 +1,76 @@
+package mocacong.server.service;
+
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Comment;
+import mocacong.server.domain.Member;
+import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.exception.notfound.NotFoundCafeException;
+import mocacong.server.exception.notfound.NotFoundCommentException;
+import mocacong.server.repository.CafeRepository;
+import mocacong.server.repository.CommentRepository;
+import mocacong.server.repository.MemberRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ServiceTest
+class CommentServiceTest {
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("특정 카페에 댓글을 작성할 수 있다")
+    void save() {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        String expected = "공부하기 좋아요~🥰";
+        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+
+        CommentSaveResponse savedComment = commentService.save(email, mapId, expected);
+
+        Comment actual = commentRepository.findById(savedComment.getId())
+                .orElseThrow(NotFoundCommentException::new);
+        assertThat(actual.getContent()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("존재하지 않거나 삭제된 카페에 댓글을 작성하면 예외를 반환한다")
+    void saveNotExistsCafe() {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+
+        assertThatThrownBy(() -> commentService.save(email, mapId, "공부하기 좋아요~🥰"))
+                .isInstanceOf(NotFoundCafeException.class);
+    }
+
+    @Test
+    @DisplayName("특정 카페에 댓글을 여러 번 작성할 수 있다")
+    void saveManyTimes() {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+
+        commentService.save(email, mapId, "공부하기 좋아요~🥰");
+
+        assertDoesNotThrow(() -> commentService.save(email, mapId, "공부하기 좋아요~🥰"));
+    }
+}


### PR DESCRIPTION
## 개요
- 카페에 코멘트(댓글) 작성하는 api을 구현했습니다.

## 작업사항
- 카페 코멘트 작성 api를 구현했습니다.
- 세부정보 6가지를 null로 요청보내는 경우가 불가능한 버그가 있었습니다. 해당 버그를 수정했습니다.

## 주의사항
- 댓글은 리뷰와 다르게 여러 번 작성할 수 있는 것으로 알고 있습니다. 기획과 맞지 않다면 리뷰 부탁드려요.
- 성능을 개선할만한 부분이 있다면 리뷰 부탁드립니다.
- imgUrl TODO 관련 주석이 있습니다. 확인해주세요.
