### PR TITLE
fix: 특정 카페 조회 api response 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -1,11 +1,5 @@
 package mocacong.server.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import mocacong.server.domain.cafedetail.*;
-
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +7,11 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mocacong.server.domain.cafedetail.*;
 
 @Entity
 @Table(name = "cafe")

--- a/src/main/java/mocacong/server/domain/CafeDetail.java
+++ b/src/main/java/mocacong/server/domain/CafeDetail.java
@@ -1,12 +1,12 @@
 package mocacong.server.domain;
 
-import lombok.*;
-import mocacong.server.domain.cafedetail.*;
-
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mocacong.server.domain.cafedetail.*;
 
 @Embeddable
 @NoArgsConstructor

--- a/src/main/java/mocacong/server/domain/CafeDetail.java
+++ b/src/main/java/mocacong/server/domain/CafeDetail.java
@@ -45,4 +45,28 @@ public class CafeDetail {
         this.power = power;
         this.sound = sound;
     }
+
+    public String getWifiValue() {
+        return wifi != null ? wifi.getValue() : null;
+    }
+
+    public String getParkingValue() {
+        return parking != null ? parking.getValue() : null;
+    }
+
+    public String getToiletValue() {
+        return toilet != null ? toilet.getValue() : null;
+    }
+
+    public String getDeskValue() {
+        return desk != null ? desk.getValue() : null;
+    }
+
+    public String getPowerValue() {
+        return power != null ? power.getValue() : null;
+    }
+
+    public String getSoundValue() {
+        return sound != null ? sound.getValue() : null;
+    }
 }

