### PR TITLE
feat: 리뷰 남긴 카페 목록 조회 GET API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -3,7 +3,6 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.EmailVerifyCodeRequest;
 import mocacong.server.dto.request.MemberProfileUpdateRequest;
@@ -17,6 +16,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -79,6 +80,18 @@ public class MemberController {
             @RequestParam("count") final int count
     ) {
         MyFavoriteCafesResponse response = cafeService.findMyFavoriteCafes(email, page, count);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "마이페이지 - 리뷰 남긴 카페 목록 조회")
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/mypage/reviews")
+    public ResponseEntity<MyReviewCafesResponse> findMyReviewCafes(
+            @LoginUserEmail String email,
+            @RequestParam("page") final Integer page,
+            @RequestParam("count") final int count
+    ) {
+        MyReviewCafesResponse response = cafeService.findMyReivewCafes(email, page, count);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -91,7 +91,7 @@ public class MemberController {
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count
     ) {
-        MyReviewCafesResponse response = cafeService.findMyReivewCafes(email, page, count);
+        MyReviewCafesResponse response = cafeService.findMyReviewCafes(email, page, count);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
@@ -1,0 +1,13 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class MyReviewCafeResponse {
+
+    private String name;
+    private double myScore;
+}

--- a/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
@@ -9,5 +9,5 @@ import lombok.*;
 public class MyReviewCafeResponse {
 
     private String name;
-    private double myScore;
+    private int myScore;
 }

--- a/src/main/java/mocacong/server/dto/response/MyReviewCafesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafesResponse.java
@@ -1,0 +1,15 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class MyReviewCafesResponse {
+
+    private int currentPage;
+    private List<MyReviewCafeResponse> cafes;
+}

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -2,7 +2,6 @@ package mocacong.server.repository;
 
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.cafedetail.StudyType;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,5 +26,5 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
             "join r.cafe c " +
             "join r.member m " +
             "where m.email = :email")
-    Slice<Cafe> findByMyReviewCafes(String email, PageRequest of);
+    Slice<Cafe> findByMyReviewCafes(String email, Pageable pageRequest);
 }

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -2,6 +2,7 @@ package mocacong.server.repository;
 
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.cafedetail.StudyType;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,10 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
             "join f.member m " +
             "where m.email = :email")
     Slice<Cafe> findByMyFavoriteCafes(String email, Pageable pageRequest);
+
+    @Query("select c from Review r " +
+            "join r.cafe c " +
+            "join r.member m " +
+            "where m.email = :email")
+    Slice<Cafe> findByMyReviewCafes(String email, PageRequest of);
 }

--- a/src/main/java/mocacong/server/repository/ScoreRepository.java
+++ b/src/main/java/mocacong/server/repository/ScoreRepository.java
@@ -1,12 +1,20 @@
 package mocacong.server.repository;
 
