### PR TITLE
feat: ContentType 관련 예외 핸들링 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -46,9 +46,9 @@ public class ControllerAdvice {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleJsonException(HttpMessageNotReadableException e) {
-        log.error("Json Exception:errMessage={}\n", e.getMessage());
+        log.warn("Json Exception ErrMessage={}\n", e.getMessage());
 
-        return ResponseEntity.badRequest().body(new ErrorResponse(9000, "Json 형식 또는 ContentType이 올바르지 않습니다."));
+        return ResponseEntity.badRequest().body(new ErrorResponse(9000, "Json 형식이 올바르지 않습니다."));
     }
 
     @ExceptionHandler(MocacongException.class)

--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -49,6 +50,13 @@ public class ControllerAdvice {
         log.warn("Json Exception ErrMessage={}\n", e.getMessage());
 
         return ResponseEntity.badRequest().body(new ErrorResponse(9000, "Json 형식이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(HttpMediaTypeException.class)
+    public ResponseEntity<ErrorResponse> handleContentTypeException(HttpMediaTypeException e) {
+        log.warn("ContentType Exception ErrMessage={}\n", e.getMessage());
+
+        return ResponseEntity.badRequest().body(new ErrorResponse(9001, "ContentType 값이 올바르지 않습니다."));
     }
 
     @ExceptionHandler(MocacongException.class)


### PR DESCRIPTION
## 개요
- `Content type 'application/x-www-form-urlencoded;charset=UTF-8' not supported` 에러는 서버 측 에러가 아님에도 불구하고 핸들링을 안해주고 있었습니다.

## 작업사항
- `HttpMediaTypeNotAcceptableException`, `HttpMediaTypeNotSupportedException`의 상위 호환인 `HttpMediaTypeException`을 핸들링하도록 추가했습니다. 
- 로깅 레벨은 error보다 한 단계 낮은 warn으로 설정했습니다.

## 주의사항
- 에러 메시지가 예쁜지 확인해주세요
