### PR TITLE
feat: HttpRequestMethodNotSupportedException 예외 핸들링 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -57,6 +58,13 @@ public class ControllerAdvice {
         log.warn("ContentType Exception ErrMessage={}\n", e.getMessage());
 
         return ResponseEntity.badRequest().body(new ErrorResponse(9001, "ContentType 값이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleRequestMethodException(HttpRequestMethodNotSupportedException e) {
+        log.warn("Http Method not supported Exception ErrMessage={}\n", e.getMessage());
+
+        return ResponseEntity.badRequest().body(new ErrorResponse(9002, "해당 Http Method에 맞는 API가 존재하지 않습니다."));
     }
 
     @ExceptionHandler(MocacongException.class)


### PR DESCRIPTION
## 개요
- Http Request URL이랑 Method가 매치되지 않는 요청으로 들어오는 경우는 서버 에러가 아닌 요청이 잘못된 경우입니다. 이러한 경우에 서버 에러라고 뜨는 현상이 발생합니다.

## 작업사항
- HttpRequestMethodNotSupportedException 예외 핸들링을 구현했습니다.

## 주의사항
- 에러 커스텀 Docs와 비교하여 확인해주세요
