### PR TITLE
feat: 애플리케이션 로깅 전략 수립 및 로그 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'com.amazonaws:aws-java-sdk-ses:1.12.429'
 	implementation 'commons-io:commons-io:2.11.0'

--- a/src/main/java/mocacong/server/dto/request/AppleLoginRequest.java
+++ b/src/main/java/mocacong/server/dto/request/AppleLoginRequest.java
@@ -1,14 +1,12 @@
 package mocacong.server.dto.request;
 
 import javax.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class AppleLoginRequest {
 
     @NotBlank(message = "1012:공백일 수 없습니다.")

--- a/src/main/java/mocacong/server/dto/request/AuthLoginRequest.java
+++ b/src/main/java/mocacong/server/dto/request/AuthLoginRequest.java
@@ -2,14 +2,12 @@ package mocacong.server.dto.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class AuthLoginRequest {
 
     @Email(message = "1006:이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/mocacong/server/dto/request/CafeFilterRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeFilterRequest.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.request;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class CafeFilterRequest {
     private List<String> mapIds;
 }

--- a/src/main/java/mocacong/server/dto/request/CafeRegisterRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeRegisterRequest.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.request;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class CafeRegisterRequest {
     @NotBlank
     private String id;

--- a/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.request;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class CafeReviewRequest {
 
     @NotBlank(message = "3009:공백일 수 없습니다.")

--- a/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.request;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class CafeReviewUpdateRequest {
 
     @NotBlank(message = "3009:공백일 수 없습니다.")

--- a/src/main/java/mocacong/server/dto/request/CommentSaveRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CommentSaveRequest.java
@@ -1,14 +1,12 @@
 package mocacong.server.dto.request;
 
 import javax.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class CommentSaveRequest {
 
     @NotBlank(message = "4002:공백일 수 없습니다.")

--- a/src/main/java/mocacong/server/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CommentUpdateRequest.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.request;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class CommentUpdateRequest {
 
     @NotBlank(message = "4002:공백일 수 없습니다.")

--- a/src/main/java/mocacong/server/dto/request/EmailVerifyCodeRequest.java
+++ b/src/main/java/mocacong/server/dto/request/EmailVerifyCodeRequest.java
@@ -2,14 +2,12 @@ package mocacong.server.dto.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class EmailVerifyCodeRequest {
 
     @Email(message = "1006:이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/mocacong/server/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/mocacong/server/dto/request/MemberSignUpRequest.java
@@ -2,14 +2,12 @@ package mocacong.server.dto.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class MemberSignUpRequest {
 
     @Email(message = "1006:이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/mocacong/server/dto/request/OAuthMemberSignUpRequest.java
+++ b/src/main/java/mocacong/server/dto/request/OAuthMemberSignUpRequest.java
@@ -1,14 +1,12 @@
 package mocacong.server.dto.request;
 
 import javax.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class OAuthMemberSignUpRequest {
 
     private String email;

--- a/src/main/java/mocacong/server/dto/response/AppleTokenResponse.java
+++ b/src/main/java/mocacong/server/dto/response/AppleTokenResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class AppleTokenResponse {
 
     private String token;

--- a/src/main/java/mocacong/server/dto/response/CafeFilterResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeFilterResponse.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class CafeFilterResponse {
     private List<String> mapIds;
 }

--- a/src/main/java/mocacong/server/dto/response/CafeReviewResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeReviewResponse.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.CafeDetail;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class CafeReviewResponse {
 
     private double score;

--- a/src/main/java/mocacong/server/dto/response/CafeReviewUpdateResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeReviewUpdateResponse.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.CafeDetail;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class CafeReviewUpdateResponse {
 
     private double score;

--- a/src/main/java/mocacong/server/dto/response/CommentResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class CommentResponse {
 
     private String imgUrl;

--- a/src/main/java/mocacong/server/dto/response/CommentSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentSaveResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class CommentSaveResponse {
 
     private Long id;

--- a/src/main/java/mocacong/server/dto/response/CommentsResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentsResponse.java
@@ -1,14 +1,12 @@
 package mocacong.server.dto.response;
 
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class CommentsResponse {
 
     private int currentPage;

--- a/src/main/java/mocacong/server/dto/response/EmailVerifyCodeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/EmailVerifyCodeResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class EmailVerifyCodeResponse {
 
     private String code;

--- a/src/main/java/mocacong/server/dto/response/ErrorResponse.java
+++ b/src/main/java/mocacong/server/dto/response/ErrorResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class ErrorResponse {
 
     private int code;

--- a/src/main/java/mocacong/server/dto/response/FavoriteSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/FavoriteSaveResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class FavoriteSaveResponse {
 
     private Long favoriteId;

--- a/src/main/java/mocacong/server/dto/response/FindCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/FindCafeResponse.java
@@ -1,14 +1,12 @@
 package mocacong.server.dto.response;
 
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class FindCafeResponse {
 
     private Boolean favorite;

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateEmailResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class IsDuplicateEmailResponse {
 
     private boolean result;

--- a/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
+++ b/src/main/java/mocacong/server/dto/response/IsDuplicateNicknameResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class IsDuplicateNicknameResponse {
 
     private boolean result;

--- a/src/main/java/mocacong/server/dto/response/MemberGetAllResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberGetAllResponse.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class MemberGetAllResponse {
     private List<MemberGetResponse> members;
 }

--- a/src/main/java/mocacong/server/dto/response/MemberGetResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberGetResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class MemberGetResponse {
 
     private Long id;

--- a/src/main/java/mocacong/server/dto/response/MemberSignUpResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberSignUpResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class MemberSignUpResponse {
 
     private Long id;

--- a/src/main/java/mocacong/server/dto/response/MyFavoriteCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyFavoriteCafeResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class MyFavoriteCafeResponse {
 
     private String name;

--- a/src/main/java/mocacong/server/dto/response/MyFavoriteCafesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyFavoriteCafesResponse.java
@@ -1,14 +1,12 @@
 package mocacong.server.dto.response;
 
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class MyFavoriteCafesResponse {
 
     private int currentPage;

--- a/src/main/java/mocacong/server/dto/response/MyPageResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyPageResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class MyPageResponse {
 
     private String nickname;

--- a/src/main/java/mocacong/server/dto/response/OAuthMemberSignUpResponse.java
+++ b/src/main/java/mocacong/server/dto/response/OAuthMemberSignUpResponse.java
@@ -1,13 +1,11 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class OAuthMemberSignUpResponse {
 
     private Long id;

--- a/src/main/java/mocacong/server/dto/response/ReviewResponse.java
+++ b/src/main/java/mocacong/server/dto/response/ReviewResponse.java
@@ -1,15 +1,13 @@
 package mocacong.server.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import mocacong.server.domain.Review;
 import mocacong.server.domain.cafedetail.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@ToString
 public class ReviewResponse {
 
     private Wifi wifi;

--- a/src/main/java/mocacong/server/dto/response/TokenResponse.java
+++ b/src/main/java/mocacong/server/dto/response/TokenResponse.java
@@ -3,10 +3,12 @@ package mocacong.server.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class TokenResponse {
     private String token;
 

--- a/src/main/java/mocacong/server/support/logging/LoggingAspect.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingAspect.java
@@ -1,0 +1,64 @@
+package mocacong.server.support.logging;
+
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LoggingAspect {
+
+    private final LoggingTracer loggingTracer;
+    private final LoggingStatusManager loggingStatusManager;
+
+    @Pointcut("execution(public * mocacong.server..*(..)) "
+            + "&& !execution(public * mocacong.server.support.logging..*(..))")
+    private void allComponents() {
+    }
+
+    @Pointcut("execution(public * mocacong.server.controller..*Controller.*(..))")
+    private void allController() {
+    }
+
+    @Around("allComponents()")
+    public Object doLogTrace(ProceedingJoinPoint joinPoint) throws Throwable {
+        final String message = joinPoint.getSignature().toShortString();
+        final Object[] args = joinPoint.getArgs();
+        try {
+            loggingTracer.begin(message, args);
+            Object result = joinPoint.proceed();
+            loggingTracer.end(message);
+            return result;
+        } catch (Exception e) {
+            loggingTracer.exception(message, e);
+            throw e;
+        }
+    }
+
+    @Around("allController()")
+    public Object doLogRequest(ProceedingJoinPoint joinPoint) throws Throwable {
+        loggingStatusManager.syncStatus();
+        String taskId = loggingStatusManager.getTaskId();
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+                .getRequest();
+        String method = request.getMethod();
+        String requestURI = request.getRequestURI();
+        Object[] args = joinPoint.getArgs();
+        log.info("[{}] {} {} args={}", taskId, method, requestURI, args);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            loggingStatusManager.release();
+        }
+    }
+}

--- a/src/main/java/mocacong/server/support/logging/LoggingStatus.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingStatus.java
@@ -1,0 +1,28 @@
+package mocacong.server.support.logging;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoggingStatus {
+
+    public static final int END_DEPTH_LEVEL = 0;
+
+    private final String taskId;
+    private final long startTimeMillis;
+
+    private int depthLevel = 0;
+
+    public void enterDepth() {
+        depthLevel++;
+    }
+
+    public void comeOutDepth() {
+        depthLevel--;
+    }
+
+    public boolean isEndDepth() {
+        return depthLevel == END_DEPTH_LEVEL;
+    }
+}

--- a/src/main/java/mocacong/server/support/logging/LoggingStatusManager.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingStatusManager.java
@@ -1,0 +1,58 @@
+package mocacong.server.support.logging;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoggingStatusManager {
+
+    private final ThreadLocal<LoggingStatus> statusContainer = new ThreadLocal<>();
+
+    public void syncStatus() {
+        final LoggingStatus status = statusContainer.get();
+        if (status != null) {
+            status.enterDepth();
+            return;
+        }
+        final LoggingStatus firstLoggingStatus = createLoggingStatus();
+        statusContainer.set(firstLoggingStatus);
+    }
+
+    private LoggingStatus createLoggingStatus() {
+        final String traceId = UUID.randomUUID().toString().substring(0, 8);
+        final long startTimeMillis = System.currentTimeMillis();
+        return new LoggingStatus(traceId, startTimeMillis);
+    }
+
+    public String getTaskId() {
+        final LoggingStatus status = getExistLoggingStatus();
+        return status.getTaskId();
+    }
+
+    public long getStartTimeMillis() {
+        final LoggingStatus status = getExistLoggingStatus();
+        return status.getStartTimeMillis();
+    }
+
+    public int getDepthLevel() {
+        final LoggingStatus status = getExistLoggingStatus();
+        return status.getDepthLevel();
+    }
+
+    public void release() {
+        final LoggingStatus status = getExistLoggingStatus();
+        if (status.isEndDepth()) {
+            statusContainer.remove();
+            return;
+        }
+        status.comeOutDepth();
+    }
+
+    private LoggingStatus getExistLoggingStatus() {
+        final LoggingStatus status = statusContainer.get();
+        if (status == null) {
+            throw new IllegalStateException("로깅 작업 중 예외가 발생했습니다.");
+        }
+        return status;
+    }
+}

--- a/src/main/java/mocacong/server/support/logging/LoggingTracer.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingTracer.java
@@ -17,7 +17,7 @@ public class LoggingTracer {
         loggingStatusManager.syncStatus();
         if (log.isInfoEnabled()) {
             log.info(
-                    "[{}] {}> {} args={}",
+                    "[{}] {}-> {} args={}",
                     loggingStatusManager.getTaskId(),
                     getDepthSpace(loggingStatusManager.getDepthLevel()),
                     message,
@@ -31,7 +31,7 @@ public class LoggingTracer {
             long stopTimeMillis = System.currentTimeMillis();
             long resultTimeMillis = stopTimeMillis - loggingStatusManager.getStartTimeMillis();
             log.info(
-                    "[{}] <{} {} time={}ms",
+                    "[{}] <-{} {} time={}ms",
                     loggingStatusManager.getTaskId(),
                     getDepthSpace(loggingStatusManager.getDepthLevel()),
                     message,

--- a/src/main/java/mocacong/server/support/logging/LoggingTracer.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingTracer.java
@@ -1,0 +1,63 @@
+package mocacong.server.support.logging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LoggingTracer {
+
+    private static final String TRACE_DEPTH_SPACE = "--";
+
+    private final LoggingStatusManager loggingStatusManager;
+
+    public void begin(final String message, final Object[] args) {
+        loggingStatusManager.syncStatus();
+        if (log.isInfoEnabled()) {
+            log.info(
+                    "[{}] {}> {} args={}",
+                    loggingStatusManager.getTaskId(),
+                    getDepthSpace(loggingStatusManager.getDepthLevel()),
+                    message,
+                    args
+            );
+        }
+    }
+
+    public void end(final String message) {
+        if (log.isInfoEnabled()) {
+            long stopTimeMillis = System.currentTimeMillis();
+            long resultTimeMillis = stopTimeMillis - loggingStatusManager.getStartTimeMillis();
+            log.info(
+                    "[{}] <{} {} time={}ms",
+                    loggingStatusManager.getTaskId(),
+                    getDepthSpace(loggingStatusManager.getDepthLevel()),
+                    message,
+                    resultTimeMillis
+            );
+        }
+        loggingStatusManager.release();
+    }
+
+    public void exception(String message, Exception e) {
+        if (log.isInfoEnabled()) {
+            long stopTimeMillis = System.currentTimeMillis();
+            long resultTimeMillis = stopTimeMillis - loggingStatusManager.getStartTimeMillis();
+            log.info(
+                    "[{}] <X{} {} time={}ms ex={}",
+                    loggingStatusManager.getTaskId(),
+                    getDepthSpace(loggingStatusManager.getDepthLevel()),
+                    message,
+                    resultTimeMillis,
+                    e.toString()
+            );
+        }
+        loggingStatusManager.release();
+    }
+
+    private String getDepthSpace(int depthLevel) {
+        return TRACE_DEPTH_SPACE.repeat(depthLevel);
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATH" value="./logs"/>
+    <property name="ARCHIVE_PATH" value="./archive"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%C.%M:%line] - %msg%n"/>
+
+    <springProfile name="!prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <!-- 로컬 환경에서는 기본 로그레벨 INFO -->
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <!-- 운영 환경에서는 로그를 파일로 저장 -->
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/mocacong-${BY_DATE}.log</file>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <!-- rolling(백업) 파일 저장 위치 -->
+                <fileNamePattern>${ARCHIVE_PATH}/mocacong-${BY_DATE}-%i.log</fileNamePattern>
+                <!-- 로그 파일이 10MB 넘으면 백업하고 새로운 파일 생성 -->
+                <maxFileSize>10MB</maxFileSize>
+                <!-- 백업 로그 파일은 7일 이후 삭제 -->
+                <maxHistory>7</maxHistory>
+                <!-- 로그 파일과 백업 로그 파일의 최대 크기는 100MB -->
+                <!-- 초과 시 가장 오래된 백업 파일부터 삭제 -->
+                <totalSizeCap>100MB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/error/mocacong-error-${BY_DATE}.log</file>
+            <!-- ERROR 로깅 레벨만 필터링 -->
+            <filter class = "ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <!-- 에러 rolling(백업) 파일 저장 위치 -->
+                <fileNamePattern>${ARCHIVE_PATH}/error/mocacong-error-${BY_DATE}-%i.log</fileNamePattern>
+                <!-- 에러 로그 파일이 10MB 넘으면 백업하고 새로운 파일 생성 -->
+                <maxFileSize>10MB</maxFileSize>
+                <!-- 에러 백업 로그 파일은 20일 이후 삭제 -->
+                <maxHistory>20</maxHistory>
+                <!-- 에러 관련 로그 파일과 백업 로그 파일의 최대 크기는 500MB -->
+                <!-- 초과 시 가장 오래된 백업 파일부터 삭제 -->
+                <totalSizeCap>500MB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <!-- 운영 환경에서는 기본 로그레벨 INFO -->
+        <root level="INFO">
+            <appender-ref ref="FILE"/>
+            <appender-ref ref="FILE_ERROR"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 개요
- 기존에는 프론트에서 요청을 보냈을 때, 애플리케이션 내에 요청이 들어왔는지 알 수 없었습니다.
  - `nohup.out`으로 SQL 확인 정도는 가능했지만, 요청이 실패한 경우나 어디까지 작업이 진행됐는지, 어떤 스레드에서 작업이 진행됐는지, 응답 시간(responsetime)은 알기 어려웠습니다.

## 작업사항
- 스프링에서 기본으로 채택한 `logback` 라이브러리로 로깅 작업 기능을 구현했습니다.

## 주의사항
- logback에 대한 이해 및 rollingfile policy에 대한 이해가 필요한 PR입니다.
- 로그가 잘 동작하는지 애플리케이션을 **로컬 환경에서만** 수행해주세요.
- 불필요한 로그 및 로그가 출력되지 않았으면 좋겠는 부분이 있다면 리뷰 부탁드려요.
- 로깅 전략을 한 번 확인해주세요.
