### PR TITLE
fix: KAKAO OAuth 플랫폼이 잘못 저장되는 버그 및 인가코드 예외 핸들링 구현

### DIFF
--- a/src/main/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProvider.java
+++ b/src/main/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProvider.java
@@ -1,5 +1,7 @@
 package mocacong.server.security.auth.kakao;
 
+import feign.FeignException;
+import mocacong.server.exception.unauthorized.InvalidTokenException;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -30,10 +32,18 @@ public class KakaoOAuthUserProvider {
     public OAuthPlatformMemberResponse getKakaoPlatformMember(String authorizationCode) {
         KakaoAccessTokenRequest kakaoAccessTokenRequest =
                 new KakaoAccessTokenRequest(authorizationCode, kakaoClientId, kakaoClientSecret, redirectUri);
-        KakaoAccessToken token = kakaoAccessTokenClient.getToken(kakaoAccessTokenRequest);
+        KakaoAccessToken token = getKakaoAccessToken(kakaoAccessTokenRequest);
 
         KakaoUserRequest kakaoUserRequest = new KakaoUserRequest("[\"kakao_account.email\"]");
         KakaoUser user = kakaoUserClient.getUser(kakaoUserRequest, token.getAuthorization());
         return new OAuthPlatformMemberResponse(String.valueOf(user.getId()), user.getEmail());
+    }
+
+    private KakaoAccessToken getKakaoAccessToken(KakaoAccessTokenRequest kakaoAccessTokenRequest) {
+        try {
+            return kakaoAccessTokenClient.getToken(kakaoAccessTokenRequest);
+        } catch (FeignException e) {
+            throw new InvalidTokenException("KAKAO OAuth 인가 코드가 올바르지 않습니다.");
+        }
     }
 }

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -40,17 +40,25 @@ public class AuthService {
     public OAuthTokenResponse appleOAuthLogin(AppleLoginRequest request) {
         OAuthPlatformMemberResponse applePlatformMember =
                 appleOAuthUserProvider.getApplePlatformMember(request.getToken());
-        return generateOAuthTokenResponse(applePlatformMember.getEmail(), applePlatformMember.getPlatformId());
+        return generateOAuthTokenResponse(
+                Platform.APPLE,
+                applePlatformMember.getEmail(),
+                applePlatformMember.getPlatformId()
+        );
     }
 
     public OAuthTokenResponse kakaoOAuthLogin(KakaoLoginRequest request) {
-        OAuthPlatformMemberResponse applePlatformMember =
+        OAuthPlatformMemberResponse kakaoPlatformMember =
                 kakaoOAuthUserProvider.getKakaoPlatformMember(request.getCode());
-        return generateOAuthTokenResponse(applePlatformMember.getEmail(), applePlatformMember.getPlatformId());
+        return generateOAuthTokenResponse(
+                Platform.KAKAO,
+                kakaoPlatformMember.getEmail(),
+                kakaoPlatformMember.getPlatformId()
+        );
     }
 
-    private OAuthTokenResponse generateOAuthTokenResponse(String email, String platformId) {
-        return memberRepository.findIdByPlatformAndPlatformId(Platform.APPLE, platformId)
+    private OAuthTokenResponse generateOAuthTokenResponse(Platform platform, String email, String platformId) {
+        return memberRepository.findIdByPlatformAndPlatformId(platform, platformId)
                 .map(memberId -> {
                     Member findMember = memberRepository.findById(memberId)
                             .orElseThrow(NotFoundMemberException::new);
@@ -62,7 +70,7 @@ public class AuthService {
                     return new OAuthTokenResponse(token, findMember.getEmail(), true, platformId);
                 })
                 .orElseGet(() -> {
-                    Member oauthMember = new Member(email, Platform.APPLE, platformId);
+                    Member oauthMember = new Member(email, platform, platformId);
                     Member savedMember = memberRepository.save(oauthMember);
                     String token = issueToken(savedMember);
                     return new OAuthTokenResponse(token, email, false, platformId);

--- a/src/test/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/kakao/KakaoOAuthUserProviderTest.java
@@ -1,7 +1,10 @@
 package mocacong.server.security.auth.kakao;
 
+import feign.FeignException;
+import mocacong.server.exception.unauthorized.InvalidTokenException;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,5 +44,13 @@ class KakaoOAuthUserProviderTest {
                 () -> assertThat(actual.getEmail()).isEqualTo(email),
                 () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
         );
+    }
+
+    @Test
+    @DisplayName("Kakao OAuth 서버와 통신할 때 인가코드가 올바르지 않으면 예외를 반환한다")
+    void getKakaoPlatformMemberWhenInvalidAuthorizationCode() {
+        when(kakaoAccessTokenClient.getToken(any())).thenThrow(FeignException.class);
+        assertThatThrownBy(() -> kakaoOAuthUserProvider.getKakaoPlatformMember("invalid_token"))
+                .isInstanceOf(InvalidTokenException.class);
     }
 }


### PR DESCRIPTION
## 개요
- KAKAO OAuth 로그인하면 Platform이 KAKAO가 아닌 APPLE로 저장되는 버그 존재
- 카카오 인가코드가 잘못될 경우 400 Bad Request임에도 불구하고 500으로 처리되어 슬랙 알림 전송

## 작업사항
- 플랫폼 저장이 각 OAuth 구현체에 따라 다르게 저장되도록 수정
- 잘못된 인가코드로 인해 Feign Exception 발생 시 예외 핸들링 구현

## 주의사항
- 예외 핸들링이 마음에 드는지 확인해주세요.
- KAKAO OAuth 로그인하면 Platform이 KAKAO로 저장되는지는 프론트와 테스트해봐야될 것 같습니다. 이 부분은 일단 코드상으로만 확인해주세요.