--- a/src/main/java/mocacong/server/dto/response/FindCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/FindCafeResponse.java
@@ -16,8 +16,13 @@ public class FindCafeResponse {
     private double score;
     private Integer myScore;
     private String studyType;
+    private String wifi;
+    private String parking;
+    private String toilet;
+    private String power;
+    private String sound;
+    private String desk;
     private int reviewsCount;
-    private List<ReviewResponse> reviews;
     private int commentsCount;
     private List<CommentResponse> comments;
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -56,7 +56,6 @@ public class CafeService {
         Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
 
-        List<ReviewResponse> reviewResponses = findReviewResponses(cafe);
         List<CommentResponse> commentResponses = findCommentResponses(cafe, member);
         return new FindCafeResponse(
                 favoriteId != null,
@@ -64,18 +63,16 @@ public class CafeService {
                 cafe.findAverageScore(),
                 scoreByLoginUser != null ? scoreByLoginUser.getScore() : null,
                 studyType,
-                reviewResponses.size(),
-                reviewResponses,
+                cafe.getCafeDetail().getWifiValue(),
+                cafe.getCafeDetail().getParkingValue(),
+                cafe.getCafeDetail().getToiletValue(),
+                cafe.getCafeDetail().getPowerValue(),
+                cafe.getCafeDetail().getSoundValue(),
+                cafe.getCafeDetail().getDeskValue(),
+                cafe.getReviews().size(),
                 commentResponses.size(),
                 commentResponses
         );
-    }
-
-    private List<ReviewResponse> findReviewResponses(Cafe cafe) {
-        return cafe.getReviews()
-                .stream()
-                .map(ReviewResponse::from)
-                .collect(Collectors.toList());
     }
 
     private List<CommentResponse> findCommentResponses(Cafe cafe, Member member) {

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -48,6 +48,7 @@ public class CafeService {
     public FindCafeResponse findCafeByMapId(String email, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
+        CafeDetail cafeDetail = cafe.getCafeDetail();
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         Score scoreByLoginUser = scoreRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
@@ -55,7 +56,6 @@ public class CafeService {
         String studyType = findMostFrequentStudyTypes(cafe.getId());
         Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
-
         List<CommentResponse> commentResponses = findCommentResponses(cafe, member);
         return new FindCafeResponse(
                 favoriteId != null,
@@ -63,12 +63,12 @@ public class CafeService {
                 cafe.findAverageScore(),
                 scoreByLoginUser != null ? scoreByLoginUser.getScore() : null,
                 studyType,
-                cafe.getCafeDetail().getWifiValue(),
-                cafe.getCafeDetail().getParkingValue(),
-                cafe.getCafeDetail().getToiletValue(),
-                cafe.getCafeDetail().getPowerValue(),
-                cafe.getCafeDetail().getSoundValue(),
-                cafe.getCafeDetail().getDeskValue(),
+                cafeDetail.getWifiValue(),
+                cafeDetail.getParkingValue(),
+                cafeDetail.getToiletValue(),
+                cafeDetail.getPowerValue(),
+                cafeDetail.getSoundValue(),
+                cafeDetail.getDeskValue(),
                 cafe.getReviews().size(),
                 commentResponses.size(),
                 commentResponses

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,8 @@ spring:
     open-in-view: false
     properties:
       hibernate:
+        create_empty_composites:
+          enabled: true
         show_sql: true
         format_sql: true
   servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     open-in-view: false
     properties:
       hibernate:
+        create_empty_composites:
+          enabled: true
         show_sql: true
         format_sql: true
   h2:

--- a/src/test/java/mocacong/server/domain/CafeDetailTest.java
+++ b/src/test/java/mocacong/server/domain/CafeDetailTest.java
@@ -1,0 +1,28 @@
+package mocacong.server.domain;
+
+import mocacong.server.domain.cafedetail.Power;
+import mocacong.server.domain.cafedetail.Sound;
+import mocacong.server.domain.cafedetail.Toilet;
+import mocacong.server.domain.cafedetail.Wifi;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CafeDetailTest {
+
+    @Test
+    @DisplayName("카페 세부정보가 존재하면 해당 값의 value를, 존재하지 않으면 null을 반환한다")
+    void getTypeValue() {
+        CafeDetail actual = new CafeDetail(Wifi.FAST, null, Toilet.CLEAN, null, Power.MANY, Sound.LOUD);
+
+        assertAll(
+                () -> assertThat(actual.getWifiValue()).isEqualTo(Wifi.FAST.getValue()),
+                () -> assertThat(actual.getParkingValue()).isNull(),
+                () -> assertThat(actual.getToiletValue()).isEqualTo(Toilet.CLEAN.getValue()),
+                () -> assertThat(actual.getDeskValue()).isNull(),
+                () -> assertThat(actual.getPowerValue()).isEqualTo(Power.MANY.getValue()),
+                () -> assertThat(actual.getSoundValue()).isEqualTo(Sound.LOUD.getValue())
+        );
+    }
+}

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -77,7 +77,7 @@ class CafeServiceTest {
                 () -> assertThat(actual.getMyScore()).isNull(),
                 () -> assertThat(actual.getStudyType()).isNull(),
                 () -> assertThat(actual.getCommentsCount()).isEqualTo(0),
-                () -> assertThat(actual.getReviews()).isEmpty(),
+                () -> assertThat(actual.getReviewsCount()).isEqualTo(0),
                 () -> assertThat(actual.getCommentsCount()).isEqualTo(0),
                 () -> assertThat(actual.getComments()).isEmpty()
         );
@@ -106,7 +106,6 @@ class CafeServiceTest {
                 () -> assertThat(actual.getMyScore()).isEqualTo(score1.getScore()),
                 () -> assertThat(actual.getStudyType()).isNull(),
                 () -> assertThat(actual.getReviewsCount()).isEqualTo(0),
-                () -> assertThat(actual.getReviews()).isEmpty(),
                 () -> assertThat(actual.getCommentsCount()).isEqualTo(0),
                 () -> assertThat(actual.getComments()).isEmpty()
         );

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     open-in-view: false
     properties:
       hibernate:
+        create_empty_composites:
+          enabled: true
         show_sql: true
         format_sql: true
   h2:


### PR DESCRIPTION
## 개요
- 특정 카페 GET 조회 시 해당 카페의 세부정보들이 반환되도록 구현했습니다. 리뷰에 대한 정보들은 개수 외에는 사실상 response에 필요없으므로 제거했습니다.

## 작업사항
- JPA의 값 객체에 해당되는 `@Embedded` CafeDetail의 모든 컬럼이 null일 경우 해당 cafeDetail 자체도 null이 돼버립니다. 생성자에서 NPE를 피하기 위해 `new CafeDetail()`한 것이 의미가 없어져버린 것이죠.
  - 이를 해결하기 위해 아래 설정을 추가했습니다.
```groovy
spring:
  jpa:
    properties:
      hibernate:
        create_empty_composites:
          enabled: true
```
- 아래와 같이 api response가 변경되도록 구현했습니다.
![image](https://user-images.githubusercontent.com/57135043/230850415-1377f3c3-0af7-460d-b00c-d412c9957560.png)


## 주의사항
- 불필요한 getter나 오타가 있는지 확인해주세요.
- 누락된 테스트 코드가 있으면 리뷰해주세요.
