### PR TITLE
fix: 리뷰나 댓글 작성한 회원탈퇴가 불가능한 버그 수정 

### DIFF
--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -64,4 +64,8 @@ public class Comment extends BaseTime {
             throw new NotFoundMemberException();
         }
     }
+
+    public void removeMember() {
+        this.member = null;
+    }
 }

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -1,12 +1,11 @@
 package mocacong.server.domain;
 
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.ExceedCommentLengthException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
-
-import javax.persistence.*;
 
 @Entity
 @Table(name = "comment")
@@ -45,15 +44,15 @@ public class Comment extends BaseTime {
     }
 
     public String getWriterNickname() {
-        return this.member.getNickname();
+        return this.member != null ? this.member.getNickname() : null;
     }
 
     public String getWriterImgUrl() {
-        return this.member.getImgUrl();
+        return this.member != null ? this.member.getImgUrl() : null;
     }
 
     public boolean isWrittenByMember(Member member) {
-        return this.member.equals(member);
+        return this.member != null && this.member.equals(member);
     }
 
     public void updateComment(Member member, String content) {

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -5,7 +5,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.ExceedCommentLengthException;
-import mocacong.server.exception.notfound.NotFoundMemberException;
 
 @Entity
 @Table(name = "comment")
@@ -55,13 +54,9 @@ public class Comment extends BaseTime {
         return this.member != null && this.member.equals(member);
     }
 
-    public void updateComment(Member member, String content) {
-        if (isWrittenByMember(member)) {
-            validateCommentLength(content);
-            this.content = content;
-        } else {
-            throw new NotFoundMemberException();
-        }
+    public void updateComment(String content) {
+        validateCommentLength(content);
+        this.content = content;
     }
 
     public void removeMember() {

--- a/src/main/java/mocacong/server/domain/Review.java
+++ b/src/main/java/mocacong/server/domain/Review.java
@@ -66,4 +66,8 @@ public class Review extends BaseTime {
     public void updateReview(CafeDetail newCafeDetail) {
         this.cafeDetail = newCafeDetail;
     }
+
+    public void removeMember() {
+        this.member = null;
+    }
 }

--- a/src/main/java/mocacong/server/domain/Score.java
+++ b/src/main/java/mocacong/server/domain/Score.java
@@ -24,7 +24,7 @@ public class Score extends BaseTime {
     private int score;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,5 +48,9 @@ public class Score extends BaseTime {
     public void updateScore(int score) {
         validateScoreRange(score);
         this.score = score;
+    }
+
+    public void removeMember() {
+        this.member = null;
     }
 }

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidCommentUpdateException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidCommentUpdateException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class InvalidCommentUpdateException extends BadRequestException {
+
+    public InvalidCommentUpdateException() {
+        super("코멘트 수정은 작성자만 가능합니다.", 4004);
+    }
+}

--- a/src/main/java/mocacong/server/repository/CommentRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentRepository.java
@@ -1,7 +1,10 @@
 package mocacong.server.repository;
 
+import java.util.List;
 import mocacong.server.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/mocacong/server/repository/ReviewRepository.java
+++ b/src/main/java/mocacong/server/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package mocacong.server.repository;
 
+import java.util.List;
 import mocacong.server.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,5 +14,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "join r.member m " +
             "where c.id = :cafeId and m.id = :memberId")
     Optional<Long> findIdByCafeIdAndMemberId(Long cafeId, Long memberId);
-    Optional<Review> findByCafeIdAndMemberId(Long id, Long id1);
+
+    Optional<Review> findByCafeIdAndMemberId(Long cafeId, Long memberId);
+
+    List<Review> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/mocacong/server/repository/ScoreRepository.java
+++ b/src/main/java/mocacong/server/repository/ScoreRepository.java
@@ -1,10 +1,12 @@
 package mocacong.server.repository;
 
+import java.util.List;
+import java.util.Optional;
 import mocacong.server.domain.Score;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ScoreRepository extends JpaRepository<Score, Long> {
     Optional<Score> findByCafeIdAndMemberId(Long cafeId, Long memberId);
+
+    List<Score> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -17,6 +17,8 @@ import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
+import mocacong.server.service.event.MemberEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -152,6 +154,16 @@ public class CafeService {
 
         score.updateScore(request.getMyScore());
         review.updateReview(updatedCafeDetail);
+    }
+
+    @EventListener
+    public void updateReviewWhenMemberDelete(MemberEvent event) {
+        Long memberId = event.getMember()
+                .getId();
+        reviewRepository.findAllByMemberId(memberId)
+                .forEach(Review::removeMember);
+        scoreRepository.findAllByMemberId(memberId)
+                .forEach(Score::removeMember);
     }
 
     public CafeFilterResponse filterCafesByStudyType(String studyTypeValue, CafeFilterRequest requestBody) {

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -5,6 +5,7 @@ import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.exception.badrequest.InvalidCommentUpdateException;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
@@ -35,6 +36,7 @@ public class CommentService {
         return new CommentSaveResponse(commentRepository.save(comment).getId());
     }
 
+    @Transactional
     public void update(String email, String mapId, String content, Long commentId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
@@ -45,7 +47,10 @@ public class CommentService {
                 .findFirst()
                 .orElseThrow(NotFoundCommentException::new);
 
-        comment.updateComment(member, content);
+        if (!comment.isWrittenByMember(member)) {
+            throw new InvalidCommentUpdateException();
+        }
+        comment.updateComment(content);
     }
 
     @EventListener

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -11,6 +11,8 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
+import mocacong.server.service.event.MemberEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,5 +46,12 @@ public class CommentService {
                 .orElseThrow(NotFoundCommentException::new);
 
         comment.updateComment(member, content);
+    }
+
+    @EventListener
+    public void updateCommentWhenMemberDelete(MemberEvent event) {
+        Member member = event.getMember();
+        commentRepository.findAllByMemberId(member.getId())
+                .forEach(Comment::removeMember);
     }
 }

--- a/src/main/java/mocacong/server/service/event/MemberEvent.java
+++ b/src/main/java/mocacong/server/service/event/MemberEvent.java
@@ -1,0 +1,12 @@
+package mocacong.server.service.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import mocacong.server.domain.Member;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberEvent {
+
+    private final Member member;
+}

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -4,18 +4,18 @@ import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.exception.badrequest.InvalidCommentUpdateException;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @ServiceTest
 class CommentServiceTest {
@@ -111,5 +111,23 @@ class CommentServiceTest {
         commentService.update(email, mapId, expected, savedComment.getId());
 
         assertDoesNotThrow(() -> commentService.update(email, mapId, expected, savedComment.getId()));
+    }
+
+    @Test
+    @DisplayName("댓글 작성자가 아닌 사람이 특정 댓글 수정에 접근할 경우 예외를 반환한다")
+    void updateByNonWriter() {
+        String email1 = "kth990303@naver.com";
+        String email2 = "mery@naver.com";
+        String mapId = "2143154352323";
+        Member member1 = new Member(email1, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member1);
+        Member member2 = new Member(email2, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        CommentSaveResponse savedComment = commentService.save(email1, mapId, "조용하고 좋네요");
+
+        assertThatThrownBy(() -> commentService.update(email2, mapId, "몰래 이 코멘트를 바꿔", savedComment.getId()))
+                .isInstanceOf(InvalidCommentUpdateException.class);
     }
 }


### PR DESCRIPTION
## 개요
- 리뷰나 댓글을 작성한 경우, 외래키 제약 조건으로 인해 회원삭제가 불가능합니다.
- 해당 버그는 사용자가 불편함을 초래할 수 있을 정도로 위험하지만, 배포 전이기도 하고 사용자가 앱 이용 중에 크게 불편함을 느끼는 부분은 아니라 생각해서 긴급한 PR은 아니라고 생각듭니다.

## 작업사항
- `MemberService`에서 코멘트, 리뷰 엔티티의 제약조건을 해지하려면 `CommentRepository`, `ReviewRepository`, `ScoreRepository`의 의존성을 추가해야 합니다. 
<img width="444" alt="image" src="https://user-images.githubusercontent.com/57135043/234052843-d1501911-e266-4f94-b532-990579b9b7c0.png">
이는 지나치게 높은 의존성을 가지게 된다고 판단했습니다.

- 따라서 `ApplicationEventPublisher`을 이용한 이벤트 발행 방식으로 구현했습니다.
- 코멘트 수정 시에, 작성자가 아니면 NotFoundMemberException을 도메인에서 반환하던 로직을 수정했습니다.
  - 코멘트 객체는 자신의 필드 유효성 검증 외에는 예외반환 책임을 가지고 있지 않다고 판단하여 작성자가 아닌 경우 예외반환은 서비스로 책임을 이동시켰습니다. 
  -  작성자가 아닌 경우에는 멤버가 없는 NotFoundMemberException이 아닌, 요청이 잘못 들어온 예외라 판단 InvalidCommentUpdateException을 새로 생성하여 반환하도록 했습니다.

## 주의사항
- ApplicationEventPublisher에 대한 이해가 필요한 PR입니다.
- swagger로 리뷰, 코멘트 작성한 회원의 탈퇴가 올바르게 동작하는지, 탈퇴 후 리뷰나 코멘트 조회 시에 올바르게 동작하는지 확인해주세요.
- nullable 컬럼 설정이 변경되는 부분이 존재합니다. 머지 후 배포 시에 한번 확인해주세요.
