### PR TITLE
feat: 카페 이미지 등록 POST api 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -83,7 +83,7 @@ public class CafeController {
     @Operation(summary = "카페 이미지 업로드")
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = "/{mapId}/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> updateCafeImage(
+    public ResponseEntity<Void> updateCafeImage(
             @LoginUserEmail String email,
             @PathVariable String mapId,
             @RequestParam(value = "file", required = false) MultipartFile multipartFile

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -14,8 +14,10 @@ import mocacong.server.dto.response.CafeReviewUpdateResponse;
 import mocacong.server.dto.response.FindCafeResponse;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.CafeService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
@@ -76,5 +78,17 @@ public class CafeController {
                                                                   @RequestBody CafeFilterRequest requestBody) {
         CafeFilterResponse responseBody = cafeService.filterCafesByStudyType(studytype, requestBody);
         return ResponseEntity.ok(responseBody);
+    }
+
+    @Operation(summary = "카페 이미지 업로드")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping(value = "/{mapId}/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> updateCafeImage(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @RequestParam(value = "file", required = false) MultipartFile multipartFile
+    ) {
+        cafeService.saveCafeImage(email, mapId, multipartFile);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -86,7 +86,7 @@ public class CafeController {
     public ResponseEntity<Void> updateCafeImage(
             @LoginUserEmail String email,
             @PathVariable String mapId,
-            @RequestParam(value = "file", required = false) MultipartFile multipartFile
+            @RequestParam(value = "file") MultipartFile multipartFile
     ) {
         cafeService.saveCafeImage(email, mapId, multipartFile);
         return ResponseEntity.ok().build();

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -37,8 +37,8 @@ public class Cafe extends BaseTime {
     @Embedded
     private CafeDetail cafeDetail;
 
-    @Embedded
-    private CafeImage cafeImage;
+    @ElementCollection
+    private List<CafeImage> cafeImages;
 
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY)
     private List<Review> reviews;
@@ -50,7 +50,7 @@ public class Cafe extends BaseTime {
         this.mapId = mapId;
         this.name = name;
         this.cafeDetail = new CafeDetail();
-        this.cafeImage = new CafeImage();
+        this.cafeImages = new ArrayList<>();
         this.score = new ArrayList<>();
         this.reviews = new ArrayList<>();
         this.comments = new ArrayList<>();
@@ -108,10 +108,11 @@ public class Cafe extends BaseTime {
         this.reviews.add(review);
     }
 
-    public void updateCafeImgUrl(String imgUrl) {
-        if (this.cafeImage == null) {
-            this.cafeImage = new CafeImage();
+    public void addCafeImgUrl(Long memberId, String imgUrl) {
+        if (this.cafeImages == null) {
+            this.cafeImages = new ArrayList<>();
         }
-        this.cafeImage = new CafeImage(this.cafeImage.getMemberId(), imgUrl);
+        CafeImage cafeImage = new CafeImage(memberId, imgUrl);
+        this.cafeImages.add(cafeImage);
     }
 }

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -56,6 +56,16 @@ public class Cafe extends BaseTime {
         this.comments = new ArrayList<>();
     }
 
+    public Cafe(String mapId, String name) {
+        this.mapId = mapId;
+        this.name = name;
+        this.imgUrl = null;
+        this.cafeDetail = new CafeDetail();
+        this.score = new ArrayList<>();
+        this.reviews = new ArrayList<>();
+        this.comments = new ArrayList<>();
+    }
+
     public void updateCafeDetails() {
         StudyType studyType = getMostFrequentStudyType();
         Wifi wifi = (Wifi) getMostFrequentType(reviews.stream().map(Review::getWifi));

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -37,7 +37,7 @@ public class Cafe extends BaseTime {
     @Embedded
     private CafeDetail cafeDetail;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "cafe_image")
     private List<CafeImage> cafeImages;
 

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -38,6 +38,7 @@ public class Cafe extends BaseTime {
     private CafeDetail cafeDetail;
 
     @ElementCollection
+    @CollectionTable(name = "cafe_image")
     private List<CafeImage> cafeImages;
 
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY)
@@ -109,9 +110,6 @@ public class Cafe extends BaseTime {
     }
 
     public void saveCafeImgUrl(Long memberId, String imgUrl) {
-        if (this.cafeImages == null) {
-            this.cafeImages = new ArrayList<>();
-        }
         CafeImage cafeImage = new CafeImage(memberId, imgUrl);
         this.cafeImages.add(cafeImage);
     }

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -31,14 +31,14 @@ public class Cafe extends BaseTime {
     @Column(name = "map_id", nullable = false)
     private String mapId;
 
-    @Column(name = "img_url")
-    private String imgUrl;
-
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Score> score;
 
     @Embedded
     private CafeDetail cafeDetail;
+
+    @Embedded
+    private CafeImage cafeImage;
 
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY)
     private List<Review> reviews;
@@ -46,21 +46,11 @@ public class Cafe extends BaseTime {
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY)
     private List<Comment> comments;
 
-    public Cafe(String mapId, String name, String imgUrl) {
-        this.mapId = mapId;
-        this.name = name;
-        this.imgUrl = imgUrl;
-        this.cafeDetail = new CafeDetail();
-        this.score = new ArrayList<>();
-        this.reviews = new ArrayList<>();
-        this.comments = new ArrayList<>();
-    }
-
     public Cafe(String mapId, String name) {
         this.mapId = mapId;
         this.name = name;
-        this.imgUrl = null;
         this.cafeDetail = new CafeDetail();
+        this.cafeImage = new CafeImage();
         this.score = new ArrayList<>();
         this.reviews = new ArrayList<>();
         this.comments = new ArrayList<>();
@@ -116,5 +106,12 @@ public class Cafe extends BaseTime {
 
     public void addReview(Review review) {
         this.reviews.add(review);
+    }
+
+    public void updateCafeImgUrl(String imgUrl) {
+        if (this.cafeImage == null) {
+            this.cafeImage = new CafeImage();
+        }
+        this.cafeImage = new CafeImage(this.cafeImage.getMember(), imgUrl);
     }
 }

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -108,7 +108,7 @@ public class Cafe extends BaseTime {
         this.reviews.add(review);
     }
 
-    public void addCafeImgUrl(Long memberId, String imgUrl) {
+    public void saveCafeImgUrl(Long memberId, String imgUrl) {
         if (this.cafeImages == null) {
             this.cafeImages = new ArrayList<>();
         }

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -112,6 +112,6 @@ public class Cafe extends BaseTime {
         if (this.cafeImage == null) {
             this.cafeImage = new CafeImage();
         }
-        this.cafeImage = new CafeImage(this.cafeImage.getMember(), imgUrl);
+        this.cafeImage = new CafeImage(this.cafeImage.getMemberId(), imgUrl);
     }
 }

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -1,5 +1,11 @@
 package mocacong.server.domain;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mocacong.server.domain.cafedetail.*;
+
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -7,11 +13,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import mocacong.server.domain.cafedetail.*;
 
 @Entity
 @Table(name = "cafe")
@@ -30,6 +31,9 @@ public class Cafe extends BaseTime {
     @Column(name = "map_id", nullable = false)
     private String mapId;
 
+    @Column(name = "img_url")
+    private String imgUrl;
+
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Score> score;
 
@@ -42,9 +46,10 @@ public class Cafe extends BaseTime {
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY)
     private List<Comment> comments;
 
-    public Cafe(String mapId, String name) {
+    public Cafe(String mapId, String name, String imgUrl) {
         this.mapId = mapId;
         this.name = name;
+        this.imgUrl = imgUrl;
         this.cafeDetail = new CafeDetail();
         this.score = new ArrayList<>();
         this.reviews = new ArrayList<>();

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -1,0 +1,28 @@
+package mocacong.server.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Embeddable
+@NoArgsConstructor
+@Getter
+public class CafeImage {
+
+    @Column(name = "member")
+    @Enumerated(EnumType.STRING)
+    private Member member;
+
+    @Column(name = "img_url")
+    @Enumerated(EnumType.STRING)
+    private String imgUrl;
+
+    public CafeImage(Member member, String imgUrl) {
+        this.member = member;
+        this.imgUrl = imgUrl;
+    }
+}

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -5,24 +5,20 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 
 @Embeddable
 @NoArgsConstructor
 @Getter
 public class CafeImage {
 
-    @Column(name = "member")
-    @Enumerated(EnumType.STRING)
-    private Member member;
+    @Column(name = "member_id")
+    private Long memberId;
 
     @Column(name = "img_url")
-    @Enumerated(EnumType.STRING)
     private String imgUrl;
 
-    public CafeImage(Member member, String imgUrl) {
-        this.member = member;
+    public CafeImage(Long memberId, String imgUrl) {
+        this.memberId = memberId;
         this.imgUrl = imgUrl;
     }
 }

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -21,4 +21,8 @@ public class CafeImage {
         this.memberId = memberId;
         this.imgUrl = imgUrl;
     }
+
+    public Long getMemberId() {
+        return memberId;
+    }
 }

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -21,8 +21,4 @@ public class CafeImage {
         this.memberId = memberId;
         this.imgUrl = imgUrl;
     }
-
-    public Long getMemberId() {
-        return memberId;
-    }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -191,6 +191,6 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
 
         String imgUrl = cafeImg == null ? null : awsS3Uploader.uploadImage(cafeImg);
-        cafe.addCafeImgUrl(member.getId(), imgUrl);
+        cafe.saveCafeImgUrl(member.getId(), imgUrl);
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -191,7 +191,7 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
 
         String imgUrl = cafeImg == null ? null : awsS3Uploader.uploadImage(cafeImg);
-        CafeImage cafeImage = new CafeImage(member, imgUrl);
+        CafeImage cafeImage = new CafeImage(member.getId(), imgUrl);
         cafe.updateCafeImgUrl(cafeImage.getImgUrl());
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -18,9 +14,16 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.MemberEvent;
+import mocacong.server.support.AwsS3Uploader;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +35,7 @@ public class CafeService {
     private final ReviewRepository reviewRepository;
     private final FavoriteRepository favoriteRepository;
     private final EntityManager em;
+    private final AwsS3Uploader awsS3Uploader;
 
     public void save(CafeRegisterRequest request) {
         Cafe cafe = new Cafe(request.getId(), request.getName());
@@ -177,5 +181,17 @@ public class CafeService {
                 .collect(Collectors.toList());
 
         return new CafeFilterResponse(filteredIds);
+    }
+
+    @Transactional
+    public void saveCafeImage(String email, String mapId, MultipartFile cafeImg) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+
+        String imgUrl = cafeImg == null ? null : awsS3Uploader.uploadImage(cafeImg);
+        CafeImage cafeImage = new CafeImage(member, imgUrl);
+        cafe.updateCafeImgUrl(cafeImage.getImgUrl());
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -191,7 +191,6 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
 
         String imgUrl = cafeImg == null ? null : awsS3Uploader.uploadImage(cafeImg);
-        CafeImage cafeImage = new CafeImage(member.getId(), imgUrl);
-        cafe.updateCafeImgUrl(cafeImage.getImgUrl());
+        cafe.addCafeImgUrl(member.getId(), imgUrl);
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -190,7 +190,7 @@ public class CafeService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
 
-        String imgUrl = cafeImg == null ? null : awsS3Uploader.uploadImage(cafeImg);
+        String imgUrl = awsS3Uploader.uploadImage(cafeImg);
         cafe.saveCafeImgUrl(member.getId(), imgUrl);
     }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -14,7 +14,6 @@ import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.support.AwsS3Uploader;
-import mocacong.server.support.AwsSESSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,8 +53,6 @@ class CafeServiceTest {
 
     @MockBean
     private AwsS3Uploader awsS3Uploader;
-    @MockBean
-    private AwsSESSender awsSESSender;
 
     @Test
     @DisplayName("등록되지 않은 카페를 성공적으로 등록한다")
@@ -422,8 +419,8 @@ class CafeServiceTest {
 
         Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
         assertAll(
-                () -> assertThat(actual.getCafeImage()).hasSize(1),
-                () -> assertThat(actual.getCafeImage().get(0).getImgUrl()).isEqualTo(expected)
+                () -> assertThat(actual.getCafeImages()).hasSize(1),
+                () -> assertThat(actual.getCafeImages().get(0).getImgUrl()).isEqualTo(expected)
         );
     }
 
@@ -446,9 +443,9 @@ class CafeServiceTest {
         assertDoesNotThrow(() -> cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile));
         Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
         assertAll(
-                () -> assertThat(actual.getCafeImage()).hasSize(2),
-                () -> assertThat(actual.getCafeImage().get(0).getImgUrl()).isEqualTo(expected),
-                () -> assertThat(actual.getCafeImage().get(1).getImgUrl()).isEqualTo(expected)
+                () -> assertThat(actual.getCafeImages()).hasSize(2),
+                () -> assertThat(actual.getCafeImages().get(0).getImgUrl()).isEqualTo(expected),
+                () -> assertThat(actual.getCafeImages().get(1).getImgUrl()).isEqualTo(expected)
         );
     }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -404,6 +405,7 @@ class CafeServiceTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("카페 이미지를 성공적으로 저장한다")
     void saveCafeImage() throws IOException {
         String expected = "test_img.jpg";
@@ -419,10 +421,14 @@ class CafeServiceTest {
         cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
 
         Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
-        assertThat(actual.getCafeImage().getImgUrl()).isEqualTo(expected);
+        assertAll(
+                () -> assertThat(actual.getCafeImage()).hasSize(1),
+                () -> assertThat(actual.getCafeImage().get(0).getImgUrl()).isEqualTo(expected)
+        );
     }
 
     @Test
+    @Transactional
     @DisplayName("사용자가 카페 이미지를 여러번 저장한다")
     void saveCafeImages() throws IOException {
         String expected = "test_img.jpg";
@@ -438,5 +444,11 @@ class CafeServiceTest {
         cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
 
         assertDoesNotThrow(() -> cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile));
+        Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
+        assertAll(
+                () -> assertThat(actual.getCafeImage()).hasSize(2),
+                () -> assertThat(actual.getCafeImage().get(0).getImgUrl()).isEqualTo(expected),
+                () -> assertThat(actual.getCafeImage().get(1).getImgUrl()).isEqualTo(expected)
+        );
     }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
 @ServiceTest
@@ -419,5 +420,23 @@ class CafeServiceTest {
 
         Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
         assertThat(actual.getCafeImage().getImgUrl()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("사용자가 카페 이미지를 여러번 저장한다")
+    void saveCafeImages() throws IOException {
+        String expected = "test_img.jpg";
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        memberRepository.save(member);
+        String mapId = cafe.getMapId();
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg", fileInputStream);
+
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
+
+        assertDoesNotThrow(() -> cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile));
     }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -28,6 +27,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
 @ServiceTest
@@ -401,7 +401,6 @@ class CafeServiceTest {
     }
 
     @Test
-    @Transactional
     @DisplayName("카페 이미지를 성공적으로 저장한다")
     void saveCafeImage() throws IOException {
         String expected = "test_img.jpg";
@@ -424,7 +423,6 @@ class CafeServiceTest {
     }
 
     @Test
-    @Transactional
     @DisplayName("사용자가 카페 이미지를 여러번 저장한다")
     void saveCafeImages() throws IOException {
         String expected = "test_img.jpg";
@@ -438,10 +436,10 @@ class CafeServiceTest {
 
         when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
         cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
-        cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
 
         Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
         assertAll(
+                () -> assertDoesNotThrow(() -> cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile)),
                 () -> assertThat(actual.getCafeImages()).hasSize(2),
                 () -> assertThat(actual.getCafeImages().get(0).getImgUrl()).isEqualTo(expected),
                 () -> assertThat(actual.getCafeImages().get(1).getImgUrl()).isEqualTo(expected)

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
 @ServiceTest
@@ -439,8 +438,8 @@ class CafeServiceTest {
 
         when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
         cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
+        cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
 
-        assertDoesNotThrow(() -> cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile));
         Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
         assertAll(
                 () -> assertThat(actual.getCafeImages()).hasSize(2),

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,6 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.CafeFilterRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
@@ -11,14 +10,25 @@ import mocacong.server.dto.response.CafeReviewResponse;
 import mocacong.server.dto.response.CafeReviewUpdateResponse;
 import mocacong.server.dto.response.FindCafeResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
+import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import mocacong.server.support.AwsS3Uploader;
+import mocacong.server.support.AwsSESSender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
 class CafeServiceTest {
@@ -39,6 +49,11 @@ class CafeServiceTest {
     private FavoriteRepository favoriteRepository;
     @Autowired
     private MemberService memberService;
+
+    @MockBean
+    private AwsS3Uploader awsS3Uploader;
+    @MockBean
+    private AwsSESSender awsSESSender;
 
     @Test
     @DisplayName("등록되지 않은 카페를 성공적으로 등록한다")
@@ -385,5 +400,24 @@ class CafeServiceTest {
         CafeFilterResponse filteredCafes = cafeService.filterCafesByStudyType("group", requestBody);
 
         assertThat(filteredCafes.getMapIds()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("카페 이미지를 성공적으로 저장한다")
+    void saveCafeImage() throws IOException {
+        String expected = "test_img.jpg";
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        memberRepository.save(member);
+        String mapId = cafe.getMapId();
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg", fileInputStream);
+
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
+
+        Cafe actual = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
+        assertThat(actual.getCafeImage().getImgUrl()).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
## 개요
- 카페 이미지 POST api 구현

## 작업사항
- S3와 연동하여 카페 이미지 등록 POST api를 구현했습니다.
- 카페 이미지 등록 테스트 코드를 작성했습니다.

## 주의사항
- 인수테스트를 한다면 테스트 환경에 S3 설정을 넣어줘야 하고 이미 스웨거와 서비스 테스트에서 동작이 잘 확인되기 때문에 이번 구현에서는 인수 테스트를 생략했습니다.
- 누락된 테스트 코드가 있는지 확인해주세요.
- 스웨거로 실제 동작 테스트 확인해주세요.
- 잘못된 로직이 있는지 확인해주세요.
