### PR TITLE
feat: 회원 전체삭제 관련 로직 및 api 삭제

### DIFF
--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -100,13 +100,6 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "회원전체탈퇴")
-    @DeleteMapping("/all")
-    public ResponseEntity<Void> deleteAllMembers() {
-        memberService.deleteAll();
-        return ResponseEntity.ok().build();
-    }
-
     @Operation(summary = "회원전체조회")
     @GetMapping("/all")
     public MemberGetAllResponse getAllMembers() {

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -79,12 +79,6 @@ public class MemberService {
         memberRepository.delete(findMember);
     }
 
-    @Transactional
-    public void deleteAll() {
-        memberRepository.findAll()
-                .forEach(member -> delete(member.getEmail()));
-    }
-
     @Transactional(readOnly = true)
     public MemberGetAllResponse getAllMembers() {
         List<Member> members = memberRepository.findAll();

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -123,21 +123,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("모든 회원을 전체 삭제한다")
-    void deleteAll() {
-        MemberSignUpRequest request1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
-        회원_가입(request1);
-        MemberSignUpRequest request2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
-        회원_가입(request2);
-
-        RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().delete("/members/all")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value());
-    }
-
-    @Test
     @DisplayName("회원은 올바르지 않은 형식의 필드로 가입할 수 없다")
     void signUpInvalidInputField() {
         MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "abcdefgh", "케이", "010-1234-5678");

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -204,18 +204,6 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("모든 회원을 전체 삭제한다")
-    void deleteAll() {
-        memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678"));
-        memberRepository.save(new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678"));
-
-        memberService.deleteAll();
-
-        List<Member> actual = memberRepository.findAll();
-        assertThat(actual).hasSize(0);
-    }
-
-    @Test
     @DisplayName("회원을 전체 조회한다")
     void getAllMembers() {
         memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678"));


### PR DESCRIPTION
## 개요
- 회원 전체삭제 관련 api를 잘못 동작하면 위험성이 있다고 판단했습니다. DB 백업 생산성 비용도 발생할 듯합니다.

## 작업사항
- 회원 전체삭제 로직 및 api를 삭제했습니다.

## 주의사항
- 불필요한 로직이 남아있거나, 지나치게 많이 삭제한 부분이 있다면 리뷰 부탁드립니다.
