### PR TITLE
feat: OAuth Apple 로그인 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+	implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -34,6 +36,6 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }

--- a/src/main/java/mocacong/server/config/AuthConfig.java
+++ b/src/main/java/mocacong/server/config/AuthConfig.java
@@ -1,5 +1,6 @@
 package mocacong.server.config;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.security.auth.AuthenticationPrincipalArgumentResolver;
 import mocacong.server.security.auth.LoginInterceptor;
@@ -7,8 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -21,9 +20,10 @@ public class AuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
-                .excludePathPatterns("/members", "/login", "/members/check-duplicate/email", "/members/check-duplicate/nickname",
-                        "/members/all", "/cafes");
-        }
+                .excludePathPatterns("/members", "/members/all", "/members/check-duplicate/**")
+                .excludePathPatterns("/login/**")
+                .excludePathPatterns("/cafes");
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/src/main/java/mocacong/server/config/AuthConfig.java
+++ b/src/main/java/mocacong/server/config/AuthConfig.java
@@ -12,6 +12,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @RequiredArgsConstructor
 public class AuthConfig implements WebMvcConfigurer {
+
     private final LoginInterceptor loginInterceptor;
     private final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
 
@@ -20,7 +21,7 @@ public class AuthConfig implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
-                .excludePathPatterns("/members", "/members/all", "/members/check-duplicate/**")
+                .excludePathPatterns("/members", "/members/oauth", "/members/all", "/members/check-duplicate/**")
                 .excludePathPatterns("/login/**")
                 .excludePathPatterns("/cafes");
     }

--- a/src/main/java/mocacong/server/config/FeignClientConfig.java
+++ b/src/main/java/mocacong/server/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package mocacong.server.config;
+
+import mocacong.server.ServerApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = ServerApplication.class)
+public class FeignClientConfig {
+}

