### PR TITLE
fix: Apple OAuth 최종 회원가입 로직 수정

### DIFF
--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -80,6 +80,10 @@ public class Member extends BaseTime {
         }
     }
 
+    public boolean isRegisteredOAuthMember() {
+        return nickname != null;
+    }
+
     private void validateMemberInfo(String nickname, String phone) {
         validateNickname(nickname);
         validatePhone(phone);

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -45,6 +45,12 @@ public class AuthService {
                     Member findMember = memberRepository.findById(memberId)
                             .orElseThrow(NotFoundMemberException::new);
                     String token = issueToken(findMember);
+
+                    // OAuth 로그인은 성공했지만 회원가입에 실패한 경우
+                    if (!findMember.isRegisteredOAuthMember()) {
+                        return new AppleTokenResponse(token, findMember.getEmail(), false, platformId);
+                    }
+
                     return new AppleTokenResponse(token, findMember.getEmail(), true, platformId);
                 })
                 .orElseGet(() -> {

--- a/src/test/java/mocacong/server/domain/MemberTest.java
+++ b/src/test/java/mocacong/server/domain/MemberTest.java
@@ -47,6 +47,14 @@ class MemberTest {
         );
     }
 
+    @Test
+    @DisplayName("OAuth 회원이 등록은 돼있지만, 닉네임이 없는 경우 회원가입 절차가 진행되지 않은 것으로 판단한다")
+    void isRegisterMember() {
+        Member member = new Member("kth@apple.com", Platform.APPLE, "1234321");
+
+        assertThat(member.isRegisteredOAuthMember()).isFalse();
+    }
+
     @ParameterizedTest
     @DisplayName("닉네임은 초성, 중성, 종성 분리하여 지을 수 있다")
     @ValueSource(strings = {"ㄱㅁㄴㄷㄹ", "ㅏㅣㅓㅜ", "가ㅏ누ㅟ"})


### PR DESCRIPTION
## 개요
- OAuth 로그인 후, 회원가입을 진행하는 과정이 실패하면 nickname엔 null이 들어갑니다. 하지만 기존 로직 상으로는 platformId 값을 가지는 member 가 db에 저장돼있어 `isRegistered` true 값으로 response를 보내줍니다.

## 작업사항
- 최종적인 모카콩 회원가입 과정이 진행되지 않아 nickname이 Null인 경우 `isRegistered`를 false를 반환하도록 변경했습니다.

## 주의사항
- 코드 가독성이 괜찮은지 확인해주세요.
- 비교적 빠른 머지가 필요합니다.
