### PR TITLE
feat: JSON 파싱 예외 핸들러 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -15,6 +15,7 @@ import mocacong.server.dto.response.ErrorResponse;
 import mocacong.server.exception.MocacongException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -41,6 +42,13 @@ public class ControllerAdvice {
         String message = errorInfo[FIELD_ERROR_MESSAGE_INDEX];
 
         return ResponseEntity.badRequest().body(new ErrorResponse(code, message));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleJsonException(HttpMessageNotReadableException e) {
+        log.error("Json Exception:errMessage={}\n", e.getMessage());
+
+        return ResponseEntity.badRequest().body(new ErrorResponse(9000, "Json 형식 또는 ContentType이 올바르지 않습니다."));
     }
 
     @ExceptionHandler(MocacongException.class)


### PR DESCRIPTION
## 개요
- 서버 측 에러가 아닌 입력데이터 형식 오류인 경우에 서버 측 에러로 처리되지 않도록 해야 합니다. 현재는 해당 경우 서버 측 에러로 처리되고 있습니다.

## 작업사항
- 입력데이터 형식 오류인 경우 예외처리해주도록 했습니다. `HttpMessageNotReadableException`은 Http message를 읽을 수 없을 때 발생하는 에러로, 보통 json 형식 오류나 contenttype이 application/json이 아닌 다른 형식의 경우 발생할 수 있습니다. `JsonParseException`, `JsonMappingException`의 상위 에러이므로 HttpMessageNotReadableException으로 처리했습니다.

## 주의사항
- Docs와 비교하여 다른 부분이 있는지 확인해주세요.
- 더 좋은 에러메시지가 있다면 추천해주세요.
