### PR TITLE
feat: 카페 즐겨찾기 해제 delete api 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/FavoriteController.java
+++ b/src/main/java/mocacong/server/controller/FavoriteController.java
@@ -31,13 +31,12 @@ public class FavoriteController {
 
     @Operation(summary = "카페 즐겨찾기 삭제")
     @SecurityRequirement(name = "JWT")
-    @DeleteMapping
+    @DeleteMapping("/{favoriteId}")
     public ResponseEntity<Void> deleteFavoriteCafe(
             @LoginUserEmail String email,
-            @PathVariable String mapId,
-            @PathVariable Long favoriteId
+            @PathVariable String mapId
     ) {
-        favoriteService.delete(email, mapId, favoriteId);
+        favoriteService.delete(email, mapId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/mocacong/server/controller/FavoriteController.java
+++ b/src/main/java/mocacong/server/controller/FavoriteController.java
@@ -31,7 +31,7 @@ public class FavoriteController {
 
     @Operation(summary = "카페 즐겨찾기 삭제")
     @SecurityRequirement(name = "JWT")
-    @DeleteMapping("/{favoriteId}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteFavoriteCafe(
             @LoginUserEmail String email,
             @PathVariable String mapId

--- a/src/main/java/mocacong/server/controller/FavoriteController.java
+++ b/src/main/java/mocacong/server/controller/FavoriteController.java
@@ -39,5 +39,4 @@ public class FavoriteController {
         favoriteService.delete(email, mapId);
         return ResponseEntity.ok().build();
     }
-
 }

--- a/src/main/java/mocacong/server/controller/FavoriteController.java
+++ b/src/main/java/mocacong/server/controller/FavoriteController.java
@@ -8,10 +8,7 @@ import mocacong.server.dto.response.FavoriteSaveResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.FavoriteService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Favorites", description = "즐겨찾기")
 @RestController
@@ -31,4 +28,17 @@ public class FavoriteController {
         FavoriteSaveResponse response = favoriteService.save(email, mapId);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "카페 즐겨찾기 삭제")
+    @SecurityRequirement(name = "JWT")
+    @DeleteMapping
+    public ResponseEntity<Void> deleteFavoriteCafe(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @PathVariable Long favoriteId
+    ) {
+        favoriteService.delete(email, mapId, favoriteId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/mocacong/server/exception/notfound/NotFoundFavoriteException.java
+++ b/src/main/java/mocacong/server/exception/notfound/NotFoundFavoriteException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.notfound;
+
+public class NotFoundFavoriteException extends NotFoundException {
+
+    public NotFoundFavoriteException() {
+        super("존재하지 않는 즐겨찾기입니다.", 5000);
+    }
+}

--- a/src/main/java/mocacong/server/repository/FavoriteRepository.java
+++ b/src/main/java/mocacong/server/repository/FavoriteRepository.java
@@ -1,9 +1,10 @@
 package mocacong.server.repository;
 
-import java.util.Optional;
 import mocacong.server.domain.Favorite;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
@@ -13,4 +14,5 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
             "join f.member m " +
             "where c.id = :cafeId and m.id = :memberId")
     Optional<Long> findFavoriteIdByCafeIdAndMemberId(Long cafeId, Long memberId);
+    Favorite findByFavoriteId(Long favoriteId);
 }

--- a/src/main/java/mocacong/server/repository/FavoriteRepository.java
+++ b/src/main/java/mocacong/server/repository/FavoriteRepository.java
@@ -14,5 +14,4 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
             "join f.member m " +
             "where c.id = :cafeId and m.id = :memberId")
     Optional<Long> findFavoriteIdByCafeIdAndMemberId(Long cafeId, Long memberId);
-    Favorite findByFavoriteId(Long favoriteId);
 }

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -7,6 +7,7 @@ import mocacong.server.domain.Member;
 import mocacong.server.dto.response.FavoriteSaveResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsFavorite;
 import mocacong.server.exception.notfound.NotFoundCafeException;
+import mocacong.server.exception.notfound.NotFoundFavoriteException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
@@ -39,5 +40,18 @@ public class FavoriteService {
                 .ifPresent(fav -> {
                     throw new AlreadyExistsFavorite();
                 });
+    }
+
+    public void delete(String email, String mapId, Long favoriteId) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Favorite favorite = favoriteRepository.findByFavoriteId(favoriteId);
+
+        if (favorite == null || !favorite.getMember().equals(member) || !favorite.getCafe().equals(cafe)) {
+            throw new NotFoundFavoriteException();
+        }
+        favoriteRepository.delete(favorite);
     }
 }

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -42,16 +42,15 @@ public class FavoriteService {
                 });
     }
 
