### PR TITLE
feat: 특정 카페 코멘트 중 나의 코멘트만 조회하는 api 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CommentController.java
+++ b/src/main/java/mocacong/server/controller/CommentController.java
@@ -46,6 +46,19 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "카페 코멘트 중 나의 코멘트만 조회")
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/me")
+    public ResponseEntity<CommentsResponse> findCommentsByMe(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @RequestParam("page") final Integer page,
+            @RequestParam("count") final int count
+    ) {
+        CommentsResponse response = commentService.findCafeCommentsOnlyMyComments(email, mapId, page, count);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "카페 코멘트 수정")
     @SecurityRequirement(name = "JWT")
     @PutMapping("/{commentId}")

--- a/src/main/java/mocacong/server/repository/CommentRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentRepository.java
@@ -11,4 +11,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByMemberId(Long memberId);
 
     Slice<Comment> findAllByCafeId(Long cafeId, Pageable pageRequest);
+
+    Slice<Comment> findAllByCafeIdAndMemberId(Long cafeId, Long memberId, Pageable pageRequest);
 }

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -53,6 +53,18 @@ public class CommentService {
         return new CommentsResponse(comments.getNumber(), responses);
     }
 
+    @Transactional(readOnly = true)
+    public CommentsResponse findCafeCommentsOnlyMyComments(String email, String mapId, Integer page, int count) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Slice<Comment> comments =
+                commentRepository.findAllByCafeIdAndMemberId(cafe.getId(), member.getId(), PageRequest.of(page, count));
+        List<CommentResponse> responses = findCommentResponses(member, comments);
+        return new CommentsResponse(comments.getNumber(), responses);
+    }
+
     private List<CommentResponse> findCommentResponses(Member member, Slice<Comment> comments) {
         return comments.stream()
                 .map(comment -> {

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -103,6 +103,33 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("특정 카페에 달린 댓글 목록 중 내가 작성한 댓글만을 조회한다")
+    void findOnlyMyComments() {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        memberRepository.save(member);
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        commentRepository.save(new Comment(cafe, member, "댓글1"));
+        commentRepository.save(new Comment(cafe, member2, "댓글2"));
+        commentRepository.save(new Comment(cafe, member, "댓글3"));
+        commentRepository.save(new Comment(cafe, member2, "댓글4"));
+
+        CommentsResponse actual = commentService.findCafeCommentsOnlyMyComments(email, mapId, 0, 3);
+
+        assertAll(
+                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getComments()).hasSize(2),
+                () -> assertThat(actual.getComments())
+                        .extracting("content")
+                        .containsExactly("댓글1", "댓글3")
+        );
+    }
+
+    @Test
     @DisplayName("특정 카페에 작성한 댓글을 수정한다")
     void updateComment() {
         String email = "kth990303@naver.com";


### PR DESCRIPTION
## 개요
- 테스트 편리성 및 확장성을 위해 특정 카페 코멘트 중 나의 코멘트만 조회 api를 구현해달라는 요청이 들어왔습니다.

## 작업사항
- 특정 카페 코멘트 중 나의 코멘트만 조회하는 api를 구현했습니다.
<img width="561" alt="image" src="https://user-images.githubusercontent.com/57135043/235349691-f66fbca4-3e57-4117-8bd6-7d1a715e4d3e.png">

- 프론트 편의성이라 response dto가 카페 코멘트 조회 dto랑 같은데, 혹시 이 부분 마음에 걸리면 리뷰로 남겨주세요.

## 주의사항
- 스웨거로 동작 테스트 확인 부탁드립니다.
- 추가로 리팩터링 원하시는 부분 있으면 리뷰 부탁드려요
