### PR TITLE
feat: 서버 에러 발생 시 슬랙 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.slack.api:slack-api-client:1.29.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -34,6 +35,6 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }

--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -69,7 +69,7 @@ public class ControllerAdvice {
                     )
             ));
         } catch (IOException slackError) {
-            throw new IllegalArgumentException(slackError.getMessage());
+            log.debug("Slack 통신과의 예외 발생");
         }
     }
 

--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -1,10 +1,19 @@
 package mocacong.server.controller;
 
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import static com.slack.api.webhook.WebhookPayloads.payload;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import mocacong.server.dto.response.ErrorResponse;
 import mocacong.server.exception.MocacongException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,6 +26,11 @@ public class ControllerAdvice {
 
     private static final int FIELD_ERROR_CODE_INDEX = 0;
     private static final int FIELD_ERROR_MESSAGE_INDEX = 1;
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleInputFieldException(MethodArgumentNotValidException e) {
@@ -41,7 +55,44 @@ public class ControllerAdvice {
                 request.getRequestURI(),
                 e.getMessage()
         );
+        sendSlackAlertErrorLog(e, request);
         return ResponseEntity.internalServerError()
                 .body(new ErrorResponse(9999, "일시적으로 접속이 원활하지 않습니다. 모카콩 서비스 팀에 문의 부탁드립니다."));
+    }
+
+    private void sendSlackAlertErrorLog(Exception e, HttpServletRequest request) {
+        try {
+            slackClient.send(webhookUrl, payload(p -> p
+                    .text("서버 에러 발생! 백엔드 측의 빠른 확인 요망")
+                    .attachments(
+                            List.of(generateSlackAttachment(e, request))
+                    )
+            ));
+        } catch (IOException slackError) {
+            throw new IllegalArgumentException(slackError.getMessage());
+        }
+    }
+
+    private Attachment generateSlackAttachment(Exception e, HttpServletRequest request) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        String xffHeader = request.getHeader("X-FORWARDED-FOR");
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + " 발생 에러 로그")
+                .fields(List.of(
+                                generateSlackField("Request IP", xffHeader == null ? request.getRemoteAddr() : xffHeader),
+                                generateSlackField("Request URL", request.getRequestURL() + " " + request.getMethod()),
+                                generateSlackField("Error Message", e.getMessage())
+                        )
+                )
+                .build();
+    }
+
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(false)
+                .build();
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -44,3 +44,7 @@ cloud:
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,7 @@ cloud:
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}
+
+slack:
+  webhook:
+    url: test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,3 +31,7 @@ cloud:
       auto: false
     stack:
       auto: false
+
+slack:
+  webhook:
+    url: test


### PR DESCRIPTION
## 개요
- 현재는 에러 발생 시 issue 채널에 직접 등록해야 하는 번거로움이 존재합니다.

## 작업사항
- internal server error (500번대 에러) 발생 시에 슬랙에 알림을 보내도록 구현했습니다.
- MavenRepository를 참고하여 비교적 최신이면서도 가장 안정적인 `slack-api-client:1.29.0` 의존성을 추가했습니다. 
<img width="932" alt="image" src="https://user-images.githubusercontent.com/57135043/231928159-0077c44c-fcda-407e-8d79-df4b661aa578.png">
- 알림 예시는 아래와 같습니다.
<img width="769" alt="image" src="https://user-images.githubusercontent.com/57135043/231928298-a516771a-5200-4ad2-9a83-71a52d3d15ce.png">

## 주의사항
- 로컬 환경에서 직접 테스트해보고 싶을 경우 환경변수를 주입해주셔야 됩니다.
- 에러 로그가 마음에 드시는지 확인해주세요.
