### PR TITLE
feat: kakao OAuth 로그인 api 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/AuthController.java
+++ b/src/main/java/mocacong/server/controller/AuthController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
+import mocacong.server.dto.request.KakaoLoginRequest;
 import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.service.AuthService;
@@ -34,6 +35,13 @@ public class AuthController {
     @PostMapping("/apple")
     public ResponseEntity<OAuthTokenResponse> loginApple(@RequestBody @Valid AppleLoginRequest request) {
         OAuthTokenResponse response = authService.appleOAuthLogin(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "카카오 OAuth 로그인")
+    @PostMapping("/kakao")
+    public ResponseEntity<OAuthTokenResponse> loginKakao(@RequestBody @Valid KakaoLoginRequest request) {
+        OAuthTokenResponse response = authService.kakaoOAuthLogin(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/mocacong/server/controller/AuthController.java
+++ b/src/main/java/mocacong/server/controller/AuthController.java
@@ -6,7 +6,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
-import mocacong.server.dto.response.AppleTokenResponse;
+import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.service.AuthService;
 import org.springframework.http.ResponseEntity;
@@ -32,8 +32,8 @@ public class AuthController {
 
     @Operation(summary = "애플 OAuth 로그인")
     @PostMapping("/apple")
-    public ResponseEntity<AppleTokenResponse> loginApple(@RequestBody @Valid AppleLoginRequest request) {
-        AppleTokenResponse response = authService.appleOAuthLogin(request);
+    public ResponseEntity<OAuthTokenResponse> loginApple(@RequestBody @Valid AppleLoginRequest request) {
+        OAuthTokenResponse response = authService.appleOAuthLogin(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/mocacong/server/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/mocacong/server/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,16 @@
+package mocacong.server.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class KakaoLoginRequest {
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String code;
+}

--- a/src/main/java/mocacong/server/dto/response/OAuthTokenResponse.java
+++ b/src/main/java/mocacong/server/dto/response/OAuthTokenResponse.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class AppleTokenResponse {
+public class OAuthTokenResponse {
 
     private String token;
     private String email;

--- a/src/main/java/mocacong/server/security/auth/OAuthPlatformMemberResponse.java
+++ b/src/main/java/mocacong/server/security/auth/OAuthPlatformMemberResponse.java
@@ -1,4 +1,4 @@
-package mocacong.server.security.auth.apple;
+package mocacong.server.security.auth;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class ApplePlatformMemberResponse {
+public class OAuthPlatformMemberResponse {
 
     private String platformId;
     private String email;

--- a/src/main/java/mocacong/server/security/auth/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleOAuthUserProvider.java
@@ -5,6 +5,7 @@ import java.security.PublicKey;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.exception.unauthorized.InvalidTokenException;
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,7 +17,7 @@ public class AppleOAuthUserProvider {
     private final PublicKeyGenerator publicKeyGenerator;
     private final AppleClaimsValidator appleClaimsValidator;
 
-    public ApplePlatformMemberResponse getApplePlatformMember(String identityToken) {
+    public OAuthPlatformMemberResponse getApplePlatformMember(String identityToken) {
         Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
         ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
 
@@ -24,7 +25,7 @@ public class AppleOAuthUserProvider {
 
         Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
         validateClaims(claims);
-        return new ApplePlatformMemberResponse(claims.getSubject(), claims.get("email", String.class));
+        return new OAuthPlatformMemberResponse(claims.getSubject(), claims.get("email", String.class));
     }
 
     private void validateClaims(Claims claims) {

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoAccessToken.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoAccessToken.java
@@ -1,0 +1,22 @@
+package mocacong.server.security.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class KakaoAccessToken {
+
+    private static final String AUTHORIZATION_BEARER = "Bearer ";
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    public String getAuthorization() {
+        return AUTHORIZATION_BEARER + accessToken;
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoAccessTokenClient.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoAccessTokenClient.java
@@ -1,0 +1,12 @@
+package mocacong.server.security.auth.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "kakao-access-token-client", url = "https://kauth.kakao.com/oauth/token")
+public interface KakaoAccessTokenClient {
+
+    @PostMapping(consumes = "application/x-www-form-urlencoded")
+    KakaoAccessToken getToken(@SpringQueryMap KakaoAccessTokenRequest request);
+}

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoAccessTokenRequest.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoAccessTokenRequest.java
@@ -1,0 +1,30 @@
+package mocacong.server.security.auth.kakao;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+public class KakaoAccessTokenRequest {
+
+    private static final String KAKAO_GRANT_TYPE = "authorization_code";
+
+    private String code;
+    private String client_id;
+    private String client_secret;
+    private String redirect_uri;
+    private String grant_type;
+
+    public KakaoAccessTokenRequest(
+            String authorizationCode, String kakaoClientId, String kakaoClientSecret, String redirectUri
+    ) {
+        this.code = authorizationCode;
+        this.client_id = kakaoClientId;
+        this.client_secret = kakaoClientSecret;
+        this.redirect_uri = redirectUri;
+        this.grant_type = KAKAO_GRANT_TYPE;
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProvider.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProvider.java
@@ -11,20 +11,23 @@ public class KakaoOAuthUserProvider {
     private final KakaoUserClient kakaoUserClient;
     private final String kakaoClientId;
     private final String kakaoClientSecret;
+    private final String redirectUri;
 
     public KakaoOAuthUserProvider(
             KakaoAccessTokenClient kakaoAccessTokenClient,
             KakaoUserClient kakaoUserClient,
             @Value("${oauth.kakao.client-id}") String kakaoClientId,
-            @Value("${oauth.kakao.client-secret}") String kakaoClientSecret
+            @Value("${oauth.kakao.client-secret}") String kakaoClientSecret,
+            @Value("${oauth.kakao.redirect-uri}") String redirectUri
     ) {
         this.kakaoAccessTokenClient = kakaoAccessTokenClient;
         this.kakaoUserClient = kakaoUserClient;
         this.kakaoClientId = kakaoClientId;
         this.kakaoClientSecret = kakaoClientSecret;
+        this.redirectUri = redirectUri;
     }
 
-    public OAuthPlatformMemberResponse getKakaoPlatformMember(String authorizationCode, String redirectUri) {
+    public OAuthPlatformMemberResponse getKakaoPlatformMember(String authorizationCode) {
         KakaoAccessTokenRequest kakaoAccessTokenRequest =
                 new KakaoAccessTokenRequest(authorizationCode, kakaoClientId, kakaoClientSecret, redirectUri);
         KakaoAccessToken token = kakaoAccessTokenClient.getToken(kakaoAccessTokenRequest);

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProvider.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProvider.java
@@ -1,0 +1,36 @@
+package mocacong.server.security.auth.kakao;
+
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoOAuthUserProvider {
+
+    private final KakaoAccessTokenClient kakaoAccessTokenClient;
+    private final KakaoUserClient kakaoUserClient;
+    private final String kakaoClientId;
+    private final String kakaoClientSecret;
+
+    public KakaoOAuthUserProvider(
+            KakaoAccessTokenClient kakaoAccessTokenClient,
+            KakaoUserClient kakaoUserClient,
+            @Value("${oauth.kakao.client-id}") String kakaoClientId,
+            @Value("${oauth.kakao.client-secret}") String kakaoClientSecret
+    ) {
+        this.kakaoAccessTokenClient = kakaoAccessTokenClient;
+        this.kakaoUserClient = kakaoUserClient;
+        this.kakaoClientId = kakaoClientId;
+        this.kakaoClientSecret = kakaoClientSecret;
+    }
+
+    public OAuthPlatformMemberResponse getKakaoPlatformMember(String authorizationCode, String redirectUri) {
+        KakaoAccessTokenRequest kakaoAccessTokenRequest =
+                new KakaoAccessTokenRequest(authorizationCode, kakaoClientId, kakaoClientSecret, redirectUri);
+        KakaoAccessToken token = kakaoAccessTokenClient.getToken(kakaoAccessTokenRequest);
+
+        KakaoUserRequest kakaoUserRequest = new KakaoUserRequest("[\"kakao_account.email\"]");
+        KakaoUser user = kakaoUserClient.getUser(kakaoUserRequest, token.getAuthorization());
+        return new OAuthPlatformMemberResponse(String.valueOf(user.getId()), user.getEmail());
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoUser.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoUser.java
@@ -1,0 +1,33 @@
+package mocacong.server.security.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class KakaoUser {
+
+    private Long id;
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    public static KakaoUser of(Long id, String email) {
+        return new KakaoUser(id, new KakaoAccount(email));
+    }
+
+    public String getEmail() {
+        return kakaoAccount.getEmail();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    private static class KakaoAccount {
+
+        private String email;
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoUserClient.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoUserClient.java
@@ -1,0 +1,14 @@
+package mocacong.server.security.auth.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-user-client", url = "https://kapi.kakao.com/v2/user/me")
+public interface KakaoUserClient {
+
+    @GetMapping
+    KakaoUser getUser(@SpringQueryMap KakaoUserRequest request,
+                      @RequestHeader(name = "Authorization") String authorization);
+}

--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoUserRequest.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoUserRequest.java
@@ -1,0 +1,17 @@
+package mocacong.server.security.auth.kakao;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserRequest {
+
+    private String secure_resource;
+    private String property_keys;
+
+    public KakaoUserRequest(String propertyKeys) {
+        this.secure_resource = "true";
+        this.property_keys = propertyKeys;
+    }
+}

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -5,14 +5,14 @@ import mocacong.server.domain.Member;
 import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
-import mocacong.server.dto.response.AppleTokenResponse;
+import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.security.auth.JwtTokenProvider;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
-import mocacong.server.security.auth.apple.ApplePlatformMemberResponse;
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -35,8 +35,8 @@ public class AuthService {
         return TokenResponse.from(token);
     }
 
-    public AppleTokenResponse appleOAuthLogin(AppleLoginRequest request) {
-        ApplePlatformMemberResponse applePlatformMember =
+    public OAuthTokenResponse appleOAuthLogin(AppleLoginRequest request) {
+        OAuthPlatformMemberResponse applePlatformMember =
                 appleOAuthUserProvider.getApplePlatformMember(request.getToken());
         String platformId = applePlatformMember.getPlatformId();
 
@@ -48,16 +48,16 @@ public class AuthService {
 
                     // OAuth 로그인은 성공했지만 회원가입에 실패한 경우
                     if (!findMember.isRegisteredOAuthMember()) {
-                        return new AppleTokenResponse(token, findMember.getEmail(), false, platformId);
+                        return new OAuthTokenResponse(token, findMember.getEmail(), false, platformId);
                     }
 
-                    return new AppleTokenResponse(token, findMember.getEmail(), true, platformId);
+                    return new OAuthTokenResponse(token, findMember.getEmail(), true, platformId);
                 })
                 .orElseGet(() -> {
                     Member oauthMember = new Member(applePlatformMember.getEmail(), Platform.APPLE, platformId);
                     Member savedMember = memberRepository.save(oauthMember);
                     String token = issueToken(savedMember);
-                    return new AppleTokenResponse(token, applePlatformMember.getEmail(), false, platformId);
+                    return new OAuthTokenResponse(token, applePlatformMember.getEmail(), false, platformId);
                 });
     }
 

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -14,6 +14,7 @@ import mocacong.server.repository.MemberRepository;
 import mocacong.server.security.auth.JwtTokenProvider;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
+import mocacong.server.security.auth.kakao.KakaoOAuthUserProvider;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +26,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final AppleOAuthUserProvider appleOAuthUserProvider;
+    private final KakaoOAuthUserProvider kakaoOAuthUserProvider;
 
     public TokenResponse login(AuthLoginRequest request) {
         Member findMember = memberRepository.findByEmail(request.getEmail())
@@ -43,7 +45,7 @@ public class AuthService {
 
     public OAuthTokenResponse kakaoOAuthLogin(KakaoLoginRequest request) {
         OAuthPlatformMemberResponse applePlatformMember =
-                appleOAuthUserProvider.getApplePlatformMember(request.getCode());
+                kakaoOAuthUserProvider.getKakaoPlatformMember(request.getCode());
         return generateOAuthTokenResponse(applePlatformMember.getEmail(), applePlatformMember.getPlatformId());
     }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -65,6 +65,9 @@ oauth:
     iss: https://appleid.apple.com
     client-id: ${OAUTH_APPLE_CLIENT_ID}
     nonce: ${OAUTH_APPLE_NONCE}
+  kakao:
+    client-id: ${OAUTH_KAKAO_CLIENT_ID}
+    client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
 
 feign:
   client:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -68,6 +68,7 @@ oauth:
   kakao:
     client-id: ${OAUTH_KAKAO_CLIENT_ID}
     client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
+    redirect-uri: ${OAUTH_KAKAO_REDIRECT_URI}
 
 feign:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,9 @@ oauth:
     iss: https://appleid.apple.com
     client-id: ${OAUTH_APPLE_CLIENT_ID}
     nonce: ${OAUTH_APPLE_NONCE}
+  kakao:
+    client-id: ${OAUTH_KAKAO_CLIENT_ID}
+    client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
 
 feign:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,7 @@ oauth:
   kakao:
     client-id: ${OAUTH_KAKAO_CLIENT_ID}
     client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
+    redirect-uri: ${OAUTH_KAKAO_REDIRECT_URI}
 
 feign:
   client:

--- a/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
@@ -3,16 +3,19 @@ package mocacong.server.acceptance;
 import io.restassured.RestAssured;
 import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
+import mocacong.server.dto.request.KakaoLoginRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
+import mocacong.server.security.auth.kakao.KakaoOAuthUserProvider;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,6 +27,8 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
     @MockBean
     private AppleOAuthUserProvider appleOAuthUserProvider;
+    @MockBean
+    private KakaoOAuthUserProvider kakaoOAuthUserProvider;
 
     @Test
     @DisplayName("회원이 정상적으로 로그인한다")
@@ -62,6 +67,26 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when().post("/login/apple")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(OAuthTokenResponse.class);
+
+        assertThat(actual.getEmail()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("회원이 Kakao OAuth 로그인을 정상적으로 진행한다")
+    void loginKakaoOAuth() {
+        String expected = "kth@kakao.com";
+        OAuthPlatformMemberResponse oauthResponse = new OAuthPlatformMemberResponse("1234321", expected);
+        when(kakaoOAuthUserProvider.getKakaoPlatformMember(anyString())).thenReturn(oauthResponse);
+        KakaoLoginRequest request = new KakaoLoginRequest("token");
+
+        OAuthTokenResponse actual = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/login/kakao")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()

--- a/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
@@ -4,10 +4,10 @@ import io.restassured.RestAssured;
 import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
-import mocacong.server.dto.response.AppleTokenResponse;
+import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
-import mocacong.server.security.auth.apple.ApplePlatformMemberResponse;
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.DisplayName;
@@ -54,18 +54,18 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("회원이 Apple OAuth 로그인을 정상적으로 진행한다")
     void loginAppleOAuth() {
         String expected = "kth@apple.com";
-        ApplePlatformMemberResponse oauthResponse = new ApplePlatformMemberResponse("1234321", expected);
+        OAuthPlatformMemberResponse oauthResponse = new OAuthPlatformMemberResponse("1234321", expected);
         when(appleOAuthUserProvider.getApplePlatformMember(any())).thenReturn(oauthResponse);
         AppleLoginRequest request = new AppleLoginRequest("token");
 
-        AppleTokenResponse actual = RestAssured.given().log().all()
+        OAuthTokenResponse actual = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)
                 .when().post("/login/apple")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .as(AppleTokenResponse.class);
+                .as(OAuthTokenResponse.class);
 
         assertThat(actual.getEmail()).isEqualTo(expected);
     }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -7,7 +7,7 @@ import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.ErrorResponse;
 import mocacong.server.dto.response.MyPageResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
-import mocacong.server.security.auth.apple.ApplePlatformMemberResponse;
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.support.AwsSESSender;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -48,7 +48,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     void signUpOauthMember() {
         String platformId = "1234321";
         String email = "kth@apple.com";
-        ApplePlatformMemberResponse oauthResponse = new ApplePlatformMemberResponse(platformId, email);
+        OAuthPlatformMemberResponse oauthResponse = new OAuthPlatformMemberResponse(platformId, email);
         when(appleOAuthUserProvider.getApplePlatformMember(any())).thenReturn(oauthResponse);
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/apple/AppleOAuthUserProviderTest.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.security.*;
 import java.util.Date;
 import mocacong.server.exception.unauthorized.InvalidTokenException;
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -53,7 +54,7 @@ class AppleOAuthUserProviderTest {
         when(publicKeyGenerator.generatePublicKey(any(), any())).thenReturn(publicKey);
         when(appleClaimsValidator.isValid(any())).thenReturn(true);
 
-        ApplePlatformMemberResponse actual = appleOAuthUserProvider.getApplePlatformMember(identityToken);
+        OAuthPlatformMemberResponse actual = appleOAuthUserProvider.getApplePlatformMember(identityToken);
 
         assertAll(
                 () -> assertThat(actual.getPlatformId()).isEqualTo(expected),

--- a/src/test/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProviderTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 class KakaoOAuthUserProviderTest {
 
     private static final String AUTHORIZATION_CODE = "test";
-    private static final String REDIRECT_URI = "test";
 
     @Autowired
     private KakaoOAuthUserProvider kakaoOAuthUserProvider;
@@ -36,7 +35,7 @@ class KakaoOAuthUserProviderTest {
         when(kakaoUserClient.getUser(any(), anyString())).thenReturn(mockKakaoUser);
 
         OAuthPlatformMemberResponse actual =
-                kakaoOAuthUserProvider.getKakaoPlatformMember(AUTHORIZATION_CODE, REDIRECT_URI);
+                kakaoOAuthUserProvider.getKakaoPlatformMember(AUTHORIZATION_CODE);
 
         assertAll(
                 () -> assertThat(actual.getEmail()).isEqualTo(email),

--- a/src/test/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProviderTest.java
@@ -1,0 +1,46 @@
+package mocacong.server.security.auth.kakao;
+
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+class KakaoOAuthUserProviderTest {
+
+    private static final String AUTHORIZATION_CODE = "test";
+    private static final String REDIRECT_URI = "test";
+
+    @Autowired
+    private KakaoOAuthUserProvider kakaoOAuthUserProvider;
+    @MockBean
+    private KakaoAccessTokenClient kakaoAccessTokenClient;
+    @MockBean
+    private KakaoUserClient kakaoUserClient;
+
+    @Test
+    @DisplayName("Kakao OAuth 서버와 통신하여 사용자 정보를 발급받는다")
+    void getKakaoPlatformMember() {
+        String email = "kth990303@naver.com";
+        String platformId = "1";
+        KakaoAccessToken mockAccessToken = new KakaoAccessToken("accessToken");
+        when(kakaoAccessTokenClient.getToken(any())).thenReturn(mockAccessToken);
+        KakaoUser mockKakaoUser = KakaoUser.of(1L, email);
+        when(kakaoUserClient.getUser(any(), anyString())).thenReturn(mockKakaoUser);
+
+        OAuthPlatformMemberResponse actual =
+                kakaoOAuthUserProvider.getKakaoPlatformMember(AUTHORIZATION_CODE, REDIRECT_URI);
+
+        assertAll(
+                () -> assertThat(actual.getEmail()).isEqualTo(email),
+                () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
+        );
+    }
+}

--- a/src/test/java/mocacong/server/service/AuthServiceTest.java
+++ b/src/test/java/mocacong/server/service/AuthServiceTest.java
@@ -64,8 +64,8 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("Apple OAuth 로그인 시 가입되지 않은 회원일 경우 이메일 값을 보내고 isRegistered 값을 false로 보낸다")
-    void appleOAuthNotRegistered() {
+    @DisplayName("OAuth 로그인 시 가입되지 않은 회원일 경우 이메일 값을 보내고 isRegistered 값을 false로 보낸다")
+    void loginOAuthNotRegistered() {
         String expected = "kth@apple.com";
         String platformId = "1234321";
         when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
@@ -82,8 +82,8 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("Apple OAuth 로그인 시 이미 가입된 회원일 경우 토큰과 이메일, 그리고 isRegistered 값을 true로 보낸다")
-    void appleOAuthRegisteredAndMocacongMember() {
+    @DisplayName("OAuth 로그인 시 이미 가입된 회원일 경우 토큰과 이메일, 그리고 isRegistered 값을 true로 보낸다")
+    void loginOAuthRegisteredAndMocacongMember() {
         String expected = "kth@apple.com";
         String platformId = "1234321";
         Member member = new Member(
@@ -110,8 +110,8 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("Apple OAuth 로그인 시 등록은 완료됐지만 회원가입 절차에 실패해 닉네임이 없으면 isRegistered 값을 false로 보낸다")
-    void appleOAuthRegisteredButNotMocacongMember() {
+    @DisplayName("OAuth 로그인 시 등록은 완료됐지만 회원가입 절차에 실패해 닉네임이 없으면 isRegistered 값을 false로 보낸다")
+    void loginOAuthRegisteredButNotMocacongMember() {
         String expected = "kth@apple.com";
         String platformId = "1234321";
         Member member = new Member("kth@apple.com", Platform.APPLE, "1234321");

--- a/src/test/java/mocacong/server/service/AuthServiceTest.java
+++ b/src/test/java/mocacong/server/service/AuthServiceTest.java
@@ -4,12 +4,12 @@ import mocacong.server.domain.Member;
 import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.AppleLoginRequest;
 import mocacong.server.dto.request.AuthLoginRequest;
-import mocacong.server.dto.response.AppleTokenResponse;
+import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
-import mocacong.server.security.auth.apple.ApplePlatformMemberResponse;
+import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
@@ -69,9 +69,9 @@ class AuthServiceTest {
         String expected = "kth@apple.com";
         String platformId = "1234321";
         when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
-                .thenReturn(new ApplePlatformMemberResponse(platformId, expected));
+                .thenReturn(new OAuthPlatformMemberResponse(platformId, expected));
 
-        AppleTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
+        OAuthTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
 
         assertAll(
                 () -> assertThat(actual.getToken()).isNotNull(),
@@ -97,9 +97,9 @@ class AuthServiceTest {
         );
         memberRepository.save(member);
         when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
-                .thenReturn(new ApplePlatformMemberResponse(platformId, expected));
+                .thenReturn(new OAuthPlatformMemberResponse(platformId, expected));
 
-        AppleTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
+        OAuthTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
 
         assertAll(
                 () -> assertThat(actual.getToken()).isNotNull(),
@@ -117,9 +117,9 @@ class AuthServiceTest {
         Member member = new Member("kth@apple.com", Platform.APPLE, "1234321");
         memberRepository.save(member);
         when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
-                .thenReturn(new ApplePlatformMemberResponse(platformId, expected));
+                .thenReturn(new OAuthPlatformMemberResponse(platformId, expected));
 
-        AppleTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
+        OAuthTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
 
         assertAll(
                 () -> assertThat(actual.getToken()).isNotNull(),

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -52,3 +52,4 @@ oauth:
   kakao:
     client-id: test
     client-secret: test
+    redirect-uri: test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -49,3 +49,6 @@ oauth:
     iss: https://appleid.apple.com
     client-id: test
     nonce: nonce
+  kakao:
+    client-id: test
+    client-secret: test


### PR DESCRIPTION
## 개요
- 카카오 oauth 로그인 api 구현

## 작업사항
- feign client를 이용하여 카카오 oauth 로그인 api를 구현했습니다.
  - apple feign 때와 달리 authorization code 등의 실제 환경변수 값을 요청으로 feign 통신하는 과정이 포함돼있어 feignClient 테스트 코드를 직접적으로 만들지 않았습니다.

![image](https://user-images.githubusercontent.com/57135043/235304217-35616935-5340-40ae-b2d9-73c0325b545e.png)
- Service Server (백엔드)에서 하도록 안내돼있는 Step2, Step3 기능을 구현했습니다. 

## 주의사항
-  카카오 서버와의 feign 통신이 잘 이루어지는지 확인해주세요. `@SpringQueryMap`을 도입해봤는데 올바르게 작동할지 모르겠네요.
  - 이 테스트가 진행되려면 프론트 측에서 인가 코드 받는 기능이 구현이 되어있어야 합니다. 
- 추가하고 싶은 테스트 코드가 있으면 리뷰 남겨주세요.
- 동작하지 않는 부분이 있는지 확인해주세요.
- 카카오 OAuth에서는 OIDC 사용 활성화하는 경우 외에는 공개키 캐싱을 할 필요가 없어보이는데, 이 부분도 제가 잘못 알고 있을 수 있어서 한 번 확인해주시면 감사하겠습니다
