### PR TITLE
fix: 즐겨찾기 등록한 회원 탈퇴 가능하도록 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/Favorite.java
+++ b/src/main/java/mocacong/server/domain/Favorite.java
@@ -1,10 +1,9 @@
 package mocacong.server.domain;
 
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Entity
 @Table(name = "favorite")
@@ -18,15 +17,19 @@ public class Favorite extends BaseTime {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "cafe_id", nullable = false)
+    @JoinColumn(name = "cafe_id")
     private Cafe cafe;
 
     public Favorite(Member member, Cafe cafe) {
         this.member = member;
         this.cafe = cafe;
+    }
+
+    public void removeMember() {
+        this.member = null;
     }
 }

--- a/src/main/java/mocacong/server/repository/FavoriteRepository.java
+++ b/src/main/java/mocacong/server/repository/FavoriteRepository.java
@@ -1,10 +1,11 @@
 package mocacong.server.repository;
 
+import java.util.List;
+import java.util.Optional;
 import mocacong.server.domain.Favorite;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.Optional;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
@@ -14,4 +15,10 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
             "join f.member m " +
             "where c.id = :cafeId and m.id = :memberId")
     Optional<Long> findFavoriteIdByCafeIdAndMemberId(Long cafeId, Long memberId);
+
+    List<Favorite> findAllByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Favorite f where f.member.id IS null")
+    void deleteAllByMemberIdIsNull();
 }

--- a/src/main/java/mocacong/server/service/AsyncService.java
+++ b/src/main/java/mocacong/server/service/AsyncService.java
@@ -1,0 +1,24 @@
+package mocacong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import mocacong.server.repository.FavoriteRepository;
+import mocacong.server.service.event.MemberEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncService {
+
+    private final FavoriteRepository favoriteRepository;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener
+    public void deleteFavoritesWhenMemberDeleted(MemberEvent event) {
+        favoriteRepository.deleteAllByMemberIdIsNull();
+    }
+}

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -12,6 +12,8 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
+import mocacong.server.service.event.MemberEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,5 +54,12 @@ public class FavoriteService {
                 .orElseThrow(NotFoundFavoriteException::new);
 
         favoriteRepository.deleteById(favoriteId);
+    }
+
+    @EventListener
+    public void deleteAllWhenMemberDelete(MemberEvent event) {
+        Member member = event.getMember();
+        favoriteRepository.findAllByMemberId(member.getId())
+                .forEach(Favorite::removeMember);
     }
 }

--- a/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
+++ b/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
@@ -72,7 +72,7 @@ public class AcceptanceFixtures {
                 .statusCode(HttpStatus.OK.value())
                 .extract();
     }
-    
+
     public static ExtractableResponse<Response> 카페_코멘트_작성(String token, String mapId, CommentSaveRequest request) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -84,12 +84,22 @@ public class AcceptanceFixtures {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 카페_코멘트_수정 (String token, String mapId, Long commentId, CommentUpdateRequest request) {
+    public static ExtractableResponse<Response> 카페_코멘트_수정(String token, String mapId, Long commentId, CommentUpdateRequest request) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .body(request)
                 .when().put("/cafes/" + mapId + "/comments/" + commentId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 즐겨찾기_등록(String token, String mapId) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().post("/cafes/" + mapId + "/favorites/")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -104,6 +104,25 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("즐겨찾기를 등록한 회원이 정상적으로 탈퇴한다")
+    void deleteWhenSaveFavorites() {
+        String mapId = "1234";
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(memberSignUpRequest);
+        String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
+
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+        즐겨찾기_등록(token, mapId);
+
+        RestAssured.given().log().all()
+                .auth().oauth2(token)
+                .when().delete("/members")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    @Test
     @DisplayName("모든 회원을 전체 삭제한다")
     void deleteAll() {
         MemberSignUpRequest request1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");

--- a/src/test/java/mocacong/server/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/FavoriteRepositoryTest.java
@@ -1,5 +1,6 @@
 package mocacong.server.repository;
 
+import java.util.List;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
@@ -34,5 +35,18 @@ class FavoriteRepositoryTest {
                 () -> assertThat(actual).isNotNull(),
                 () -> assertThat(actual).isEqualTo(favorite.getId())
         );
+    }
+
+    @Test
+    @DisplayName("멤버 id가 null인 즐겨찾기들을 모두 삭제한다")
+    void deleteAllByMemberIdIsNull() {
+        Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
+        Favorite favorite = new Favorite(null, savedCafe);
+        favoriteRepository.save(favorite);
+
+        favoriteRepository.deleteAllByMemberIdIsNull();
+
+        List<Favorite> actual = favoriteRepository.findAll();
+        assertThat(actual).isEmpty();
     }
 }

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -1,5 +1,6 @@
 package mocacong.server.service;
 
+import java.util.List;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
@@ -9,16 +10,13 @@ import mocacong.server.exception.notfound.NotFoundFavoriteException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @ServiceTest
 class FavoriteServiceTest {


### PR DESCRIPTION
## 개요
- 즐겨찾기 등록 시에도 #44 와 마찬가지로 탈퇴가 불가능한 이슈가 존재합니다.

## 작업사항
- 즐겨찾기 외래키 역시 무시하도록 했습니다. 단, 즐겨찾기 삭제는 bulk delete 연산이 발생합니다. 따라서 연관관계만 끊어놓고 탈퇴시킨 후에, 삭제 로직은 나중에 수행되도록 비동기로 처리했습니다.

## 주의사항
- swagger로 동작 테스트 부탁드립니다.
- 클래스명, 메서드명이 적절하지 않다면 리뷰 부탁드립니다.
- 추가되길 원하는 테스트가 있다면 리뷰 부탁드립니다. 단, 비동기 로직이라 테스트가 쉽지가 않네요..
