### PR TITLE
feat: CORS 이슈 해결 적용

### DIFF
--- a/src/main/java/mocacong/server/config/SecurityConfig.java
+++ b/src/main/java/mocacong/server/config/SecurityConfig.java
@@ -15,7 +15,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .cors().disable()
                 .csrf().disable()
                 .formLogin().disable()
                 .headers().frameOptions().disable();

--- a/src/main/java/mocacong/server/config/WebConfig.java
+++ b/src/main/java/mocacong/server/config/WebConfig.java
@@ -1,0 +1,23 @@
+package mocacong.server.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+                .exposedHeaders(HttpHeaders.LOCATION)
+                .maxAge(5000);
+    }
+}


### PR DESCRIPTION
## 개요
- HTTPS가 적용되면 프로토콜이 달라 CORS 이슈가 발생합니다. (사실 HTTP 에서도 발생했어야 했지만, spring security의 `cors.disable() `옵션 때문에 발생 안한 걸로 예상됩니다.)

## 작업사항
- CORS Mapping 허용 정책 오버라이딩 메서드를 작성했습니다.

## 주의사항
- 보안적으로 추가하고 싶은 부분이 있다면 리뷰해주세요.
