### PR TITLE
feat: aws S3와 연동하여 프로필 이미지 변경 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -3,6 +3,7 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.IsDuplicateEmailResponse;
@@ -11,10 +12,10 @@ import mocacong.server.dto.response.MemberGetAllResponse;
 import mocacong.server.dto.response.MemberSignUpResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -45,6 +46,16 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "프로필 이미지 수정")
+    @PutMapping(value = "/mypage/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> updateProfileImage(
+            @LoginUserEmail String email,
+            @RequestParam(value = "file", required = false) MultipartFile multipartFile
+    ) {
+        memberService.updateProfileImage(email, multipartFile);
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "회원탈퇴")
     @SecurityRequirement(name = "JWT")
     @DeleteMapping
@@ -59,7 +70,7 @@ public class MemberController {
         memberService.deleteAll();
         return ResponseEntity.ok().build();
     }
-    
+
     @Operation(summary = "회원전체조회")
     @GetMapping("/all")
     public MemberGetAllResponse getAllMembers() {

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -47,6 +47,7 @@ public class MemberController {
     }
 
     @Operation(summary = "프로필 이미지 수정")
+    @SecurityRequirement(name = "JWT")
     @PutMapping(value = "/mypage/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> updateProfileImage(
             @LoginUserEmail String email,

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -46,6 +46,10 @@ public class Comment {
         return this.member.getNickname();
     }
 
+    public String getWriterImgUrl() {
+        return this.member.getImgUrl();
+    }
+
     public boolean isWrittenByMember(Member member) {
         return this.member.equals(member);
     }

--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -34,12 +34,20 @@ public class Member {
     @Column(name = "phone", nullable = false)
     private String phone;
 
-    public Member(String email, String password, String nickname, String phone) {
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    public Member(String email, String password, String nickname, String phone, String imgUrl) {
         validateMemberInfo(nickname, phone);
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.phone = phone;
+        this.imgUrl = imgUrl;
+    }
+
+    public Member(String email, String password, String nickname, String phone) {
+        this(email, password, nickname, phone, null);
     }
 
     private void validateMemberInfo(String nickname, String phone) {
@@ -57,5 +65,9 @@ public class Member {
         if (!PHONE_REGEX.matcher(phone).matches()) {
             throw new InvalidPhoneException();
         }
+    }
+
+    public void updateProfileImgUrl(String imgUrl) {
+        this.imgUrl = imgUrl;
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -82,11 +82,10 @@ public class CafeService {
         return cafe.getComments()
                 .stream()
                 .map(comment -> {
-                    // TODO: imgUrl 추가되면 해당 로직 변경할 것
                     if (comment.isWrittenByMember(member)) {
-                        return new CommentResponse("", member.getNickname(), comment.getContent(), true);
+                        return new CommentResponse(member.getImgUrl(), member.getNickname(), comment.getContent(), true);
                     } else {
-                        return new CommentResponse("", comment.getWriterNickname(), comment.getContent(), false);
+                        return new CommentResponse(comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
                     }
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/mocacong/server/support/AwsS3Uploader.java
+++ b/src/main/java/mocacong/server/support/AwsS3Uploader.java
@@ -1,0 +1,43 @@
+package mocacong.server.support;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsS3Uploader {
+
+    private static final String S3_BUCKET_DIRECTORY_NAME = "static";
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(MultipartFile multipartFile) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+
+        String fileName = S3_BUCKET_DIRECTORY_NAME + "/" + UUID.randomUUID() + "." + multipartFile.getOriginalFilename();
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            log.error("S3 파일 업로드에 실패했습니다. {}", e.getMessage());
+        }
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,6 +12,10 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
 
 security.jwt.token:
   secret-key: ${JWT_SECRET_KEY}
@@ -26,3 +30,15 @@ springdoc:
     display-request-duration: true
     operations-sorter: alpha
     tags-sorter: alpha
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    region:
+      static: ${S3_REGION}
+    stack:
+      auto: false
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
       enabled: true
       settings:
         web-allow-others: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
 
 security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttesttest
@@ -29,3 +33,15 @@ springdoc:
     display-request-duration: true
     operations-sorter: alpha
     tags-sorter: alpha
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    region:
+      static: ${S3_REGION}
+    stack:
+      auto: false
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}

--- a/src/test/java/mocacong/server/domain/CommentTest.java
+++ b/src/test/java/mocacong/server/domain/CommentTest.java
@@ -37,6 +37,16 @@ class CommentTest {
     }
 
     @Test
+    @DisplayName("댓글 작성자 프로필 이미지 url을 반환한다")
+    void getWriterImgUrl() {
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678", "test_img.jpg");
+        Cafe cafe = new Cafe("1", "케이카페");
+        Comment comment = new Comment(cafe, member, "안녕하세요");
+
+        assertThat(comment.getWriterImgUrl()).isEqualTo(member.getImgUrl());
+    }
+
+    @Test
     @DisplayName("코멘트가 해당 회원이 작성한 게 맞는지 여부를 반환한다")
     void isWrittenByMember() {
         Member member1 = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:h2:~/test;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+
+security.jwt.token:
+  secret-key: testtesttesttesttesttesttesttesttesttest
+  expire-length: 864000
+
+cloud:
+  aws:
+    s3:
+      bucket: testtesttesttesttestttest
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
## 개요
- 프로필 이미지를 저장하는 AWS S3 서버 연동
- 프로필 이미지 api 구현

## 작업사항
- aws s3와 연동하였습니다. `AwsS3Uploader` 클래스는 support 패키지로 분리했습니다.
- 현재 모카콩은 개발서버와 배포서버가 분리돼있지 않습니다. 그렇기 때문에 이미지가 변경되는지 swagger 테스트를 로컬에서 할 필요가 있다고 봤습니다. -> 테스트 환경에서는 실제 s3와 연동이 불가능하기 때문에 application.yml 테스트용을 별도로 만들었습니다.
  - 테스트용 AwsS3Uploader를 위해 `@MockBean` 어노테이션을 사용했습니다.
- 누락된 테스트 어노테이션 (회원 전체조회 통합테스트 쪽)을 추가했습니다. 

## 주의사항
- **코드 내에 보안적으로 문제될 부분이 있는지 체크해주세요.**
- 테스트 코드 한정, `@MockBean` 및 mockito에 대한 이해가 필요한 PR입니다.
- 실제로 s3와 연동이 잘 되는지 확인해주세요.
- 놓친 기획적 이슈가 있는지 체크해주세요.

---

### local 환경에서 swagger를 돌릴 시에 환경변수 주입이 필요합니다.
1. 애플리케이션 실행 전, 우측 상단에 `Edit Configurations`을 클릭합니다.
<img width="382" alt="image" src="https://user-images.githubusercontent.com/57135043/230611414-eaef7d8b-09d0-4b49-864d-cd986c9f28ea.png">
2. Modify Options -> Environment variables
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/57135043/230611612-f3a15328-ffc0-43c0-a7b6-63d8499b40b1.png">
3. S3 관련 환경변수 주입 (실제 환경변수 주입 시, s3에 이미지가 실제로 올라가는 점 참고해주세요)
<img width="281" alt="image" src="https://user-images.githubusercontent.com/57135043/230611718-c132b056-95bc-4f5d-9205-a2034d1fcf32.png">
4. (선택) 로컬은 aws ec2 메타데이터가 실제로 존재하지 않는 환경이므로 실행에는 상관없는 일부 에러가 발생합니다. (EC2의 메타데이터를 읽다가 발생하는 에러로써, EC2인스턴스가 아닌 곳에서는 의미가 없는 에러라고 하네요.) `'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'` 의존성 때문에 발생하는 에러입니다. 메타데이터를 읽는 과정이 좀 느리므로, 아래 VM options에 `-Dcom.amazonaws.sdk.disableEc2Metadata=true`를 추가하시면 됩니다. 
<img width="935" alt="image" src="https://user-images.githubusercontent.com/57135043/230611865-a29b501a-61c4-4536-b8ba-61cd69969cbd.png">
위와 같이 설정하면 Metadata disabled 에러가 뜹니다. 우린 ec2 환경이 아닌 로컬에서 돌리므로 사실상 에러가 아닌, 의도한 결과입니다.

참고: https://lemontia.tistory.com/1006