-import java.util.List;
-import java.util.Optional;
 import mocacong.server.domain.Score;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ScoreRepository extends JpaRepository<Score, Long> {
     Optional<Score> findByCafeIdAndMemberId(Long cafeId, Long memberId);
 
     List<Score> findAllByMemberId(Long memberId);
+
+    @Query("select s.score from Score s " +
+            "join s.cafe c " +
+            "join s.member m " +
+            "where c.id = :cafeId and m.id = :memberId")
+    int findScoreByCafeIdAndMemberId(Long cafeId, Long memberId);
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -26,7 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -134,9 +133,8 @@ public class CafeService {
                 .getContent()
                 .stream()
                 .map(cafe -> {
-                    Optional<Score> score = scoreRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId());
-                    double scoreValue = score.map(Score::getScore).orElse(0);
-                    return new MyReviewCafeResponse(cafe.getName(), scoreValue);
+                    int score = scoreRepository.findScoreByCafeIdAndMemberId(cafe.getId(), member.getId());
+                    return new MyReviewCafeResponse(cafe.getName(), score);
                 })
                 .collect(Collectors.toList());
         return new MyReviewCafesResponse(myReviewCafes.getNumber(), responses);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -126,7 +126,7 @@ public class CafeService {
     }
 
     @Transactional(readOnly = true)
-    public MyReviewCafesResponse findMyReivewCafes(String email, Integer page, int count) {
+    public MyReviewCafesResponse findMyReviewCafes(String email, Integer page, int count) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Cafe> myReviewCafes = cafeRepository.findByMyReviewCafes(email, PageRequest.of(page, count));

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -5,6 +5,7 @@ import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.ErrorResponse;
 import mocacong.server.dto.response.MyPageResponse;
+import mocacong.server.dto.response.MyReviewCafesResponse;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.support.AwsSESSender;
@@ -289,6 +290,46 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
+    }
+
+    @Test
+    @DisplayName("마이페이지에서 리뷰를 등록한 카페 목록을 조회한다")
+    void findMyReviewCafes() {
+        String mapId1 = "12332312";
+        String mapId2 = "12121212";
+        카페_등록(new CafeRegisterRequest(mapId1, "메리네 카페"));
+        카페_등록(new CafeRegisterRequest(mapId2, "케이네 카페"));
+        MemberSignUpRequest signUpRequest1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1111-1111");
+        회원_가입(signUpRequest1);
+        회원_가입(signUpRequest2);
+        String token1 = 로그인_토큰_발급(signUpRequest1.getEmail(), signUpRequest1.getPassword());
+        String token2 = 로그인_토큰_발급(signUpRequest2.getEmail(), signUpRequest2.getPassword());
+        CafeReviewRequest request1 = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
+                "깨끗해요", "충분해요", "조용해요", "편해요");
+        CafeReviewRequest request2 = new CafeReviewRequest(2, "solo", "빵빵해요", "여유로워요",
+                "깨끗해요", "충분해요", "조용해요", "편해요");
+        CafeReviewRequest request3 = new CafeReviewRequest(1, "group", "빵빵해요", "여유로워요",
+                "깨끗해요", "충분해요", "조용해요", "편해요");
+        카페_리뷰_작성(token1, mapId1, request1);
+        카페_리뷰_작성(token1, mapId2, request2);
+        카페_리뷰_작성(token2, mapId1, request3);
+
+        MyReviewCafesResponse actual = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token1)
+                .when().get("/members/mypage/reviews?page=0&count=20")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(MyReviewCafesResponse.class);
+
+        assertAll(
+                () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(4),
+                () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("메리네 카페"),
+                () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(2),
+                () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("케이네 카페")
+        );
     }
 
     @Test

--- a/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
@@ -1,16 +1,15 @@
 package mocacong.server.repository;
 
