### PR TITLE
feat: 카페 코멘트 목록 조회 api 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CommentController.java
+++ b/src/main/java/mocacong/server/controller/CommentController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.CommentSaveRequest;
 import mocacong.server.dto.request.CommentUpdateRequest;
 import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.dto.response.CommentsResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.CommentService;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,19 @@ public class CommentController {
             @RequestBody CommentSaveRequest request
     ) {
         CommentSaveResponse response = commentService.save(email, mapId, request.getContent());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "카페 코멘트 조회")
+    @SecurityRequirement(name = "JWT")
+    @GetMapping
+    public ResponseEntity<CommentsResponse> findComments(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @RequestParam("page") final Integer page,
+            @RequestParam("count") final int count
+    ) {
+        CommentsResponse response = commentService.findAll(email, mapId, page, count);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/mocacong/server/dto/response/CommentsResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentsResponse.java
@@ -1,0 +1,16 @@
+package mocacong.server.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CommentsResponse {
+
+    private int currentPage;
+    private List<CommentResponse> comments;
+}

--- a/src/main/java/mocacong/server/repository/CommentRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentRepository.java
@@ -2,9 +2,13 @@ package mocacong.server.repository;
 
 import java.util.List;
 import mocacong.server.domain.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByMemberId(Long memberId);
+
+    Slice<Comment> findAllByCafeId(Long cafeId, Pageable pageRequest);
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -26,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CafeService {
 
+    private static final int CAFE_SHOW_PAGE_COMMENTS_LIMIT_COUNTS = 3;
+
     private final CafeRepository cafeRepository;
     private final MemberRepository memberRepository;
     private final ScoreRepository scoreRepository;
@@ -68,7 +70,7 @@ public class CafeService {
                 cafeDetail.getSoundValue(),
                 cafeDetail.getDeskValue(),
                 cafe.getReviews().size(),
-                commentResponses.size(),
+                cafe.getComments().size(),
                 commentResponses
         );
     }
@@ -76,6 +78,7 @@ public class CafeService {
     private List<CommentResponse> findCommentResponses(Cafe cafe, Member member) {
         return cafe.getComments()
                 .stream()
+                .limit(CAFE_SHOW_PAGE_COMMENTS_LIMIT_COUNTS)
                 .map(comment -> {
                     if (comment.isWrittenByMember(member)) {
                         return new CommentResponse(member.getImgUrl(), member.getNickname(), comment.getContent(), true);

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -1,10 +1,14 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
 import mocacong.server.domain.Member;
+import mocacong.server.dto.response.CommentResponse;
 import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.dto.response.CommentsResponse;
 import mocacong.server.exception.badrequest.InvalidCommentUpdateException;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
@@ -14,6 +18,8 @@ import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.MemberEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +40,29 @@ public class CommentService {
         Comment comment = new Comment(cafe, member, content);
 
         return new CommentSaveResponse(commentRepository.save(comment).getId());
+    }
+
+    @Transactional(readOnly = true)
+    public CommentsResponse findAll(String email, String mapId, Integer page, int count) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Slice<Comment> comments = commentRepository.findAllByCafeId(cafe.getId(), PageRequest.of(page, count));
+        List<CommentResponse> responses = findCommentResponses(member, comments);
+        return new CommentsResponse(comments.getNumber(), responses);
+    }
+
+    private List<CommentResponse> findCommentResponses(Member member, Slice<Comment> comments) {
+        return comments.stream()
+                .map(comment -> {
+                    if (comment.isWrittenByMember(member)) {
+                        return new CommentResponse(member.getImgUrl(), member.getNickname(), comment.getContent(), true);
+                    } else {
+                        return new CommentResponse(comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
+                    }
+                })
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
@@ -53,6 +53,26 @@ public class CommentAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("카페 코멘트 목록을 조회한다")
+    void findComments() {
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        카페_코멘트_작성(token, mapId, new CommentSaveRequest("댓글"));
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().get("/cafes/" + mapId + "/comments?page=0&count=20")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    @Test
     @DisplayName("카페에 작성한 코멘트를 수정한다")
     void updateComment() {
         String content = "공부하기 좋아요~🥰";

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -154,6 +154,30 @@ class CafeServiceTest {
     }
 
     @Test
+    @DisplayName("카페를 조회할 때 댓글은 3개까지만 보여준다")
+    void findCafeAndShowLimitComments() {
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Comment comment1 = new Comment(cafe, member, "댓글1");
+        commentRepository.save(comment1);
+        Comment comment2 = new Comment(cafe, member, "댓글2");
+        commentRepository.save(comment2);
+        Comment comment3 = new Comment(cafe, member, "댓글3");
+        commentRepository.save(comment3);
+        Comment comment4 = new Comment(cafe, member, "댓글4");
+        commentRepository.save(comment4);
+
+        FindCafeResponse actual = cafeService.findCafeByMapId(member.getEmail(), cafe.getMapId());
+
+        assertAll(
+                () -> assertThat(actual.getCommentsCount()).isEqualTo(4),
+                () -> assertThat(actual.getComments()).hasSize(3)
+        );
+    }
+
+    @Test
     @DisplayName("탈퇴한 회원이 작성한 리뷰와 코멘트가 존재하는 카페를 조회한다")
     void findCafeWithReviewsAndCommentsByDeleteMember() {
         Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentSaveResponse;
+import mocacong.server.dto.response.CommentsResponse;
 import mocacong.server.exception.badrequest.InvalidCommentUpdateException;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
@@ -12,6 +13,7 @@ import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,6 +75,31 @@ class CommentServiceTest {
         commentService.save(email, mapId, "공부하기 좋아요~🥰");
 
         assertDoesNotThrow(() -> commentService.save(email, mapId, "공부하기 좋아요~🥰"));
+    }
+
+    @Test
+    @DisplayName("특정 카페에 달린 댓글 목록을 조회한다")
+    void findComments() {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        commentRepository.save(new Comment(cafe, member, "댓글1"));
+        commentRepository.save(new Comment(cafe, member, "댓글2"));
+        commentRepository.save(new Comment(cafe, member, "댓글3"));
+        commentRepository.save(new Comment(cafe, member, "댓글4"));
+
+        CommentsResponse actual = commentService.findAll(email, mapId, 0, 3);
+
+        assertAll(
+                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getComments()).hasSize(3),
+                () -> assertThat(actual.getComments())
+                        .extracting("content")
+                        .containsExactly("댓글1", "댓글2", "댓글3")
+        );
     }
 
     @Test


### PR DESCRIPTION
## 개요
- 카페 코멘트 목록 조회 api 구현

## 작업사항
- 카페 코멘트 목록 조회 api 구현
- 카페 조회 화면에서는 댓글은 최대 3개까지만 보이도록 구현했습니다.

## 주의사항
- swagger로 페이지네이션, 코멘트 목록 조회 동작이 잘 되는지 확인해주세요.
- 누락된 테스트코드가 있는지 확인해주세요.
