### PR TITLE
feat: 카페 즐겨찾기 등록 api 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/FavoriteController.java
+++ b/src/main/java/mocacong/server/controller/FavoriteController.java
@@ -1,0 +1,34 @@
+package mocacong.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import mocacong.server.dto.response.FavoriteSaveResponse;
+import mocacong.server.security.auth.LoginUserEmail;
+import mocacong.server.service.FavoriteService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Favorites", description = "즐겨찾기")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cafes/{mapId}/favorites")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    @Operation(summary = "카페 즐겨찾기 등록")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping
+    public ResponseEntity<FavoriteSaveResponse> saveFavoriteCafe(
+            @LoginUserEmail String email,
+            @PathVariable String mapId
+    ) {
+        FavoriteSaveResponse response = favoriteService.save(email, mapId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/mocacong/server/domain/Favorite.java
+++ b/src/main/java/mocacong/server/domain/Favorite.java
@@ -1,0 +1,31 @@
+package mocacong.server.domain;
+
+import javax.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "favorite")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite {
+
+    @Id
+    @Column(name = "favorite_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id", nullable = false)
+    private Cafe cafe;
+
+    public Favorite(Member member, Cafe cafe) {
+        this.member = member;
+        this.cafe = cafe;
+    }
+}

--- a/src/main/java/mocacong/server/dto/response/FavoriteSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/FavoriteSaveResponse.java
@@ -1,0 +1,14 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FavoriteSaveResponse {
+
+    private Long favoriteId;
+}

--- a/src/main/java/mocacong/server/dto/response/FindCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/FindCafeResponse.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FindCafeResponse {
 
+    private Boolean favorite;
+    private Long favoriteId;
     private double score;
     private Integer myScore;
     private String studyType;

--- a/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsFavorite.java
+++ b/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsFavorite.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class AlreadyExistsFavorite extends BadRequestException {
+
+    public AlreadyExistsFavorite() {
+        super("이미 즐겨찾기된 카페입니다.", 5001);
+    }
+}

--- a/src/main/java/mocacong/server/repository/FavoriteRepository.java
+++ b/src/main/java/mocacong/server/repository/FavoriteRepository.java
@@ -1,7 +1,10 @@
 package mocacong.server.repository;
 
+import java.util.Optional;
 import mocacong.server.domain.Favorite;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    Optional<Favorite> findByCafeIdAndMemberId(Long cafeId, Long memberId);
 }

--- a/src/main/java/mocacong/server/repository/FavoriteRepository.java
+++ b/src/main/java/mocacong/server/repository/FavoriteRepository.java
@@ -1,0 +1,7 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+}

--- a/src/main/java/mocacong/server/repository/FavoriteRepository.java
+++ b/src/main/java/mocacong/server/repository/FavoriteRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     Optional<Favorite> findByCafeIdAndMemberId(Long cafeId, Long memberId);
+    boolean existsByCafeIdAndMemberId(Long cafeId, Long memberId);
 }

--- a/src/main/java/mocacong/server/repository/FavoriteRepository.java
+++ b/src/main/java/mocacong/server/repository/FavoriteRepository.java
@@ -3,9 +3,14 @@ package mocacong.server.repository;
 import java.util.Optional;
 import mocacong.server.domain.Favorite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
