### PR TITLE
fix: 이메일 뿐 아니라 닉네임이 중복되면 가입하지 못하도록 변경

### DIFF
--- a/src/main/java/mocacong/server/exception/badrequest/DuplicateNicknameException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/DuplicateNicknameException.java
@@ -1,0 +1,11 @@
+package mocacong.server.exception.badrequest;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateNicknameException extends BadRequestException {
+
+    public DuplicateNicknameException() {
+        super("이미 존재하는 닉네임입니다.", 1004);
+    }
+}

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmailOrNickname(String email, String nickname);
-
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmailOrNickname(String email, String nickname);
+
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
     }
 
     private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {
-        memberRepository.findByEmail(memberSignUpRequest.getEmail())
+        memberRepository.findByEmailOrNickname(memberSignUpRequest.getEmail(), memberSignUpRequest.getNickname())
                 .ifPresent(member -> {
                     throw new DuplicateMemberException();
                 });

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -11,10 +11,7 @@ import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.request.OAuthMemberSignUpRequest;
 import mocacong.server.dto.response.*;
-import mocacong.server.exception.badrequest.DuplicateMemberException;
-import mocacong.server.exception.badrequest.InvalidEmailException;
-import mocacong.server.exception.badrequest.InvalidNicknameException;
-import mocacong.server.exception.badrequest.InvalidPasswordException;
+import mocacong.server.exception.badrequest.*;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.MemberEvent;
@@ -55,9 +52,13 @@ public class MemberService {
     }
 
     private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {
-        memberRepository.findByEmailOrNickname(memberSignUpRequest.getEmail(), memberSignUpRequest.getNickname())
+        memberRepository.findByEmail(memberSignUpRequest.getEmail())
                 .ifPresent(member -> {
                     throw new DuplicateMemberException();
+                });
+        memberRepository.findByNickname(memberSignUpRequest.getNickname())
+                .ifPresent(member -> {
+                    throw new DuplicateNicknameException();
                 });
     }
 

--- a/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
@@ -79,7 +79,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
 
         MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
         회원_가입(signUpRequest);
-        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("mery@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("mery@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
         회원_가입(signUpRequest2);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         String token2 = 로그인_토큰_발급(signUpRequest2.getEmail(), signUpRequest.getPassword());

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -59,11 +59,22 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("이미 가입된 회원이 존재하면 회원 가입 시에 예외를 반환한다")
-    void signUpByDuplicateMember() {
-        String expected = "kth990303@naver.com";
-        MemberSignUpRequest request = new MemberSignUpRequest(expected, "a1b2c3d4", "케이", "010-1234-5678");
-        memberRepository.save(new Member(expected, "1234", "케이", "010-1234-5678"));
+    @DisplayName("이미 가입된 이메일이 존재하면 회원 가입 시에 예외를 반환한다")
+    void signUpByDuplicateEmailMember() {
+        String email = "kth990303@naver.com";
+        memberRepository.save(new Member(email, "1234", "케이", "010-1234-5678"));
+        MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
+
+        assertThatThrownBy(() -> memberService.signUp(request))
+                .isInstanceOf(DuplicateMemberException.class);
+    }
+
+    @Test
+    @DisplayName("이미 가입된 닉네임이 존재하면 회원 가입 시에 예외를 반환한다")
+    void signUpByDuplicateNicknameMember() {
+        String nickname = "케이";
+        memberRepository.save(new Member("kth2@naver.com", "1234", nickname, "010-1234-5678"));
+        MemberSignUpRequest request = new MemberSignUpRequest("kth@naver.com", "a1b2c3d4", nickname, "010-1234-5678");
 
         assertThatThrownBy(() -> memberService.signUp(request))
                 .isInstanceOf(DuplicateMemberException.class);

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -10,6 +10,7 @@ import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.request.OAuthMemberSignUpRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.DuplicateMemberException;
+import mocacong.server.exception.badrequest.DuplicateNicknameException;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPasswordException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
@@ -77,7 +78,7 @@ class MemberServiceTest {
         MemberSignUpRequest request = new MemberSignUpRequest("kth@naver.com", "a1b2c3d4", nickname, "010-1234-5678");
 
         assertThatThrownBy(() -> memberService.signUp(request))
-                .isInstanceOf(DuplicateMemberException.class);
+                .isInstanceOf(DuplicateNicknameException.class);
     }
 
     @Test


### PR DESCRIPTION
## 개요
- 중복된 이메일은 서버 쪽에서 막고 있었지만, 중복된 닉네임 가입은 막지 않고 있었습니다.
- 프론트 쪽에서 중복닉네임 시 post 요청을 못보내도록 해주고는 있었지만, 서버 쪽에서도 막는 게 필요해보였습니다.

## 작업사항
- 이메일 뿐 아니라 닉네임이 중복되면 가입하지 못하도록 변경했습니다.
  - api 변경은 없으므로 acceptanceTest, controller 변경은 없었습니다.
  - DB I/O 비용을 줄이도록 `findByEmail`, `findByNickname` 두 개의 메서드 호출이 아닌 `findByEmailOrNickname` 메서드를 생성했습니다.

## 주의사항
- 스웨거로 동작 테스트 부탁드립니다.
