### PR TITLE
feat: 스프링 애플리케이션 time zone 설정

### DIFF
--- a/src/main/java/mocacong/server/config/BaseTimeConfig.java
+++ b/src/main/java/mocacong/server/config/BaseTimeConfig.java
@@ -1,10 +1,16 @@
 package mocacong.server.config;
 
-
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class BaseTimeConfig {
+
+    @PostConstruct
+    public void setSeoulTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }

--- a/src/test/java/mocacong/server/domain/BaseTimeTest.java
+++ b/src/test/java/mocacong/server/domain/BaseTimeTest.java
@@ -7,6 +7,7 @@ import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.repository.RepositoryTest;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,8 +51,10 @@ class BaseTimeTest {
         LocalDateTime createdTime = findCafe.getCreatedTime();
         LocalDateTime modifiedTime = findCafe.getModifiedTime();
 
-        assertThat(modifiedTime).isNotNull();
-        assertThat(createdTime).isNotNull();
-        assertThat(modifiedTime).isAfter(createdTime);
+        assertAll(
+                () -> assertThat(modifiedTime).isNotNull(),
+                () -> assertThat(createdTime).isNotNull(),
+                () -> assertThat(modifiedTime).isAfter(createdTime)
+        );
     }
 }


### PR DESCRIPTION
## 개요
- DB에 UTC+9 시각이 아닌 UTC 시각으로 저장됩니다. RDS timezone 설정을 해줬음에도 불구하고 스프링 서버에서 timezone이 UTC 이기 때문에 그런 것이 아닐까 싶습니다.

## 작업사항
- 빈 초기화가 끝날 때 1회 timezone 설정이 실행되도록 `@PostContruct`를 이용했습니다.

## 주의사항