-    public void delete(String email, String mapId, Long favoriteId) {
+    @Transactional
+    public void delete(String email, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
-        Favorite favorite = favoriteRepository.findByFavoriteId(favoriteId);
+        Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
+                        .orElseThrow(NotFoundFavoriteException::new);
 
-        if (favorite == null || !favorite.getMember().equals(member) || !favorite.getCafe().equals(cafe)) {
-            throw new NotFoundFavoriteException();
-        }
-        favoriteRepository.delete(favorite);
+        favoriteRepository.deleteById(favoriteId);
     }
 }

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -49,7 +49,7 @@ public class FavoriteService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
-                        .orElseThrow(NotFoundFavoriteException::new);
+                .orElseThrow(NotFoundFavoriteException::new);
 
         favoriteRepository.deleteById(favoriteId);
     }

--- a/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
@@ -38,7 +38,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
-        Response response = RestAssured.given().log().all()
+        RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .when().post("/cafes/" + mapId + "/favorites")
@@ -46,12 +46,10 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract().response();
 
-        String favoriteId = response.path("id");
-
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
-                .when().delete("/cafes/" + mapId + "/favorites/" + favoriteId)
+                .when().delete("/cafes/" + mapId + "/favorites")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }

--- a/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
@@ -1,13 +1,15 @@
 package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
-import static mocacong.server.acceptance.AcceptanceFixtures.*;
+import io.restassured.response.Response;
 import mocacong.server.dto.request.CafeRegisterRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
 
 public class FavoriteAcceptanceTest extends AcceptanceTest {
 
@@ -24,6 +26,32 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .when().post("/cafes/" + mapId + "/favorites")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("회원이 카페 즐겨찾기 삭제를 진행한다")
+    void deleteFavoriteCafe() {
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        Response response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().post("/cafes/" + mapId + "/favorites")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().response();
+
+        String favoriteId = response.path("id");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().delete("/cafes/" + mapId + "/favorites/" + favoriteId)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -60,7 +60,6 @@ class FavoriteServiceTest {
                 .isInstanceOf(AlreadyExistsFavorite.class);
     }
 
-
     @Test
     @DisplayName("회원이 카페를 즐겨찾기 삭제한다")
     void delete() {

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -1,6 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
@@ -9,12 +8,15 @@ import mocacong.server.exception.badrequest.AlreadyExistsFavorite;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ServiceTest
 class FavoriteServiceTest {

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -59,4 +59,20 @@ class FavoriteServiceTest {
         assertThatThrownBy(() -> favoriteService.save(member.getEmail(), cafe.getMapId()))
                 .isInstanceOf(AlreadyExistsFavorite.class);
     }
+
+
+    @Test
+    @DisplayName("회원이 카페를 즐겨찾기 삭제한다")
+    void delete() {
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Favorite favorite = new Favorite(member, cafe);
+        favoriteRepository.save(favorite);
+
+        favoriteService.delete(member.getEmail(), cafe.getMapId());
+
+        assertThat(favoriteRepository.findById(favorite.getId())).isEmpty();
+    }
 }

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -5,6 +5,7 @@ import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.FavoriteSaveResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsFavorite;
+import mocacong.server.exception.notfound.NotFoundFavoriteException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
@@ -17,6 +18,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ServiceTest
 class FavoriteServiceTest {
@@ -73,5 +75,17 @@ class FavoriteServiceTest {
         favoriteService.delete(member.getEmail(), cafe.getMapId());
 
         assertThat(favoriteRepository.findById(favorite.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원이 즐겨찾기를 안한 카페 즐겨찾기 삭제할 경우 예외를 던진다")
+    void deleteWithException() {
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+
+        assertThrows(NotFoundFavoriteException.class,
+                () -> favoriteService.delete(member.getEmail(), cafe.getMapId()));
     }
 }


### PR DESCRIPTION
## 개요
- 카페 즐겨찾기 해제 API를 구현했습니다.

## 작업사항
- 카페 즐겨찾기 해제 DELETE API 구현
- 카페 즐겨찾기 해제 테스트 코드 작성

## 주의사항
- API 명세서 조건을 만족했는지 확인해주세요
- 오타가 있는지 확인해주세요
