### PR TITLE
feat: 카페 이미지 수정 PUT API 구현 및 조회 API 변경

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -91,7 +91,7 @@ public class CafeController {
     @Operation(summary = "카페 이미지 업로드")
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = "/{mapId}/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> updateCafeImage(
+    public ResponseEntity<Void> saveCafeImage(
             @LoginUserEmail String email,
             @PathVariable String mapId,
             @RequestParam(value = "file") MultipartFile multipartFile
@@ -115,12 +115,12 @@ public class CafeController {
 
     @Operation(summary = "카페 이미지 수정")
     @SecurityRequirement(name = "JWT")
-    @GetMapping("/{mapId}/img/{cafeImageId}")
+    @PutMapping(value = "/{mapId}/img/{cafeImageId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> updateCafeImage(
             @LoginUserEmail String email,
             @PathVariable String mapId,
             @PathVariable Long cafeImageId,
-            @RequestParam(value = "file", required = false) MultipartFile multipartFile
+            @RequestParam(value = "file") MultipartFile multipartFile
     ) {
         cafeService.updateCafeImage(email, mapId, cafeImageId, multipartFile);
         return ResponseEntity.ok().build();

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -3,7 +3,6 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.CafeFilterRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
@@ -16,6 +15,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
 
 @Tag(name = "Cafes", description = "카페")
 @RestController
@@ -110,5 +111,18 @@ public class CafeController {
     ) {
         CafeImagesResponse response = cafeService.findCafeImages(email, mapId, page, count);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "카페 이미지 수정")
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/{mapId}/img/{cafeImageId}")
+    public ResponseEntity<Void> updateCafeImage(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @PathVariable Long cafeImageId,
+            @RequestParam(value = "file", required = false) MultipartFile multipartFile
+    ) {
+        cafeService.updateCafeImage(email, mapId, cafeImageId, multipartFile);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -20,6 +20,9 @@ public class CafeImage extends BaseTime {
     @Column(name = "img_url")
     private String imgUrl;
 
+    @Column(name = "is_used")
+    private Boolean isUsed;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cafe_id")
     private Cafe cafe;
@@ -28,13 +31,18 @@ public class CafeImage extends BaseTime {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public CafeImage(String imgUrl, Cafe cafe, Member member) {
+    public CafeImage(String imgUrl, Boolean isUsed, Cafe cafe, Member member) {
         this.imgUrl = imgUrl;
+        this.isUsed = isUsed;
         this.cafe = cafe;
         this.member = member;
     }
 
     public boolean isOwned(Member member) {
         return this.member.equals(member);
+    }
+
+    public void setIsUsed(Boolean isUsed) {
+        this.isUsed = isUsed;
     }
 }

--- a/src/main/java/mocacong/server/dto/response/CafeImageResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeImageResponse.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CafeImageResponse {
+    private Long id;
     private String imageUrl;
     private Boolean isMe;
 }

--- a/src/main/java/mocacong/server/exception/notfound/NotFoundCafeImageException.java
+++ b/src/main/java/mocacong/server/exception/notfound/NotFoundCafeImageException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.notfound;
+
+public class NotFoundCafeImageException extends NotFoundException {
+
+    public NotFoundCafeImageException() {
+        super("존재하지 않는 카페 이미지입니다.", 2007);
+    }
+}

--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
-    Slice<CafeImage> findAllByCafeId(Long cafeId, Pageable pageRequest);
+    Slice<CafeImage> findAllByCafeIdAndIsUsedTrue(Long id, Pageable pageable);
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -26,6 +22,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -236,7 +237,7 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
 
         String imgUrl = awsS3Uploader.uploadImage(cafeImg);
-        CafeImage cafeImage = new CafeImage(imgUrl, cafe, member);
+        CafeImage cafeImage = new CafeImage(imgUrl, true, cafe, member);
         cafeImageRepository.save(cafeImage);
     }
 
@@ -259,5 +260,18 @@ public class CafeService {
                 .collect(Collectors.toList());
 
         return new CafeImagesResponse(cafeImages.getNumber(), responses);
+    }
+
+    public void updateCafeImage(String email, String mapId, Long cafeImageId, MultipartFile cafeImg) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        CafeImage notUsedImage = cafeImageRepository.getReferenceById(cafeImageId);
+        notUsedImage.setIsUsed(false);
+
+        String imgUrl = awsS3Uploader.uploadImage(cafeImg);
+        CafeImage cafeImage = new CafeImage(imgUrl, true, cafe, member);
+        cafeImageRepository.save(cafeImage);
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -103,6 +103,7 @@ public class CafeService {
     private List<CafeImageResponse> findCafeImageResponses(Cafe cafe, Member member) {
         return cafe.getCafeImages()
                 .stream()
+                .filter(CafeImage::getIsUsed)
                 .limit(CAFE_SHOW_PAGE_IMAGE_LIMIT_COUNTS)
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
@@ -253,6 +254,7 @@ public class CafeService {
         List<CafeImageResponse> responses = cafeImages
                 .getContent()
                 .stream()
+                .filter(CafeImage::getIsUsed)
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
                     return new CafeImageResponse(cafeImage.getImgUrl(), isMe);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -107,7 +107,7 @@ public class CafeService {
                 .limit(CAFE_SHOW_PAGE_IMAGE_LIMIT_COUNTS)
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
-                    return new CafeImageResponse(cafeImage.getImgUrl(), isMe);
+                    return new CafeImageResponse(cafeImage.getId(), cafeImage.getImgUrl(), isMe);
                 })
                 .collect(Collectors.toList());
     }
@@ -256,7 +256,7 @@ public class CafeService {
                 .stream()
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
-                    return new CafeImageResponse(cafeImage.getImgUrl(), isMe);
+                    return new CafeImageResponse(cafeImage.getId(), cafeImage.getImgUrl(), isMe);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -104,7 +104,6 @@ public class CafeService {
     private List<CafeImageResponse> findCafeImageResponses(Cafe cafe, Member member) {
         return cafe.getCafeImages()
                 .stream()
-                .filter(CafeImage::getIsUsed)
                 .limit(CAFE_SHOW_PAGE_IMAGE_LIMIT_COUNTS)
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
@@ -250,12 +249,11 @@ public class CafeService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         Pageable pageable = PageRequest.of(page, count);
-        Slice<CafeImage> cafeImages = cafeImageRepository.findAllByCafeId(cafe.getId(), pageable);
+        Slice<CafeImage> cafeImages = cafeImageRepository.findAllByCafeIdAndIsUsedTrue(cafe.getId(), pageable);
 
         List<CafeImageResponse> responses = cafeImages
                 .getContent()
                 .stream()
-                .filter(CafeImage::getIsUsed)
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
                     return new CafeImageResponse(cafeImage.getImgUrl(), isMe);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -270,8 +270,8 @@ public class CafeService {
         CafeImage notUsedImage = cafeImageRepository.getReferenceById(cafeImageId);
         notUsedImage.setIsUsed(false);
 
-        String imgUrl = awsS3Uploader.uploadImage(cafeImg);
-        CafeImage cafeImage = new CafeImage(imgUrl, true, cafe, member);
+        String newImgUrl = awsS3Uploader.uploadImage(cafeImg);
+        CafeImage cafeImage = new CafeImage(newImgUrl, true, cafe, member);
         cafeImageRepository.save(cafeImage);
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -10,6 +10,7 @@ import mocacong.server.dto.request.CafeReviewUpdateRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
 import mocacong.server.exception.notfound.NotFoundCafeException;
+import mocacong.server.exception.notfound.NotFoundCafeImageException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
@@ -264,16 +265,18 @@ public class CafeService {
         return new CafeImagesResponse(cafeImages.getNumber(), responses);
     }
 
+    @Transactional
     public void updateCafeImage(String email, String mapId, Long cafeImageId, MultipartFile cafeImg) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
-        CafeImage notUsedImage = cafeImageRepository.getReferenceById(cafeImageId);
-        notUsedImage.setIsUsed(false);
-
         String newImgUrl = awsS3Uploader.uploadImage(cafeImg);
         CafeImage cafeImage = new CafeImage(newImgUrl, true, cafe, member);
         cafeImageRepository.save(cafeImage);
+
+        CafeImage notUsedImage = cafeImageRepository.findById(cafeImageId)
+                        .orElseThrow(NotFoundCafeImageException::new);
+        notUsedImage.setIsUsed(false);
     }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,8 +1,5 @@
 package mocacong.server.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.CafeFilterRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
@@ -11,20 +8,24 @@ import mocacong.server.dto.request.CafeReviewUpdateRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
 import mocacong.server.exception.notfound.NotFoundCafeException;
+import mocacong.server.exception.notfound.NotFoundCafeImageException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.support.AwsS3Uploader;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
 class CafeServiceTest {
@@ -628,5 +629,53 @@ class CafeServiceTest {
                 () -> assertThat(cafeImages.get(0).getIsMe()).isFalse(),
                 () -> assertThat(cafeImages.get(1).getIsMe()).isFalse()
         );
+    }
+
+    @Test
+    @DisplayName("카페 이미지를 성공적으로 수정한다")
+    void updateCafeImage() throws IOException {
+        String oldImage = "test_img.jpg";
+        String newImage = "test_img2.jpg";
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        memberRepository.save(member);
+        String mapId = cafe.getMapId();
+        FileInputStream oldFileInputStream = new FileInputStream("src/test/resources/images/" + oldImage);
+        FileInputStream newFileInputStream = new FileInputStream("src/test/resources/images/" + newImage);
+        MockMultipartFile oldMockMultipartFile = new MockMultipartFile("test_img", oldImage, "jpg", oldFileInputStream);
+        MockMultipartFile newMockMultipartFile = new MockMultipartFile("test_img2", newImage, "jpg", newFileInputStream);
+        when(awsS3Uploader.uploadImage(oldMockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member.getEmail(), mapId, oldMockMultipartFile);
+        CafeImagesResponse oldFindImage = cafeService.findCafeImages(member.getEmail(), mapId, 0, 10);
+        when(awsS3Uploader.uploadImage(newMockMultipartFile)).thenReturn("test_img2.jpg");
+
+        cafeService.updateCafeImage(member.getEmail(), mapId, oldFindImage.getCafeImages().get(0).getId(), newMockMultipartFile);
+        CafeImagesResponse actual = cafeService.findCafeImages(member.getEmail(), mapId, 0, 10);
+        List<CafeImageResponse> cafeImages = actual.getCafeImages();
+
+        assertAll(
+                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getCafeImages().get(0).getId()).isNotEqualTo(oldFindImage.getCafeImages().get(0).getId()),
+                () -> assertThat(cafeImages.get(0).getImageUrl()).endsWith("test_img2.jpg"),
+                () -> assertThat(cafeImages).hasSize(1)
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카페 이미지를 수정 시도할 시 예외를 반환한다")
+    void updateCafeImageNotFoundImage() throws IOException {
+        String newImage = "test_img.jpg";
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        memberRepository.save(member);
+        String mapId = cafe.getMapId();
+        FileInputStream newFileInputStream = new FileInputStream("src/test/resources/images/" + newImage);
+        MockMultipartFile newMockMultipartFile = new MockMultipartFile("test_img2", newImage, "jpg", newFileInputStream);
+        when(awsS3Uploader.uploadImage(newMockMultipartFile)).thenReturn("test_img2.jpg");
+
+        assertThatThrownBy(() ->    cafeService.updateCafeImage(member.getEmail(), mapId, 0L,
+                newMockMultipartFile)).isInstanceOf(NotFoundCafeImageException.class);
     }
 }


### PR DESCRIPTION
## 개요
- 카페 이미지 수정 PUT api를 구현했습니다. 이미지 수정 기능을 구현하면서 조회 api에서 변경이 필요한 로직을 수정했습니다.

## 작업사항
- 카페 이미지 수정 api 구현
- 카페 이미지 조회 api response에 id 추가
- 카페 이미지 조회 api 로직 수정
- 카페 이미지 수정 테스트 코드 작성

## 주의사항
- 카페 이미지 수정 로직이 api 명세서에 맞게 구현되었는지 확인해주세요
- 기획 로직과 다르게 구현된 부분이 있는지 확인해주세요
- 카페 이미지 수정 api 또한 카페 이미지 저장 api처럼 인수테스트를 생략했습니다
- 누락된 테스트가 있는지 확인해주세요
- ex) feat: 로그인 토큰 발행 기능 추가
