### PR TITLE
feat: 초성, 중성, 종성 분리 닉네임 검증 허용

### DIFF
--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -14,7 +14,7 @@ import mocacong.server.exception.badrequest.InvalidPhoneException;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Z가-힣]{2,6}$");
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,6}$");
     private static final Pattern PHONE_REGEX = Pattern.compile("^01[\\d\\-]{8,12}$");
 
     @Id

--- a/src/test/java/mocacong/server/domain/MemberTest.java
+++ b/src/test/java/mocacong/server/domain/MemberTest.java
@@ -20,6 +20,15 @@ class MemberTest {
     }
 
     @ParameterizedTest
+    @DisplayName("닉네임은 초성, 중성, 종성 분리하여 지을 수 있다")
+    @ValueSource(strings = {"ㄱㅁㄴㄷㄹ", "ㅏㅣㅓㅜ", "가ㅏ누ㅟ"})
+    void createMemberNicknameOnlyOnset(String nickname) {
+        assertDoesNotThrow(
+                () -> new Member("kth990303@naver.com", "a1b2c3d4", nickname, "010-1234-5678")
+        );
+    }
+
+    @ParameterizedTest
     @DisplayName("닉네임이 2~6자가 아니면 예외를 반환한다")
     @ValueSource(strings = {"일", "일이삼사오육칠"})
     void nicknameLengthValidation(String nickname) {


### PR DESCRIPTION
## 개요
- 아래 닉네임 규칙을 허용했습니다.
<img width="450" alt="image" src="https://user-images.githubusercontent.com/57135043/230525010-bdba5fc6-bb3b-4b3e-b4e3-9fb6089cc78d.png">

## 작업사항
- 닉네임 정규표현식을 수정하고 해당 테스트 코드 추가했습니다.

## 주의사항
- 전원 찬성 시에 해당 PR을 머지해주시고, 반대 의견 또는 반대로 최종 결정이 된 경우 closed 부탁드립니다.