### PR TITLE
fix: 카페 세부정보 계산 로직 최대값에서 평균점수로 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/cafedetail/Desk.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Desk.java
@@ -1,23 +1,23 @@
 package mocacong.server.domain.cafedetail;
 
+import java.util.Arrays;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidDeskException;
-
-import java.util.Arrays;
-import java.util.Objects;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public enum Desk {
 
-    COMFORTABLE("편해요"),
-    NORMAL("보통이에요"),
-    UNCOMFORTABLE("불편해요");
+    COMFORTABLE("편해요", 3),
+    NORMAL("보통이에요", 2),
+    UNCOMFORTABLE("불편해요", 1);
 
     private String value;
+    private int score;
 
     public static Desk from(String value) {
         if (value == null) return null;
@@ -25,5 +25,12 @@ public enum Desk {
                 .filter(it -> Objects.equals(it.value, value))
                 .findFirst()
                 .orElseThrow(InvalidDeskException::new);
+    }
+
+    public static Desk averageFrom(double score) {
+        return Arrays.stream(values())
+                .filter(it -> it.score == (int) (score + 0.5))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/mocacong/server/domain/cafedetail/Desk.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Desk.java
@@ -29,7 +29,7 @@ public enum Desk {
 
     public static Desk averageFrom(double score) {
         return Arrays.stream(values())
-                .filter(it -> it.score == (int) (score + 0.5))
+                .filter(it -> it.score == Math.round(score))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/mocacong/server/domain/cafedetail/Parking.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Parking.java
@@ -12,11 +12,12 @@ import mocacong.server.exception.badrequest.InvalidParkingException;
 @Getter
 public enum Parking {
 
-    COMFORTABLE("여유로워요"),
-    UNCOMFORTABLE("협소해요"),
-    NONE("없어요");
+    COMFORTABLE("여유로워요", 3),
+    UNCOMFORTABLE("협소해요", 2),
+    NONE("없어요", 1);
 
     private String value;
+    private int score;
 
     public static Parking from(String value) {
         if (value == null) return null;
@@ -24,5 +25,12 @@ public enum Parking {
                 .filter(it -> Objects.equals(it.value, value))
                 .findFirst()
                 .orElseThrow(InvalidParkingException::new);
+    }
+
+    public static Parking averageFrom(double score) {
+        return Arrays.stream(values())
+                .filter(it -> it.score == (int) (score + 0.5))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/mocacong/server/domain/cafedetail/Parking.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Parking.java
@@ -29,7 +29,7 @@ public enum Parking {
 
     public static Parking averageFrom(double score) {
         return Arrays.stream(values())
-                .filter(it -> it.score == (int) (score + 0.5))
+                .filter(it -> it.score == Math.round(score))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/mocacong/server/domain/cafedetail/Power.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Power.java
@@ -29,7 +29,7 @@ public enum Power {
 
     public static Power averageFrom(double score) {
         return Arrays.stream(values())
-                .filter(it -> it.score == (int) (score + 0.5))
+                .filter(it -> it.score == Math.round(score))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/mocacong/server/domain/cafedetail/Power.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Power.java
@@ -12,11 +12,12 @@ import mocacong.server.exception.badrequest.InvalidPowerException;
 @Getter
 public enum Power {
 
-    MANY("충분해요"),
-    FEW("적당해요"),
-    NONE("없어요");
+    MANY("충분해요", 3),
+    FEW("적당해요", 2),
+    NONE("없어요", 1);
 
     private String value;
+    private int score;
 
     public static Power from(String value) {
         if (value == null) return null;
@@ -24,5 +25,12 @@ public enum Power {
                 .filter(it -> Objects.equals(it.value, value))
                 .findFirst()
                 .orElseThrow(InvalidPowerException::new);
+    }
+
+    public static Power averageFrom(double score) {
+        return Arrays.stream(values())
+                .filter(it -> it.score == (int) (score + 0.5))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/mocacong/server/domain/cafedetail/Sound.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Sound.java
@@ -12,11 +12,12 @@ import mocacong.server.exception.badrequest.InvalidSoundException;
 @Getter
 public enum Sound {
 
-    QUIET("조용해요"),
-    NOISY("적당해요"),
-    LOUD("북적북적해요");
+    QUIET("조용해요", 3),
+    NOISY("적당해요", 2),
+    LOUD("북적북적해요", 1);
 
     private String value;
+    private int score;
 
     public static Sound from(String value) {
         if (value == null) return null;
@@ -24,5 +25,12 @@ public enum Sound {
                 .filter(it -> Objects.equals(it.value, value))
                 .findFirst()
                 .orElseThrow(InvalidSoundException::new);
+    }
+
+    public static Sound averageFrom(double score) {
+        return Arrays.stream(values())
+                .filter(it -> it.score == (int) (score + 0.5))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/mocacong/server/domain/cafedetail/Sound.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Sound.java
@@ -29,7 +29,7 @@ public enum Sound {
 
     public static Sound averageFrom(double score) {
         return Arrays.stream(values())
-                .filter(it -> it.score == (int) (score + 0.5))
+                .filter(it -> it.score == Math.round(score))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/mocacong/server/domain/cafedetail/Toilet.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Toilet.java
@@ -29,7 +29,7 @@ public enum Toilet {
 
     public static Toilet averageFrom(double score) {
         return Arrays.stream(values())
-                .filter(it -> it.score == (int) (score + 0.5))
+                .filter(it -> it.score == Math.round(score))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/mocacong/server/domain/cafedetail/Toilet.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Toilet.java
@@ -12,11 +12,12 @@ import mocacong.server.exception.badrequest.InvalidToiletException;
 @Getter
 public enum Toilet {
 
-    CLEAN("깨끗해요"),
-    NORMAL("평범해요"),
-    UNCOMFORTABLE("불편해요");
+    CLEAN("깨끗해요", 3),
+    NORMAL("평범해요", 2),
+    UNCOMFORTABLE("불편해요", 1);
 
     private String value;
+    private int score;
 
     public static Toilet from(String value) {
         if (value == null) return null;
@@ -24,5 +25,12 @@ public enum Toilet {
                 .filter(it -> Objects.equals(it.value, value))
                 .findFirst()
                 .orElseThrow(InvalidToiletException::new);
+    }
+
+    public static Toilet averageFrom(double score) {
+        return Arrays.stream(values())
+                .filter(it -> it.score == (int) (score + 0.5))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/mocacong/server/domain/cafedetail/Wifi.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Wifi.java
@@ -12,11 +12,12 @@ import mocacong.server.exception.badrequest.InvalidWifiException;
 @Getter
 public enum Wifi {
 
-    FAST("빵빵해요"),
-    NORMAL("적당해요"),
-    SLOW("느려요");
+    FAST("빵빵해요", 3),
+    NORMAL("적당해요", 2),
+    SLOW("느려요", 1);
 
     private String value;
+    private int score;
 
     public static Wifi from(String value) {
         if (value == null) return null;
@@ -24,5 +25,12 @@ public enum Wifi {
                 .filter(it -> Objects.equals(it.value, value))
                 .findFirst()
                 .orElseThrow(InvalidWifiException::new);
+    }
+
+    public static Wifi averageFrom(double score) {
+        return Arrays.stream(values())
+                .filter(it -> it.score == (int) (score + 0.5))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/mocacong/server/domain/cafedetail/Wifi.java
+++ b/src/main/java/mocacong/server/domain/cafedetail/Wifi.java
@@ -29,7 +29,7 @@ public enum Wifi {
 
     public static Wifi averageFrom(double score) {
         return Arrays.stream(values())
-                .filter(it -> it.score == (int) (score + 0.5))
+                .filter(it -> it.score == Math.round(score))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/test/java/mocacong/server/domain/CafeTest.java
+++ b/src/test/java/mocacong/server/domain/CafeTest.java
@@ -40,7 +40,7 @@ class CafeTest {
 
         CafeDetail cafeDetail1 = new CafeDetail(StudyType.SOLO, Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.COMFORTABLE, Power.MANY, Sound.LOUD);
         Review review1 = new Review(member, cafe, cafeDetail1);
-        CafeDetail cafeDetail2 = new CafeDetail(StudyType.GROUP, Wifi.NORMAL, Parking.COMFORTABLE, Toilet.NORMAL, Desk.UNCOMFORTABLE, Power.FEW, Sound.NOISY);
+        CafeDetail cafeDetail2 = new CafeDetail(StudyType.GROUP, Wifi.NORMAL, Parking.COMFORTABLE, Toilet.UNCOMFORTABLE, Desk.UNCOMFORTABLE, Power.FEW, Sound.LOUD);
         Review review2 = new Review(member, cafe, cafeDetail2);
         CafeDetail cafeDetail3 = new CafeDetail(StudyType.SOLO, Wifi.NORMAL, Parking.UNCOMFORTABLE, Toilet.NORMAL, Desk.COMFORTABLE, Power.FEW, Sound.LOUD);
         Review review3 = new Review(member, cafe, cafeDetail3);
@@ -56,7 +56,7 @@ class CafeTest {
                 () -> assertThat(actual.getWifi()).isEqualTo(Wifi.NORMAL),
                 () -> assertThat(actual.getParking()).isEqualTo(Parking.COMFORTABLE),
                 () -> assertThat(actual.getToilet()).isEqualTo(Toilet.NORMAL),
-                () -> assertThat(actual.getDesk()).isEqualTo(Desk.COMFORTABLE),
+                () -> assertThat(actual.getDesk()).isEqualTo(Desk.NORMAL),
                 () -> assertThat(actual.getPower()).isEqualTo(Power.FEW),
                 () -> assertThat(actual.getSound()).isEqualTo(Sound.LOUD)
         );


### PR DESCRIPTION
## 개요
- 기존에는 최대값에 해당되는 객체 반환이었어서 아래와 같은 상황이 연출됩니다.
  -  하나가 good(wifi 빵빵해요) 하나가 bad(wifi 느려요)이어도 soso(wifi 적당해요)가 아니라 둘 중 하나만 나옵니다.

## 작업사항
- 카페 세부정보 계산하는 로직을 최대값에 해당되는 객체 반환에서 점수제(반올림)로 변경했습니다.

## 주의사항
- 더 좋은 도메인 로직이 있다면 리뷰 부탁드립니다.
- null 관련하여 누락된 처리가 있는지 확인해주세요