### PR TITLE
feat: 카페 코멘트 조회 시 코멘트 id 또한 조회하도록 로직 수정

### DIFF
--- a/src/main/java/mocacong/server/dto/response/CommentResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CommentResponse {
 
+    private Long id;
     private String imgUrl;
     private String nickname;
     private String content;

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -26,6 +22,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -91,9 +92,9 @@ public class CafeService {
                 .limit(CAFE_SHOW_PAGE_COMMENTS_LIMIT_COUNTS)
                 .map(comment -> {
                     if (comment.isWrittenByMember(member)) {
-                        return new CommentResponse(member.getImgUrl(), member.getNickname(), comment.getContent(), true);
+                        return new CommentResponse(comment.getId(), member.getImgUrl(), member.getNickname(), comment.getContent(), true);
                     } else {
-                        return new CommentResponse(comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
+                        return new CommentResponse(comment.getId(), comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
                     }
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -1,7 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
@@ -22,6 +20,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -69,9 +70,9 @@ public class CommentService {
         return comments.stream()
                 .map(comment -> {
                     if (comment.isWrittenByMember(member)) {
-                        return new CommentResponse(member.getImgUrl(), member.getNickname(), comment.getContent(), true);
+                        return new CommentResponse(comment.getId(), member.getImgUrl(), member.getNickname(), comment.getContent(), true);
                     } else {
-                        return new CommentResponse(comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
+                        return new CommentResponse(comment.getId(),comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
                     }
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 기존 카페 코멘트를 조회할 때 response에 코멘트의 id 또한 같이 넘기도록 수정했습니다.
![image](https://user-images.githubusercontent.com/69844138/236674717-e246fae5-26a1-421c-a65a-7d55b399b3dc.png)


## 작업사항
- `CommentResponse` 수정
- 카페 코멘트 조회 시, id 또한 같이 조회하도록 로직 수정

## 주의사항
- 스웨거로 동작 확인해주세요
- 변경된 api 명세서가 올바른지 확인해주세요