--- a/src/main/java/mocacong/server/controller/AuthController.java
+++ b/src/main/java/mocacong/server/controller/AuthController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
+import mocacong.server.dto.response.AppleTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.service.AuthService;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +27,13 @@ public class AuthController {
     @PostMapping
     public ResponseEntity<TokenResponse> login(@RequestBody @Valid AuthLoginRequest request) {
         TokenResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "애플 OAuth 로그인")
+    @PostMapping("/apple")
+    public ResponseEntity<AppleTokenResponse> loginApple(@RequestBody @Valid AppleLoginRequest request) {
+        AppleTokenResponse response = authService.appleOAuthLogin(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.request.OAuthMemberSignUpRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.MemberService;
@@ -26,6 +27,13 @@ public class MemberController {
     @PostMapping
     public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody @Valid MemberSignUpRequest request) {
         MemberSignUpResponse response = memberService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "OAuth 회원가입")
+    @PostMapping("/oauth")
+    public ResponseEntity<OAuthMemberSignUpResponse> signUp(@RequestBody @Valid OAuthMemberSignUpRequest request) {
+        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -25,7 +25,7 @@ public class Member {
     @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "password", nullable = false)
+    @Column(name = "password")
     private String password;
 
     @Column(name = "nickname", nullable = false)
@@ -37,17 +37,33 @@ public class Member {
     @Column(name = "img_url")
     private String imgUrl;
 
-    public Member(String email, String password, String nickname, String phone, String imgUrl) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform")
+    private Platform platform;
+
+    @Column(name = "platform_id")
+    private String platformId;
+
+    public Member(
+            String email, String password, String nickname, String phone, String imgUrl,
+            Platform platform, String platformId
+    ) {
         validateMemberInfo(nickname, phone);
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.phone = phone;
         this.imgUrl = imgUrl;
+        this.platform = platform;
+        this.platformId = platformId;
+    }
+
+    public Member(String email, String password, String nickname, String phone, String imgUrl) {
+        this(email, password, nickname, phone, imgUrl, Platform.MOCACONG, null);
     }
 
     public Member(String email, String password, String nickname, String phone) {
-        this(email, password, nickname, phone, null);
+        this(email, password, nickname, phone, null, Platform.MOCACONG, null);
     }
 
     private void validateMemberInfo(String nickname, String phone) {

--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -1,13 +1,12 @@
 package mocacong.server.domain;
 
+import java.util.regex.Pattern;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPhoneException;
-
-import javax.persistence.*;
-import java.util.regex.Pattern;
 
 @Entity
 @Table(name = "member")
@@ -29,10 +28,10 @@ public class Member extends BaseTime {
     @Column(name = "password")
     private String password;
 
-    @Column(name = "nickname", nullable = false)
+    @Column(name = "nickname")
     private String nickname;
 
-    @Column(name = "phone", nullable = false)
+    @Column(name = "phone")
     private String phone;
 
     @Column(name = "img_url")
@@ -65,6 +64,20 @@ public class Member extends BaseTime {
 
     public Member(String email, String password, String nickname, String phone) {
         this(email, password, nickname, phone, null, Platform.MOCACONG, null);
+    }
+
+    public Member(String email, Platform platform, String platformId) {
+        this.email = email;
+        this.platform = platform;
+        this.platformId = platformId;
+    }
+
+    public void registerOAuthMember(String email, String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
+        if (email != null) {
+            this.email = email;
+        }
     }
 
     private void validateMemberInfo(String nickname, String phone) {

--- a/src/main/java/mocacong/server/domain/Platform.java
+++ b/src/main/java/mocacong/server/domain/Platform.java
@@ -1,0 +1,9 @@
+package mocacong.server.domain;
+
+public enum Platform {
+    APPLE,
+    KAKAO,
+    NAVER,
+    GOOGLE,
+    MOCACONG
+}

--- a/src/main/java/mocacong/server/domain/Platform.java
+++ b/src/main/java/mocacong/server/domain/Platform.java
@@ -1,9 +1,29 @@
 package mocacong.server.domain;
 
+import java.util.Arrays;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mocacong.server.exception.badrequest.InvalidPlatformException;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public enum Platform {
-    APPLE,
-    KAKAO,
-    NAVER,
-    GOOGLE,
-    MOCACONG
+
+    APPLE("apple"),
+    KAKAO("kakao"),
+    NAVER("naver"),
+    GOOGLE("google"),
+    MOCACONG("mocacong");
+
+    private String value;
+
+    public static Platform from(String value) {
+        return Arrays.stream(values())
+                .filter(it -> Objects.equals(it.value, value))
+                .findFirst()
+                .orElseThrow(InvalidPlatformException::new);
+    }
 }

--- a/src/main/java/mocacong/server/dto/request/AppleLoginRequest.java
+++ b/src/main/java/mocacong/server/dto/request/AppleLoginRequest.java
@@ -1,0 +1,16 @@
+package mocacong.server.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class AppleLoginRequest {
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String token;
+}

--- a/src/main/java/mocacong/server/dto/request/OAuthMemberSignUpRequest.java
+++ b/src/main/java/mocacong/server/dto/request/OAuthMemberSignUpRequest.java
@@ -1,0 +1,24 @@
+package mocacong.server.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class OAuthMemberSignUpRequest {
+
+    private String email;
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String nickname;
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String platform;
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String platformId;
+}

--- a/src/main/java/mocacong/server/dto/response/AppleTokenResponse.java
+++ b/src/main/java/mocacong/server/dto/response/AppleTokenResponse.java
@@ -13,4 +13,5 @@ public class AppleTokenResponse {
     private String token;
     private String email;
     private Boolean isRegistered;
+    private String platformId;
 }

--- a/src/main/java/mocacong/server/dto/response/AppleTokenResponse.java
+++ b/src/main/java/mocacong/server/dto/response/AppleTokenResponse.java
@@ -1,0 +1,16 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AppleTokenResponse {
+
+    private String token;
+    private String email;
+    private Boolean isRegistered;
+}

--- a/src/main/java/mocacong/server/dto/response/OAuthMemberSignUpResponse.java
+++ b/src/main/java/mocacong/server/dto/response/OAuthMemberSignUpResponse.java
@@ -1,0 +1,14 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OAuthMemberSignUpResponse {
+
+    private Long id;
+}

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidPlatformException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidPlatformException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class InvalidPlatformException extends BadRequestException {
+
+    public InvalidPlatformException() {
+        super("플랫폼 정보가 올바르지 않습니다.", 1010);
+    }
+}

--- a/src/main/java/mocacong/server/exception/unauthorized/InvalidTokenException.java
+++ b/src/main/java/mocacong/server/exception/unauthorized/InvalidTokenException.java
@@ -5,4 +5,8 @@ public class InvalidTokenException extends UnauthorizedException {
     public InvalidTokenException() {
         super("올바르지 않은 토큰입니다. 다시 로그인해주세요.", 1015);
     }
+
+    public InvalidTokenException(String message) {
+        super(message, 1015);
+    }
 }

--- a/src/main/java/mocacong/server/exception/unauthorized/TokenExpiredException.java
+++ b/src/main/java/mocacong/server/exception/unauthorized/TokenExpiredException.java
@@ -5,4 +5,8 @@ public class TokenExpiredException extends UnauthorizedException {
     public TokenExpiredException() {
         super("로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.", 1014);
     }
+
+    public TokenExpiredException(String message) {
+        super(message, 1014);
+    }
 }

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -1,11 +1,14 @@
 package mocacong.server.repository;
 
-import mocacong.server.domain.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import mocacong.server.domain.Member;
+import mocacong.server.domain.Platform;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
     Optional<Member> findByNickname(String nickname);
+
+    Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -4,11 +4,13 @@ import java.util.Optional;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);
 
+    @Query("select m.id from Member m where m.platform = :platform and m.platformId = :platformId")
     Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -11,6 +11,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByNickname(String nickname);
 
+    Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
+
     @Query("select m.id from Member m where m.platform = :platform and m.platformId = :platformId")
     Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/mocacong/server/security/EncryptUtils.java
+++ b/src/main/java/mocacong/server/security/EncryptUtils.java
@@ -1,0 +1,22 @@
+package mocacong.server.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class EncryptUtils {
+
+    public static String encrypt(String value) {
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            byte[] digest = sha256.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : digest) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException("Apple OAuth 통신 암호화 과정 중 문제가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/mocacong/server/security/EncryptUtils.java
+++ b/src/main/java/mocacong/server/security/EncryptUtils.java
@@ -6,13 +6,16 @@ import java.security.NoSuchAlgorithmException;
 
 public class EncryptUtils {
 
+    private static final String ENCRYPT_ALGORITHM = "SHA-256";
+    private static final String FORMAT_CODE = "%02x";
+
     public static String encrypt(String value) {
         try {
-            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            MessageDigest sha256 = MessageDigest.getInstance(ENCRYPT_ALGORITHM);
             byte[] digest = sha256.digest(value.getBytes(StandardCharsets.UTF_8));
             StringBuilder hexString = new StringBuilder();
             for (byte b : digest) {
-                hexString.append(String.format("%02x", b));
+                hexString.append(String.format(FORMAT_CODE, b));
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {

--- a/src/main/java/mocacong/server/security/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleClaimsValidator.java
@@ -1,6 +1,7 @@
 package mocacong.server.security.auth.apple;
 
 import io.jsonwebtoken.Claims;
+import mocacong.server.security.EncryptUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -20,7 +21,7 @@ public class AppleClaimsValidator {
     ) {
         this.iss = iss;
         this.clientId = clientId;
-        this.nonce = nonce;
+        this.nonce = EncryptUtils.encrypt(nonce);
     }
 
     public boolean isValid(Claims claims) {

--- a/src/main/java/mocacong/server/security/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleClaimsValidator.java
@@ -1,0 +1,31 @@
+package mocacong.server.security.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleClaimsValidator {
+
+    private static final String NONCE_KEY = "nonce";
+
+    private final String iss;
+    private final String clientId;
+    private final String nonce;
+
+    public AppleClaimsValidator(
+            @Value("${oauth.apple.iss}") String iss,
+            @Value("${oauth.apple.client-id}") String clientId,
+            @Value("${oauth.apple.nonce}") String nonce
+    ) {
+        this.iss = iss;
+        this.clientId = clientId;
+        this.nonce = nonce;
+    }
+
+    public boolean isValid(Claims claims) {
+        return claims.getIssuer().contains(iss) &&
+                claims.getAudience().equals(clientId) &&
+                claims.get(NONCE_KEY, String.class).equals(nonce);
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/apple/AppleClient.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleClient.java
@@ -1,0 +1,11 @@
+package mocacong.server.security.auth.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth")
+public interface AppleClient {
+
+    @GetMapping("/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/mocacong/server/security/auth/apple/AppleJwtParser.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleJwtParser.java
@@ -1,0 +1,43 @@
+package mocacong.server.security.auth.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import java.security.PublicKey;
+import java.util.Map;
+import mocacong.server.exception.unauthorized.InvalidTokenException;
+import mocacong.server.exception.unauthorized.TokenExpiredException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+
+@Component
+public class AppleJwtParser {
+
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64Utils.decodeFromUrlSafeString(encodedHeader));
+            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new InvalidTokenException("Apple OAuth Identity Token 형식이 올바르지 않습니다.");
+        }
+    }
+
+    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(publicKey)
+                    .parseClaimsJws(idToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException("Apple OAuth 로그인 중 Identity Token 유효기간이 만료됐습니다.");
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            throw new InvalidTokenException("Apple OAuth Identity Token 값이 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleOAuthUserProvider.java
@@ -24,7 +24,7 @@ public class AppleOAuthUserProvider {
 
         Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
         validateClaims(claims);
-        return new ApplePlatformMemberResponse(claims.getSubject());
+        return new ApplePlatformMemberResponse(claims.getSubject(), claims.get("email", String.class));
     }
 
     private void validateClaims(Claims claims) {

--- a/src/main/java/mocacong/server/security/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleOAuthUserProvider.java
@@ -1,0 +1,35 @@
+package mocacong.server.security.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import java.security.PublicKey;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import mocacong.server.exception.unauthorized.InvalidTokenException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOAuthUserProvider {
+
+    private final AppleJwtParser appleJwtParser;
+    private final AppleClient appleClient;
+    private final PublicKeyGenerator publicKeyGenerator;
+    private final AppleClaimsValidator appleClaimsValidator;
+
+    public ApplePlatformMemberResponse getApplePlatformMember(String identityToken) {
+        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
+
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+        validateClaims(claims);
+        return new ApplePlatformMemberResponse(claims.getSubject());
+    }
+
+    private void validateClaims(Claims claims) {
+        if (!appleClaimsValidator.isValid(claims)) {
+            throw new InvalidTokenException("Apple OAuth Claims 값이 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/apple/ApplePlatformMemberResponse.java
+++ b/src/main/java/mocacong/server/security/auth/apple/ApplePlatformMemberResponse.java
@@ -1,0 +1,14 @@
+package mocacong.server.security.auth.apple;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApplePlatformMemberResponse {
+
+    private String platformId;
+}

--- a/src/main/java/mocacong/server/security/auth/apple/ApplePlatformMemberResponse.java
+++ b/src/main/java/mocacong/server/security/auth/apple/ApplePlatformMemberResponse.java
@@ -11,4 +11,5 @@ import lombok.NoArgsConstructor;
 public class ApplePlatformMemberResponse {
 
     private String platformId;
+    private String email;
 }

--- a/src/main/java/mocacong/server/security/auth/apple/ApplePublicKey.java
+++ b/src/main/java/mocacong/server/security/auth/apple/ApplePublicKey.java
@@ -1,0 +1,19 @@
+package mocacong.server.security.auth.apple;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ApplePublicKey {
+
+    private String kty;
+    private String kid;
+    private String use;
+    private String alg;
+    private String n;
+    private String e;
+}

--- a/src/main/java/mocacong/server/security/auth/apple/ApplePublicKeys.java
+++ b/src/main/java/mocacong/server/security/auth/apple/ApplePublicKeys.java
@@ -1,0 +1,23 @@
+package mocacong.server.security.auth.apple;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ApplePublicKeys {
+
+    private List<ApplePublicKey> keys;
+
+    public ApplePublicKey getMatchesKey(String alg, String kid) {
+        return this.keys
+                .stream()
+                .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Apple JWT 값의 alg, kid 정보가 올바르지 않습니다."));
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/apple/PublicKeyGenerator.java
+++ b/src/main/java/mocacong/server/security/auth/apple/PublicKeyGenerator.java
@@ -1,0 +1,43 @@
+package mocacong.server.security.auth.apple;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+
+@Component
+public class PublicKeyGenerator {
+
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey =
+                applePublicKeys.getMatchesKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
+
+        return generatePublicKeyWithApplePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKey publicKey) {
+        byte[] nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getN());
+        byte[] eBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getE());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getKty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new IllegalStateException("Apple OAuth 로그인 중 public key 생성에 문제가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -2,12 +2,17 @@ package mocacong.server.service;
 
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
+import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.AuthLoginRequest;
+import mocacong.server.dto.request.AppleLoginRequest;
+import mocacong.server.dto.response.AppleTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.security.auth.JwtTokenProvider;
+import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
+import mocacong.server.security.auth.apple.ApplePlatformMemberResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -15,19 +20,33 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final AppleOAuthUserProvider appleOAuthUserProvider;
 
-    public TokenResponse login(final AuthLoginRequest authLoginRequest) {
-        Member findMember = memberRepository.findByEmail(authLoginRequest.getEmail())
+    public TokenResponse login(AuthLoginRequest request) {
+        Member findMember = memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(NotFoundMemberException::new);
-
-        validatePassword(findMember, authLoginRequest.getPassword());
+        validatePassword(findMember, request.getPassword());
 
         String token = issueToken(findMember);
-
         return TokenResponse.from(token);
+    }
+
+    public AppleTokenResponse appleOAuthLogin(AppleLoginRequest request) {
+        ApplePlatformMemberResponse applePlatformMember =
+                appleOAuthUserProvider.getApplePlatformMember(request.getToken());
+
+        return memberRepository.findIdByPlatformAndPlatformId(Platform.APPLE, applePlatformMember.getPlatformId())
+                .map(memberId -> {
+                    Member findMember = memberRepository.findById(memberId)
+                            .orElseThrow(NotFoundMemberException::new);
+                    String token = issueToken(findMember);
+                    return new AppleTokenResponse(token, findMember.getEmail(), true);
+                })
+                .orElseGet(() -> new AppleTokenResponse(null, applePlatformMember.getEmail(), false));
     }
 
     private String issueToken(final Member findMember) {

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -6,7 +6,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
+import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.request.OAuthMemberSignUpRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.InvalidEmailException;
@@ -49,6 +51,16 @@ public class MemberService {
                 .ifPresent(member -> {
                     throw new DuplicateMemberException();
                 });
+    }
+
+    @Transactional
+    public OAuthMemberSignUpResponse signUpByOAuthMember(OAuthMemberSignUpRequest request) {
+        Platform platform = Platform.from(request.getPlatform());
+        Member member = memberRepository.findByPlatformAndPlatformId(platform, request.getPlatformId())
+                .orElseThrow(NotFoundMemberException::new);
+
+        member.registerOAuthMember(request.getEmail(), request.getNickname());
+        return new OAuthMemberSignUpResponse(member.getId());
     }
 
     public void delete(String email) {

--- a/src/main/java/mocacong/server/support/AwsS3Uploader.java
+++ b/src/main/java/mocacong/server/support/AwsS3Uploader.java
@@ -37,6 +37,7 @@ public class AwsS3Uploader {
                     .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e) {
             log.error("S3 파일 업로드에 실패했습니다. {}", e.getMessage());
+            throw new IllegalStateException("S3 파일 업로드에 실패했습니다.");
         }
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -42,3 +42,16 @@ cloud:
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+
+oauth:
+  apple:
+    iss: https://appleid.apple.com
+    client-id: ${OAUTH_APPLE_CLIENT_ID}
+    nonce: ${OAUTH_APPLE_NONCE}
+
+feign:
+  client:
+    config:
+      apple-public-key-client:
+        connectTimeout: 5000
+        readTimeout: 3000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,7 @@ cloud:
 oauth:
   apple:
     iss: https://appleid.apple.com
-    client-id: test
+    client-id: ${OAUTH_APPLE_CLIENT_ID}
     nonce: test
 
 feign:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,7 +56,7 @@ oauth:
   apple:
     iss: https://appleid.apple.com
     client-id: ${OAUTH_APPLE_CLIENT_ID}
-    nonce: test
+    nonce: ${OAUTH_APPLE_NONCE}
 
 feign:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,16 @@ cloud:
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+
+oauth:
+  apple:
+    iss: https://appleid.apple.com
+    client-id: test
+    nonce: test
+
+feign:
+  client:
+    config:
+      apple-public-key-client:
+        connectTimeout: 5000
+        readTimeout: 3000

--- a/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
@@ -1,19 +1,29 @@
 package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
+import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
+import mocacong.server.dto.response.AppleTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
+import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
+import mocacong.server.security.auth.apple.ApplePlatformMemberResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AuthAcceptanceTest extends AcceptanceTest {
+
+    @MockBean
+    private AppleOAuthUserProvider appleOAuthUserProvider;
 
     @Test
     @DisplayName("회원이 정상적으로 로그인한다")
@@ -38,5 +48,25 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         assertNotNull(tokenResponse);
         assertNotNull(tokenResponse.getToken());
+    }
+
+    @Test
+    @DisplayName("회원이 Apple OAuth 로그인을 정상적으로 진행한다")
+    void loginAppleOAuth() {
+        String expected = "kth@apple.com";
+        ApplePlatformMemberResponse oauthResponse = new ApplePlatformMemberResponse("1234321", expected);
+        when(appleOAuthUserProvider.getApplePlatformMember(any())).thenReturn(oauthResponse);
+        AppleLoginRequest request = new AppleLoginRequest("token");
+
+        AppleTokenResponse actual = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/login/apple")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(AppleTokenResponse.class);
+
+        assertThat(actual.getEmail()).isEqualTo(expected);
     }
 }

--- a/src/test/java/mocacong/server/domain/MemberTest.java
+++ b/src/test/java/mocacong/server/domain/MemberTest.java
@@ -2,7 +2,9 @@ package mocacong.server.domain;
 
 import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPhoneException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,32 @@ class MemberTest {
     void createMember() {
         assertDoesNotThrow(
                 () -> new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678")
+        );
+    }
+
+    @Test
+    @DisplayName("OAuth 회원 가입 시에 입력받은 정보로 수정한다")
+    void registerOAuthMember() {
+        Member member = new Member("kth@apple.com", Platform.APPLE, "1234321");
+
+        member.registerOAuthMember("kth990303@apple.com", "케이");
+
+        assertAll(
+                () -> assertThat(member.getEmail()).isEqualTo("kth990303@apple.com"),
+                () -> assertThat(member.getNickname()).isEqualTo("케이")
+        );
+    }
+
+    @Test
+    @DisplayName("OAuth 회원 가입 시에 입력받은 정보 중 이메일이 null이면 이메일은 수정되지 않는다")
+    void registerOAuthMemberWhenEmailIsNull() {
+        Member member = new Member("kth@apple.com", Platform.APPLE, "1234321");
+
+        member.registerOAuthMember(null, "케이");
+
+        assertAll(
+                () -> assertThat(member.getEmail()).isNotNull(),
+                () -> assertThat(member.getNickname()).isEqualTo("케이")
         );
     }
 

--- a/src/test/java/mocacong/server/domain/PlatformTest.java
+++ b/src/test/java/mocacong/server/domain/PlatformTest.java
@@ -1,0 +1,29 @@
+package mocacong.server.domain;
+
+import mocacong.server.exception.badrequest.InvalidPlatformException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PlatformTest {
+
+    @Test
+    @DisplayName("요청으로 들어온 platform을 올바르게 반환한다")
+    void from() {
+        Platform expected = Platform.APPLE;
+
+        Platform actual = Platform.from("apple");
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("요청으로 들어온 platform이 올바르지 않으면 예외를 반환한다")
+    void fromInvalid() {
+        Platform expected = Platform.MOCACONG;
+
+        assertThatThrownBy(() -> Platform.from(null))
+                .isInstanceOf(InvalidPlatformException.class);
+    }
+}

--- a/src/test/java/mocacong/server/repository/MemberRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/MemberRepositoryTest.java
@@ -1,0 +1,36 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.Member;
+import mocacong.server.domain.Platform;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원의 OAuth 플랫폼과 플랫폼 id 값으로 회원의 id를 조회한다")
+    void findIdByPlatformAndPlatformId() {
+        Member member = new Member(
+                "kth@apple.com",
+                "a1b2c3d4",
+                "케이",
+                "010-1234-1234",
+                null,
+                Platform.APPLE,
+                "1234321"
+        );
+        Member savedMember = memberRepository.save(member);
+
+        Long actual = memberRepository.findIdByPlatformAndPlatformId(Platform.APPLE, "1234321")
+                .orElseThrow();
+
+        assertThat(actual).isEqualTo(savedMember.getId());
+    }
+}

--- a/src/test/java/mocacong/server/security/EncryptUtilsTest.java
+++ b/src/test/java/mocacong/server/security/EncryptUtilsTest.java
@@ -1,0 +1,18 @@
+package mocacong.server.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EncryptUtilsTest {
+
+    @Test
+    @DisplayName("입력이 주어지면 해당 문자열을 암호화한다")
+    void encrypt() {
+        String given = "abc123";
+
+        String actual = EncryptUtils.encrypt(given);
+
+        assertThat(actual).isNotEqualTo(given);
+    }
+}

--- a/src/test/java/mocacong/server/security/auth/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleClaimsValidatorTest.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.util.HashMap;
 import java.util.Map;
+import mocacong.server.security.EncryptUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ class AppleClaimsValidatorTest {
     @DisplayName("올바른 Claims 이면 true 반환한다")
     void isValid() {
         Map<String, Object> claimsMap = new HashMap<>();
-        claimsMap.put(NONCE_KEY, NONCE);
+        claimsMap.put(NONCE_KEY, EncryptUtils.encrypt(NONCE));
 
         Claims claims = Jwts.claims(claimsMap)
                 .setIssuer(ISS)
@@ -41,7 +42,7 @@ class AppleClaimsValidatorTest {
     })
     void isInvalid(String nonce, String iss, String clientId) {
         Map<String, Object> claimsMap = new HashMap<>();
-        claimsMap.put(NONCE_KEY, nonce);
+        claimsMap.put(NONCE_KEY, EncryptUtils.encrypt(nonce));
 
         Claims claims = Jwts.claims(claimsMap)
                 .setIssuer(iss)

--- a/src/test/java/mocacong/server/security/auth/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleClaimsValidatorTest.java
@@ -1,0 +1,52 @@
+package mocacong.server.security.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.util.HashMap;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AppleClaimsValidatorTest {
+
+    private static final String ISS = "iss";
+    private static final String CLIENT_ID = "aud";
+    private static final String NONCE = "nonce";
+    private static final String NONCE_KEY = "nonce";
+
+    private final AppleClaimsValidator appleClaimsValidator = new AppleClaimsValidator(ISS, CLIENT_ID, NONCE);
+
+    @Test
+    @DisplayName("올바른 Claims 이면 true 반환한다")
+    void isValid() {
+        Map<String, Object> claimsMap = new HashMap<>();
+        claimsMap.put(NONCE_KEY, NONCE);
+
+        Claims claims = Jwts.claims(claimsMap)
+                .setIssuer(ISS)
+                .setAudience(CLIENT_ID);
+
+        assertThat(appleClaimsValidator.isValid(claims)).isTrue();
+    }
+
+    @ParameterizedTest
+    @DisplayName("nonce, iss, aud(client_id) 중 올바르지 않은 값이 존재하면 false 반환한다")
+    @CsvSource({
+            "invalid, iss, aud",
+            "nonce, invalid, aud",
+            "nonce, iss, invalid"
+    })
+    void isInvalid(String nonce, String iss, String clientId) {
+        Map<String, Object> claimsMap = new HashMap<>();
+        claimsMap.put(NONCE_KEY, nonce);
+
+        Claims claims = Jwts.claims(claimsMap)
+                .setIssuer(iss)
+                .setAudience(clientId);
+
+        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
+    }
+}

--- a/src/test/java/mocacong/server/security/auth/apple/AppleClientTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleClientTest.java
@@ -1,0 +1,33 @@
+package mocacong.server.security.auth.apple;
+
+import java.util.List;
+import java.util.Objects;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AppleClientTest {
+
+    @Autowired
+    private AppleClient appleClient;
+
+    @Test
+    @DisplayName("apple 서버와 통신하여 Apple public keys 응답을 받는다")
+    void getPublicKeys() {
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+        List<ApplePublicKey> keys = applePublicKeys.getKeys();
+
+        boolean isRequestedKeysNonNull = keys.stream()
+                .allMatch(this::isAllNotNull);
+        assertThat(isRequestedKeysNonNull).isTrue();
+    }
+
+    private boolean isAllNotNull(ApplePublicKey applePublicKey) {
+        return Objects.nonNull(applePublicKey.getKty()) && Objects.nonNull(applePublicKey.getKid()) &&
+                Objects.nonNull(applePublicKey.getUse()) && Objects.nonNull(applePublicKey.getAlg()) &&
+                Objects.nonNull(applePublicKey.getN()) && Objects.nonNull(applePublicKey.getE());
+    }
+}

--- a/src/test/java/mocacong/server/security/auth/apple/AppleJwtParserTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleJwtParserTest.java
@@ -1,0 +1,127 @@
+package mocacong.server.security.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.*;
+import java.util.Date;
+import java.util.Map;
+import mocacong.server.exception.unauthorized.InvalidTokenException;
+import mocacong.server.exception.unauthorized.TokenExpiredException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AppleJwtParserTest {
+
+    private final AppleJwtParser appleJwtParser = new AppleJwtParser();
+
+    @Test
+    @DisplayName("Apple identity token으로 헤더를 파싱한다")
+    void parseHeaders() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        Map<String, String> actual = appleJwtParser.parseHeaders(identityToken);
+
+        assertThat(actual).containsKeys("alg", "kid");
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 형식의 Apple identity token으로 헤더를 파싱하면 예외를 반환한다")
+    void parseHeadersWithInvalidToken() {
+        assertThatThrownBy(() -> appleJwtParser.parseHeaders("invalidToken"))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    @DisplayName("Apple identity token, PublicKey를 받아 사용자 정보가 포함된 Claims를 반환한다")
+    void parsePublicKeyAndGetClaims() throws NoSuchAlgorithmException {
+        String expected = "19281729";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(expected)
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+
+        assertAll(
+                () -> assertThat(claims).isNotEmpty(),
+                () -> assertThat(claims.getSubject()).isEqualTo(expected)
+        );
+    }
+
+    @Test
+    @DisplayName("만료된 Apple identity token을 받으면 Claims 획득 시에 예외를 반환한다")
+    void parseExpiredTokenAndGetClaims() throws NoSuchAlgorithmException {
+        String expected = "19281729";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(expected)
+                .setExpiration(new Date(now.getTime() - 1L))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        assertThatThrownBy(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey))
+                .isInstanceOf(TokenExpiredException.class);
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 public Key로 Claims 획득 시에 예외를 반환한다")
+    void parseInvalidPublicKeyAndGetClaims() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        PrivateKey privateKey = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair()
+                .getPrivate();
+        PublicKey differentPublicKey = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair()
+                .getPublic();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject("19281729")
+                .setExpiration(new Date(now.getTime() - 1L))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        assertThatThrownBy(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, differentPublicKey))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+}

--- a/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
@@ -4,7 +4,9 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.security.*;
 import java.util.Date;
+import mocacong.server.exception.unauthorized.InvalidTokenException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,5 +59,33 @@ class AppleOAuthUserProviderTest {
                 () -> assertThat(actual.getPlatformId()).isEqualTo(expected),
                 () -> assertThat(actual.getEmail()).isEqualTo("kth@apple.com")
         );
+    }
+
+    @Test
+    @DisplayName("Claim 검증에 실패할 경우 예외를 반환한다")
+    void invalidClaims() throws NoSuchAlgorithmException {
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .claim("email", "kth@apple.com")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject("19281729")
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        when(appleClient.getApplePublicKeys()).thenReturn(mock(ApplePublicKeys.class));
+        when(publicKeyGenerator.generatePublicKey(any(), any())).thenReturn(publicKey);
+        when(appleClaimsValidator.isValid(any())).thenReturn(false);
+
+        assertThatThrownBy(() -> appleOAuthUserProvider.getApplePlatformMember(identityToken))
+                .isInstanceOf(InvalidTokenException.class);
     }
 }

--- a/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
@@ -1,0 +1,56 @@
+package mocacong.server.security.auth.apple;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.*;
+import java.util.Date;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+class AppleOAuthUserProviderTest {
+
+    @Autowired
+    private AppleOAuthUserProvider appleOAuthUserProvider;
+
+    @MockBean
+    private AppleClient appleClient;
+    @MockBean
+    private PublicKeyGenerator publicKeyGenerator;
+    @MockBean
+    private AppleClaimsValidator appleClaimsValidator;
+
+    @Test
+    @DisplayName("Apple OAuth 유저 접속 시 platform Id를 반환한다")
+    void getApplePlatformMember() throws NoSuchAlgorithmException {
+        String expected = "19281729";
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        PrivateKey privateKey = keyPair.getPrivate();
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(expected)
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        when(appleClient.getApplePublicKeys()).thenReturn(mock(ApplePublicKeys.class));
+        when(publicKeyGenerator.generatePublicKey(any(), any())).thenReturn(publicKey);
+        when(appleClaimsValidator.isValid(any())).thenReturn(true);
+
+        ApplePlatformMemberResponse actual = appleOAuthUserProvider.getApplePlatformMember(identityToken);
+
+        assertThat(actual.getPlatformId()).isEqualTo(expected);
+    }
+}

--- a/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.security.*;
 import java.util.Date;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
@@ -37,6 +38,7 @@ class AppleOAuthUserProviderTest {
         String identityToken = Jwts.builder()
                 .setHeaderParam("kid", "W2R4HXF3K")
                 .claim("id", "12345678")
+                .claim("email", "kth@apple.com")
                 .setIssuer("iss")
                 .setIssuedAt(now)
                 .setAudience("aud")
@@ -51,6 +53,9 @@ class AppleOAuthUserProviderTest {
 
         ApplePlatformMemberResponse actual = appleOAuthUserProvider.getApplePlatformMember(identityToken);
 
-        assertThat(actual.getPlatformId()).isEqualTo(expected);
+        assertAll(
+                () -> assertThat(actual.getPlatformId()).isEqualTo(expected),
+                () -> assertThat(actual.getEmail()).isEqualTo("kth@apple.com")
+        );
     }
 }

--- a/src/test/java/mocacong/server/security/auth/apple/ApplePublicKeysTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/ApplePublicKeysTest.java
@@ -1,0 +1,31 @@
+package mocacong.server.security.auth.apple;
+
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ApplePublicKeysTest {
+
+    @Test
+    @DisplayName("alg, kid 값을 받아 해당 apple public key를 반환한다")
+    void getMatchesKey() {
+        ApplePublicKey expected = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(expected));
+
+        assertThat(applePublicKeys.getMatchesKey("alg", "kid")).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("alg, kid 값에 잘못된 값이 들어오면 예외를 반환한다")
+    void getMatchesInvalidKey() {
+        ApplePublicKey expected = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(expected));
+
+        assertThatThrownBy(() -> applePublicKeys.getMatchesKey("invalid", "invalid"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/mocacong/server/service/AuthServiceTest.java
+++ b/src/test/java/mocacong/server/service/AuthServiceTest.java
@@ -2,8 +2,8 @@ package mocacong.server.service;
 
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Platform;
-import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.request.AppleLoginRequest;
+import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.response.AppleTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
@@ -67,15 +67,17 @@ class AuthServiceTest {
     @DisplayName("Apple OAuth 로그인 시 가입되지 않은 회원일 경우 이메일 값을 보내고 isRegistered 값을 false로 보낸다")
     void appleOAuthNotRegistered() {
         String expected = "kth@apple.com";
+        String platformId = "1234321";
         when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
-                .thenReturn(new ApplePlatformMemberResponse("1234321", expected));
+                .thenReturn(new ApplePlatformMemberResponse(platformId, expected));
 
         AppleTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
 
         assertAll(
-                () -> assertThat(actual.getToken()).isNull(),
+                () -> assertThat(actual.getToken()).isNotNull(),
                 () -> assertThat(actual.getEmail()).isEqualTo(expected),
-                () -> assertThat(actual.getIsRegistered()).isFalse()
+                () -> assertThat(actual.getIsRegistered()).isFalse(),
+                () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
         );
     }
 
@@ -83,6 +85,7 @@ class AuthServiceTest {
     @DisplayName("Apple OAuth 로그인 시 이미 가입된 회원일 경우 토큰과 이메일, 그리고 isRegistered 값을 true로 보낸다")
     void appleOAuthRegistered() {
         String expected = "kth@apple.com";
+        String platformId = "1234321";
         Member member = new Member(
                 expected,
                 passwordEncoder.encode("a1b2c3d4"),
@@ -90,18 +93,19 @@ class AuthServiceTest {
                 "010-1234-1234",
                 null,
                 Platform.APPLE,
-                "1234321"
+                platformId
         );
         memberRepository.save(member);
         when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
-                .thenReturn(new ApplePlatformMemberResponse("1234321", expected));
+                .thenReturn(new ApplePlatformMemberResponse(platformId, expected));
 
         AppleTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
 
         assertAll(
                 () -> assertThat(actual.getToken()).isNotNull(),
                 () -> assertThat(actual.getEmail()).isEqualTo(expected),
-                () -> assertThat(actual.getIsRegistered()).isTrue()
+                () -> assertThat(actual.getIsRegistered()).isTrue(),
+                () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
         );
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,3 +29,9 @@ cloud:
       auto: false
     stack:
       auto: false
+
+oauth:
+  apple:
+    iss: https://appleid.apple.com
+    client-id: test
+    nonce: nonce


### PR DESCRIPTION
## 개요
- 애플 OAuth 로그인 기능을 FeignClient를 이용하여 구현했습니다.

## 작업사항
- OAuth 사용자 프로세스의 큰 틀은 아래와 같습니다.
<img width="443" alt="image" src="https://user-images.githubusercontent.com/57135043/231438768-8b8719fc-3e28-453f-9d6e-dbf636de64af.png">
- Apple OAuth 동작 원리 및 코드에 대해서는 컨플루언스 위키를 참고해주세요
- 추가된 로그인 및 회원가입 API spec 에 맞춰서 구현했습니다.

## 주의사항
- 보안 상 문제되는 코드가 있다면 리뷰해주세요
- 누락된 테스트 코드가 있는지 확인해주세요
- 불필요한 로직이나 추가돼야 할 로직이 있다면 리뷰해주세요
- 오타가 있는지 확인해주세요