-    Optional<Favorite> findByCafeIdAndMemberId(Long cafeId, Long memberId);
-    boolean existsByCafeIdAndMemberId(Long cafeId, Long memberId);
+    @Query("select f.id " +
+            "from Favorite f " +
+            "join f.cafe c " +
+            "join f.member m " +
+            "where c.id = :cafeId and m.id = :memberId")
+    Optional<Long> findFavoriteIdByCafeIdAndMemberId(Long cafeId, Long memberId);
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,5 +1,8 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -16,10 +19,6 @@ import mocacong.server.repository.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 public class CafeService {
@@ -33,6 +32,7 @@ public class CafeService {
     private final StudyTypeRepository studyTypeRepository;
     private final ScoreRepository scoreRepository;
     private final ReviewRepository reviewRepository;
+    private final FavoriteRepository favoriteRepository;
 
     public void save(CafeRegisterRequest request) {
         Cafe cafe = new Cafe(request.getId(), request.getName());
@@ -53,10 +53,14 @@ public class CafeService {
         Score scoreByLoginUser = scoreRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
         String studyType = findMostFrequentStudyTypes(cafe.getId());
+        Favorite favorite = favoriteRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
+                .orElse(null);
 
         List<ReviewResponse> reviewResponses = findReviewResponses(cafe);
         List<CommentResponse> commentResponses = findCommentResponses(cafe, member);
         return new FindCafeResponse(
+                favorite != null,
+                favorite != null ? favorite.getId() : null,
                 cafe.findAverageScore(),
                 scoreByLoginUser != null ? scoreByLoginUser.getScore() : null,
                 studyType,

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -53,14 +53,14 @@ public class CafeService {
         Score scoreByLoginUser = scoreRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
         String studyType = findMostFrequentStudyTypes(cafe.getId());
-        Favorite favorite = favoriteRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
+        Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
 
         List<ReviewResponse> reviewResponses = findReviewResponses(cafe);
         List<CommentResponse> commentResponses = findCommentResponses(cafe, member);
         return new FindCafeResponse(
-                favorite != null,
-                favorite != null ? favorite.getId() : null,
+                favoriteId != null,
+                favoriteId,
                 cafe.findAverageScore(),
                 scoreByLoginUser != null ? scoreByLoginUser.getScore() : null,
                 studyType,

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -5,6 +5,7 @@ import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.FavoriteSaveResponse;
+import mocacong.server.exception.badrequest.AlreadyExistsFavorite;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CafeRepository;
@@ -27,7 +28,15 @@ public class FavoriteService {
                 .orElseThrow(NotFoundCafeException::new);
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
+
+        validateDuplicateFavorite(cafe.getId(), member.getId());
         Favorite favorite = new Favorite(member, cafe);
         return new FavoriteSaveResponse(favoriteRepository.save(favorite).getId());
+    }
+
+    private void validateDuplicateFavorite(Long cafeId, Long memberId) {
+        if (favoriteRepository.existsByCafeIdAndMemberId(cafeId, memberId)) {
+            throw new AlreadyExistsFavorite();
+        }
     }
 }

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -35,8 +35,9 @@ public class FavoriteService {
     }
 
     private void validateDuplicateFavorite(Long cafeId, Long memberId) {
-        if (favoriteRepository.existsByCafeIdAndMemberId(cafeId, memberId)) {
-            throw new AlreadyExistsFavorite();
-        }
+        favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafeId, memberId)
+                .ifPresent(fav -> {
+                    throw new AlreadyExistsFavorite();
+                });
     }
 }

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -1,0 +1,33 @@
+package mocacong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Favorite;
+import mocacong.server.domain.Member;
+import mocacong.server.dto.response.FavoriteSaveResponse;
+import mocacong.server.exception.notfound.NotFoundCafeException;
+import mocacong.server.exception.notfound.NotFoundMemberException;
+import mocacong.server.repository.CafeRepository;
+import mocacong.server.repository.FavoriteRepository;
+import mocacong.server.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final MemberRepository memberRepository;
+    private final CafeRepository cafeRepository;
+
+    @Transactional
+    public FavoriteSaveResponse save(String email, String mapId) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Favorite favorite = new Favorite(member, cafe);
+        return new FavoriteSaveResponse(favoriteRepository.save(favorite).getId());
+    }
+}

--- a/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,30 @@
+package mocacong.server.acceptance;
+
+import io.restassured.RestAssured;
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
+import mocacong.server.dto.request.CafeRegisterRequest;
+import mocacong.server.dto.request.MemberSignUpRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class FavoriteAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("회원이 카페 즐겨찾기 등록을 진행한다")
+    void saveFavoriteCafe() {
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().post("/cafes/" + mapId + "/favorites")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/mocacong/server/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/FavoriteRepositoryTest.java
@@ -1,0 +1,40 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Favorite;
+import mocacong.server.domain.Member;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class FavoriteRepositoryTest {
+
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("카페 id, 멤버 id로 즐겨찾기 id를 조회한다")
+    void findByCafeIdAndMemberId() {
+        Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
+        Member savedMember = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Favorite favorite = new Favorite(savedMember, savedCafe);
+        favoriteRepository.save(favorite);
+
+        Long actual = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(savedCafe.getId(), savedMember.getId())
+                .orElse(null);
+
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual).isEqualTo(favorite.getId())
+        );
+    }
+}

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -1,0 +1,45 @@
+package mocacong.server.service;
+
+import java.util.List;
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Favorite;
+import mocacong.server.domain.Member;
+import mocacong.server.dto.response.FavoriteSaveResponse;
+import mocacong.server.repository.CafeRepository;
+import mocacong.server.repository.FavoriteRepository;
+import mocacong.server.repository.MemberRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ServiceTest
+class FavoriteServiceTest {
+
+    @Autowired
+    private FavoriteService favoriteService;
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원이 카페를 즐겨찾기 등록한다")
+    void save() {
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+
+        FavoriteSaveResponse actual = favoriteService.save(member.getEmail(), cafe.getMapId());
+
+        List<Favorite> favorites = favoriteRepository.findAll();
+        assertAll(
+                () -> assertThat(favorites).hasSize(1),
+                () -> assertThat(favorites.get(0).getId()).isEqualTo(actual.getFavoriteId())
+        );
+    }
+}

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -5,10 +5,12 @@ import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.FavoriteSaveResponse;
+import mocacong.server.exception.badrequest.AlreadyExistsFavorite;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,5 +43,18 @@ class FavoriteServiceTest {
                 () -> assertThat(favorites).hasSize(1),
                 () -> assertThat(favorites.get(0).getId()).isEqualTo(actual.getFavoriteId())
         );
+    }
+
+    @Test
+    @DisplayName("이미 즐겨찾기 등록한 카페에 즐겨찾기를 등록하면 예외를 반환한다")
+    void saveDuplicate() {
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        favoriteService.save(member.getEmail(), cafe.getMapId());
+
+        assertThatThrownBy(() -> favoriteService.save(member.getEmail(), cafe.getMapId()))
+                .isInstanceOf(AlreadyExistsFavorite.class);
     }
 }


### PR DESCRIPTION
## 개요
- 즐겨찾기 등록 api 구현 및 엔티티 설계

## 작업사항
- 즐겨찾기 엔티티를 설계하고 api를 구현했습니다.
- 카페 조회 api responseBody에 즐겨찾기 정보를 추가하고 해당 로직 및 테스트를 구현했습니다.
<img width="481" alt="image" src="https://user-images.githubusercontent.com/57135043/230060287-2a26e46d-5273-4f61-a33e-d35caf68fe6f.png">

## 주의사항
- api 형식이나 놓친 기획적 이슈가 있으면 확인해주세요.
- 즐겨찾기 등록이 swagger 상에서 잘 되는지 확인해주세요.
