### PR TITLE
fix: BaseTime 컬럼 타입 TimeStamp로 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/BaseTime.java
+++ b/src/main/java/mocacong/server/domain/BaseTime.java
@@ -1,6 +1,6 @@
 package mocacong.server.domain;
 
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -16,9 +16,9 @@ public class BaseTime {
 
     @CreatedDate
     @Column(name = "created_time", updatable = false)
-    private LocalDateTime createdTime;
+    private Timestamp createdTime;
 
     @LastModifiedDate
     @Column(name = "modified_time")
-    private LocalDateTime modifiedTime;
+    private Timestamp modifiedTime;
 }

--- a/src/test/java/mocacong/server/domain/BaseTimeTest.java
+++ b/src/test/java/mocacong/server/domain/BaseTimeTest.java
@@ -1,6 +1,6 @@
 package mocacong.server.domain;
 
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 import mocacong.server.domain.cafedetail.*;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.repository.CafeRepository;
@@ -47,8 +47,8 @@ class BaseTimeTest {
         entityManager.flush();
 
         Cafe findCafe = cafeRepository.findByMapId("2143154352323").orElseThrow(NotFoundCafeException::new);
-        LocalDateTime createdTime = findCafe.getCreatedTime();
-        LocalDateTime modifiedTime = findCafe.getModifiedTime();
+        Timestamp createdTime = findCafe.getCreatedTime();
+        Timestamp modifiedTime = findCafe.getModifiedTime();
 
         assertAll(
                 () -> assertThat(modifiedTime).isNotNull(),


### PR DESCRIPTION
## 개요
- 스프링 서버, DB time_zone 설정이 `asia/seoul`임에도 불구하고 UTC 시간으로 datagrip에서 조회됩니다.

## 작업사항
- JPA는 LocalDateTime 을 mysql 기준 datetime 컬럼과 매핑시킵니다. datetime 컬럼은 time_zone 영향을 받지 않습니다. `time_zone='asia/seoul'` 영향을  받는 timestamp 컬럼으로 변경시켰습니다.

## 주의사항
- 머지 후에 변경 여파가 어느정도일지 확인해주세요. 
  - datetime에서 timestamp로 타입이 변경됐으니 `ddl-auto: update` 에서 컬럼이 더 생길지? 아니면 컬럼 변경 문제 없을지?
- timestamp 변경이 또 필요한 곳이 있으면 리뷰해주세요