### PR TITLE
fix: 카페 리뷰 작성 시 스터디타입에 `both` 선택이 가능하도록 로직 수정

### DIFF
--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -1,11 +1,5 @@
 package mocacong.server.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import mocacong.server.domain.cafedetail.*;
-
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +7,11 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mocacong.server.domain.cafedetail.*;
 
 @Entity
 @Table(name = "cafe")
@@ -75,6 +74,10 @@ public class Cafe extends BaseTime {
             StudyType studyType = review.getStudyType();
             if (studyType == StudyType.SOLO) solo++;
             else if (studyType == StudyType.GROUP) group++;
+            else {
+                solo++;
+                group++;
+            }
         }
 
         if (solo == 0 && group == 0) return null;

--- a/src/test/java/mocacong/server/domain/CafeTest.java
+++ b/src/test/java/mocacong/server/domain/CafeTest.java
@@ -63,6 +63,40 @@ class CafeTest {
     }
 
     @Test
+    @DisplayName("카페 세부정보 리뷰로 both가 작성될 경우 solo, group 포인트가 모두 1씩 증가한다")
+    void updateCafeDetailsWhenStudyTypesAddBoth() {
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Cafe cafe = new Cafe("1", "케이카페");
+
+        // BOTH 리뷰 추가 -> SOLO, GROUP 모두 1포인트
+        CafeDetail cafeDetail1 = new CafeDetail(StudyType.BOTH, Wifi.NORMAL, Parking.COMFORTABLE, Toilet.NORMAL, Desk.UNCOMFORTABLE, Power.FEW, Sound.NOISY);
+        Review review1 = new Review(member, cafe, cafeDetail1);
+        cafe.addReview(review1);
+        cafe.updateCafeDetails();
+        CafeDetail actualWhenBothAdd = cafe.getCafeDetail();
+
+        // SOLO 리뷰 추가 -> SOLO 2포인트, GROUP 1포인트
+        CafeDetail cafeDetail2 = new CafeDetail(StudyType.SOLO, Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.COMFORTABLE, Power.MANY, Sound.LOUD);
+        Review review2 = new Review(member, cafe, cafeDetail2);
+        cafe.addReview(review2);
+        cafe.updateCafeDetails();
+        CafeDetail actualWhenSoloAdd = cafe.getCafeDetail();
+
+        // GROUP 리뷰 추가 -> SOLO, GROUP 모두 2포인트
+        CafeDetail cafeDetail3 = new CafeDetail(StudyType.GROUP, Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.COMFORTABLE, Power.MANY, Sound.LOUD);
+        Review review3 = new Review(member, cafe, cafeDetail3);
+        cafe.addReview(review3);
+        cafe.updateCafeDetails();
+        CafeDetail actualWhenGroupAdd = cafe.getCafeDetail();
+
+        assertAll(
+                () -> assertThat(actualWhenBothAdd.getStudyType()).isEqualTo(StudyType.BOTH),
+                () -> assertThat(actualWhenSoloAdd.getStudyType()).isEqualTo(StudyType.SOLO),
+                () -> assertThat(actualWhenGroupAdd.getStudyType()).isEqualTo(StudyType.BOTH)
+        );
+    }
+
+    @Test
     @DisplayName("카페 세부정보 중 study type은 같은 개수일 경우 solo나 group이 아닌 both를 반환한다")
     void updateCafeDetailsWhenStudyTypesEqual() {
         Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -138,7 +138,7 @@ class CafeServiceTest {
                 new CafeReviewRequest(1, "group", "느려요", "없어요",
                         "불편해요", "없어요", "북적북적해요", "불편해요"));
         cafeService.saveCafeReview(member2.getEmail(), cafe.getMapId(),
-                new CafeReviewRequest(2, "group", "느려요", "없어요",
+                new CafeReviewRequest(2, "both", "느려요", "없어요",
                         "깨끗해요", "없어요", null, "보통이에요"));
         Comment comment1 = new Comment(cafe, member1, "이 카페 조금 아쉬운 점이 많아요 ㅠㅠ");
         commentRepository.save(comment1);


### PR DESCRIPTION
## 개요
- 이전에는 `both` 요청이 존재하지 않는다고 판단하여 `both`에 대한 처리를 진행하지 않았습니다. 

## 작업사항
- 카페 리뷰 작성 시 스터디타입을 `both`로 작성할 경우 `solo`, `group` 모두에 투표한 것으로 간주하도록 도메인 로직을 수정했습니다.
- 리뷰 작성 요청으로 `both`가 주어지는 테스트가 존재하도록 일부 테스트를 수정했습니다.

## 주의사항
- 도메인 로직이 올바른지만 확인해주시면 될 것 같습니다.