-import mocacong.server.domain.Cafe;
-import mocacong.server.domain.Favorite;
-import mocacong.server.domain.Member;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
+import mocacong.server.domain.*;
+import mocacong.server.domain.cafedetail.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @RepositoryTest
 class CafeRepositoryTest {
@@ -21,6 +20,8 @@ class CafeRepositoryTest {
     private MemberRepository memberRepository;
     @Autowired
     private FavoriteRepository favoriteRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @Test
     @DisplayName("내가 즐겨찾기에 등록한 카페 목록을 조회한다")
@@ -35,6 +36,32 @@ class CafeRepositoryTest {
         favoriteRepository.save(new Favorite(member, savedCafe3));
 
         Slice<Cafe> actual = cafeRepository.findByMyFavoriteCafes(member.getEmail(), PageRequest.of(1, 2));
+
+        assertAll(
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actual.getNumber()).isEqualTo(1),
+                () -> assertThat(actual.isLast()).isTrue(),
+                () -> assertThat(actual)
+                        .extracting("name")
+                        .containsExactly("케이카페3")
+        );
+    }
+
+    @Test
+    @DisplayName("내가 리뷰를 등록한 카페 목록을 조회한다")
+    void findByMyReviewCafes() {
+        Cafe savedCafe1 = cafeRepository.save(new Cafe("1", "케이카페1"));
+        Cafe savedCafe2 = cafeRepository.save(new Cafe("2", "케이카페2"));
+        Cafe savedCafe3 = cafeRepository.save(new Cafe("3", "케이카페3"));
+        Cafe savedCafe4 = cafeRepository.save(new Cafe("4", "케이카페4"));
+        CafeDetail cafeDetail = new CafeDetail(StudyType.BOTH, Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.NORMAL,
+                Power.NONE, Sound.LOUD);
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        reviewRepository.save(new Review(member, savedCafe1, cafeDetail));
+        reviewRepository.save(new Review(member, savedCafe2, cafeDetail));
+        reviewRepository.save(new Review(member, savedCafe3, cafeDetail));
+
+        Slice<Cafe> actual = cafeRepository.findByMyReviewCafes(member.getEmail(), PageRequest.of(1, 2));
 
         assertAll(
                 () -> assertThat(actual).hasSize(1),

--- a/src/test/java/mocacong/server/repository/ScoreRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/ScoreRepositoryTest.java
@@ -1,0 +1,35 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Member;
+import mocacong.server.domain.Score;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@RepositoryTest
+class ScoreRepositoryTest {
+
+    @Autowired
+    private ScoreRepository scoreRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("카페 id, 멤버 id로 해당 멤버가 특정 카페에 등록한 평점을 조회한다")
+    void findScoreByCafeIdAndMemberId() {
+        Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Score score = new Score(4, member, savedCafe);
+        scoreRepository.save(score);
+
+        int actual = scoreRepository.findScoreByCafeIdAndMemberId(savedCafe.getId(), member.getId());
+
+        assertThat(actual).isEqualTo(score.getScore());
+    }
+}

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -330,7 +330,7 @@ class CafeServiceTest {
                 new CafeReviewRequest(2, "group", "느려요", "없어요",
                         "깨끗해요", "없어요", null, "보통이에요"));
 
-        MyReviewCafesResponse actual = cafeService.findMyReivewCafes(member1.getEmail(), 0, 3);
+        MyReviewCafesResponse actual = cafeService.findMyReviewCafes(member1.getEmail(), 0, 3);
 
         assertAll(
                 () -> assertThat(actual.getCurrentPage()).isEqualTo(0),

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -337,7 +337,8 @@ class CafeServiceTest {
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("케이카페"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(5),
-                () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("메리카페")
+                () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("메리카페"),
+                () -> assertThat(actual.getCafes()).hasSize(2)
         );
     }
 

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -310,6 +310,30 @@ class CafeServiceTest {
     }
 
     @Test
+    @DisplayName("회원이 리뷰를 남긴 카페 목록들을 보여준다")
+    void findMyReviewCafes() {
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member1);
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        cafeService.saveCafeReview(member1.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(1, "group", "느려요", "없어요",
+                        "불편해요", "없어요", "북적북적해요", "불편해요"));
+        cafeService.saveCafeReview(member2.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(2, "group", "느려요", "없어요",
+                        "깨끗해요", "없어요", null, "보통이에요"));
+
+        MyReviewCafesResponse actual = cafeService.findMyReivewCafes(member1.getEmail(), 0, 3);
+
+        assertAll(
+                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1)
+        );
+    }
+
+    @Test
     @DisplayName("카페에 대한 리뷰를 작성하면 해당 카페 평점과 세부정보가 갱신된다")
     void saveCafeReview() {
         Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -316,12 +316,17 @@ class CafeServiceTest {
         memberRepository.save(member1);
         Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
         memberRepository.save(member2);
-        Cafe cafe = new Cafe("2143154352323", "케이카페");
-        cafeRepository.save(cafe);
-        cafeService.saveCafeReview(member1.getEmail(), cafe.getMapId(),
+        Cafe cafe1 = new Cafe("2143154352323", "케이카페");
+        Cafe cafe2 = new Cafe("2154122541112", "메리카페");
+        cafeRepository.save(cafe1);
+        cafeRepository.save(cafe2);
+        cafeService.saveCafeReview(member1.getEmail(), cafe1.getMapId(),
                 new CafeReviewRequest(1, "group", "느려요", "없어요",
                         "불편해요", "없어요", "북적북적해요", "불편해요"));
-        cafeService.saveCafeReview(member2.getEmail(), cafe.getMapId(),
+        cafeService.saveCafeReview(member1.getEmail(), cafe2.getMapId(),
+                new CafeReviewRequest(5, "group", "느려요", "없어요",
+                        "불편해요", "없어요", "북적북적해요", "불편해요"));
+        cafeService.saveCafeReview(member2.getEmail(), cafe1.getMapId(),
                 new CafeReviewRequest(2, "group", "느려요", "없어요",
                         "깨끗해요", "없어요", null, "보통이에요"));
 
@@ -329,7 +334,10 @@ class CafeServiceTest {
 
         assertAll(
                 () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
-                () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1)
+                () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1),
+                () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("케이카페"),
+                () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(5),
+                () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("메리카페")
         );
     }
 


### PR DESCRIPTION
## 개요
- 자신이 리뷰를 남긴 카페 목록을 조회하는 API를 구현했습니다.

## 작업사항
- 리뷰 남긴 카페 목록 조회 GET API 구현
- 리뷰 남긴 카페 목록 조회 테스트 코드 작성

## 주의사항
- API 스펙과 동일하게 구현되었는지 확인해주세요
- 누락된 테스트 코드가 있는지 확인해주세요
