### PR TITLE
feat: 사용하지 않는 이미지 배치 삭제 구현

### DIFF
--- a/src/main/java/mocacong/server/config/BatchConfig.java
+++ b/src/main/java/mocacong/server/config/BatchConfig.java
@@ -1,0 +1,23 @@
+package mocacong.server.config;
+
+import lombok.RequiredArgsConstructor;
+import mocacong.server.service.CafeService;
+import mocacong.server.service.MemberService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@EnableScheduling
+@Configuration
+@RequiredArgsConstructor
+public class BatchConfig {
+
+    private final CafeService cafeService;
+    private final MemberService memberService;
+
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    public void deleteNotUsedImages() {
+        memberService.deleteNotUsedProfileImages();
+        cafeService.deleteNotUsedCafeImages();
+    }
+}

--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -1,13 +1,12 @@
 package mocacong.server.domain;
 
+import java.util.regex.Pattern;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
 import mocacong.server.exception.badrequest.InvalidPhoneException;
-
-import javax.persistence.*;
-import java.util.regex.Pattern;
 
 @Entity
 @Table(name = "member")
@@ -35,8 +34,9 @@ public class Member extends BaseTime {
     @Column(name = "phone")
     private String phone;
 
-    @Column(name = "img_url")
-    private String imgUrl;
+    @OneToOne
+    @JoinColumn(name = "member_profile_image_id")
+    private MemberProfileImage memberProfileImage;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "platform")
@@ -46,7 +46,7 @@ public class Member extends BaseTime {
     private String platformId;
 
     public Member(
-            String email, String password, String nickname, String phone, String imgUrl,
+            String email, String password, String nickname, String phone, MemberProfileImage memberProfileImage,
             Platform platform, String platformId
     ) {
         validateMemberInfo(nickname, phone);
@@ -54,13 +54,21 @@ public class Member extends BaseTime {
         this.password = password;
         this.nickname = nickname;
         this.phone = phone;
-        this.imgUrl = imgUrl;
+        this.memberProfileImage = memberProfileImage;
         this.platform = platform;
         this.platformId = platformId;
     }
 
-    public Member(String email, String password, String nickname, String phone, String imgUrl) {
-        this(email, password, nickname, phone, imgUrl, Platform.MOCACONG, null);
+    public Member(String email, String password, String nickname, String phone, MemberProfileImage memberProfileImage) {
+        this(
+                email,
+                password,
+                nickname,
+                phone,
+                memberProfileImage,
+                Platform.MOCACONG,
+                null
+        );
     }
 
     public Member(String email, String password, String nickname, String phone) {
@@ -81,8 +89,19 @@ public class Member extends BaseTime {
         }
     }
 
-    public void updateProfileImgUrl(String imgUrl) {
-        this.imgUrl = imgUrl;
+    public String getImgUrl() {
+        return this.memberProfileImage != null ? this.memberProfileImage.getImgUrl() : null;
+    }
+
+    public void updateProfileImgUrl(MemberProfileImage memberProfileImage) {
+        updateBeforeProfileImageNotUsedStatus();
+        this.memberProfileImage = memberProfileImage;
+    }
+
+    private void updateBeforeProfileImageNotUsedStatus() {
+        if (this.memberProfileImage != null) {
+            this.memberProfileImage.updateNotUsedStatus();
+        }
     }
 
     public void updateProfileInfo(String nickname, String password, String phone) {

--- a/src/main/java/mocacong/server/domain/MemberProfileImage.java
+++ b/src/main/java/mocacong/server/domain/MemberProfileImage.java
@@ -1,0 +1,37 @@
+package mocacong.server.domain;
+
+import javax.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_profile_image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberProfileImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_profile_image_id")
+    private Long id;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(name = "is_used")
+    private Boolean isUsed;
+
+    public MemberProfileImage(String imgUrl, Boolean isUsed) {
+        this.imgUrl = imgUrl;
+        this.isUsed = isUsed;
+    }
+
+    public MemberProfileImage(String imgUrl) {
+        this(imgUrl, true);
+    }
+
+    public void updateNotUsedStatus() {
+        this.isUsed = false;
+    }
+}

--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -1,15 +1,15 @@
 package mocacong.server.repository;
 
+import java.util.List;
 import mocacong.server.domain.CafeImage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
-
 public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
     Slice<CafeImage> findAllByCafeIdAndIsUsedTrue(Long cafeId, Pageable pageRequest);
 
     List<CafeImage> findAllByCafeIdAndIsUsedTrue(Long cafeId);
+
+    List<CafeImage> findAllByIsUsedFalse();
 }

--- a/src/main/java/mocacong/server/repository/MemberProfileImageRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberProfileImageRepository.java
@@ -1,7 +1,10 @@
 package mocacong.server.repository;
 
+import java.util.List;
 import mocacong.server.domain.MemberProfileImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberProfileImageRepository extends JpaRepository<MemberProfileImage, Long> {
+
+    List<MemberProfileImage> findAllByIsUsedFalse();
 }

--- a/src/main/java/mocacong/server/repository/MemberProfileImageRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberProfileImageRepository.java
@@ -1,0 +1,7 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.MemberProfileImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberProfileImageRepository extends JpaRepository<MemberProfileImage, Long> {
+}

--- a/src/main/java/mocacong/server/service/event/DeleteNotUsedImagesEvent.java
+++ b/src/main/java/mocacong/server/service/event/DeleteNotUsedImagesEvent.java
@@ -1,0 +1,12 @@
+package mocacong.server.service.event;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DeleteNotUsedImagesEvent {
+
+    private final List<String> imgUrls;
+}

--- a/src/main/java/mocacong/server/support/AwsS3Uploader.java
+++ b/src/main/java/mocacong/server/support/AwsS3Uploader.java
@@ -1,10 +1,7 @@
 package mocacong.server.support;
 
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -54,10 +51,11 @@ public class AwsS3Uploader {
         List<String> imgUrls = event.getImgUrls();
         List<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
         for (String imgUrl : imgUrls) {
-            String fileName = imgUrl.substring(imgUrl.lastIndexOf(".") + 1);
+            String fileName = S3_BUCKET_DIRECTORY_NAME + imgUrl.substring(imgUrl.lastIndexOf("/"));
             keys.add(new DeleteObjectsRequest.KeyVersion(fileName));
         }
         DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket).withKeys(keys);
-        amazonS3Client.deleteObjects(deleteObjectsRequest);
+        DeleteObjectsResult result = amazonS3Client.deleteObjects(deleteObjectsRequest);
+        log.info("Failed Delete Object Counts = {}", imgUrls.size() - result.getDeletedObjects().size());
     }
 }

--- a/src/test/java/mocacong/server/domain/CommentTest.java
+++ b/src/test/java/mocacong/server/domain/CommentTest.java
@@ -39,7 +39,7 @@ class CommentTest {
     @Test
     @DisplayName("댓글 작성자 프로필 이미지 url을 반환한다")
     void getWriterImgUrl() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678", "test_img.jpg");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678", new MemberProfileImage("test_img.jpg"));
         Cafe cafe = new Cafe("1", "케이카페");
         Comment comment = new Comment(cafe, member, "안녕하세요");
 

--- a/src/test/java/mocacong/server/domain/MemberTest.java
+++ b/src/test/java/mocacong/server/domain/MemberTest.java
@@ -87,4 +87,41 @@ class MemberTest {
         assertThatThrownBy(() -> new Member("kth990303@naver.com", "a1b2c3d4", "케이", phone))
                 .isInstanceOf(InvalidPhoneException.class);
     }
+
+    @Test
+    @DisplayName("회원의 프로필 이미지가 존재하면 해당 이미지 url을 올바르게 반환한다")
+    void getImgUrlWhenHasImage() {
+        String expected = "test_img.jpg";
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678", new MemberProfileImage(expected));
+
+        String actual = member.getImgUrl();
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("회원의 프로필 이미지가 존재하지 않으면 해당 이미지 url 반환은 null을 반환한다")
+    void getImgUrlWhenHasNotImage() {
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+
+        String actual = member.getImgUrl();
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    @DisplayName("회원 프로필 이미지를 변경하면 변경 전 이미지 사용여부는 false, 프로필 이미지는 올바르게 변경된다")
+    void updateProfileImgUrl() {
+        String expected = "test_img.jpg";
+        MemberProfileImage memberProfileImage = new MemberProfileImage("before.jpg");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678",
+                memberProfileImage, Platform.MOCACONG, "1234");
+
+        member.updateProfileImgUrl(new MemberProfileImage(expected));
+
+        assertAll(
+                () -> assertThat(member.getImgUrl()).isEqualTo(expected),
+                () -> assertThat(memberProfileImage.getIsUsed()).isFalse()
+        );
+    }
 }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import static java.lang.Integer.parseInt;
 import java.util.List;
 import mocacong.server.domain.Member;
+import mocacong.server.domain.MemberProfileImage;
 import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.MemberProfileUpdateRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
@@ -12,6 +13,7 @@ import mocacong.server.dto.request.OAuthMemberSignUpRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.*;
 import mocacong.server.exception.notfound.NotFoundMemberException;
+import mocacong.server.repository.MemberProfileImageRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.support.AwsS3Uploader;
 import mocacong.server.support.AwsSESSender;
@@ -32,6 +34,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @ServiceTest
 class MemberServiceTest {
 
+    @Autowired
+    private MemberProfileImageRepository memberProfileImageRepository;
     @Autowired
     private MemberRepository memberRepository;
     @Autowired
@@ -229,7 +233,10 @@ class MemberServiceTest {
     void findMyInfo() {
         String imgUrl = "test_img.jpg";
         String nickname = "케이";
-        Member member = new Member("kth990303@naver.com", "a1b2c3d4", nickname, "010-1234-5678", imgUrl);
+        MemberProfileImage memberProfileImage = new MemberProfileImage(imgUrl);
+        memberProfileImageRepository.save(memberProfileImage);
+        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678",
+                memberProfileImage, Platform.MOCACONG, "1234");
         memberRepository.save(member);
 
         MyPageResponse actual = memberService.findMyInfo(member.getEmail());
@@ -253,21 +260,32 @@ class MemberServiceTest {
 
         Member actual = memberRepository.findByEmail(member.getEmail())
                 .orElseThrow();
-        assertThat(actual.getImgUrl()).isEqualTo(expected);
+
+        assertAll(
+                () -> assertThat(actual.getImgUrl()).isEqualTo(expected),
+                () -> assertThat(actual.getMemberProfileImage().getIsUsed()).isTrue()
+        );
     }
 
     @Test
     @DisplayName("회원이 프로필 이미지를 삭제하거나 null로 설정하면 프로필 이미지는 null로 설정된다")
     void updateProfileImgWithNull() {
+        MemberProfileImage memberProfileImage = new MemberProfileImage("test.me.jpg");
+        memberProfileImageRepository.save(memberProfileImage);
         Member member = memberRepository.save(
-                new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678", "test.me.jpg")
+                new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678",
+                        memberProfileImage, Platform.MOCACONG, "1234")
         );
 
         memberService.updateProfileImage(member.getEmail(), null);
 
         Member actual = memberRepository.findByEmail(member.getEmail())
                 .orElseThrow();
-        assertThat(actual.getImgUrl()).isNull();
+
+        assertAll(
+                () -> assertThat(actual.getImgUrl()).isNull(),
+                () -> assertThat(actual.getMemberProfileImage()).isNull()
+        );
     }
 
     @Test


### PR DESCRIPTION
## 개요
- 기존 로직대로라면 사용하지 않는 회원 이미지, 카페 이미지들이 s3 버킷 및 DB에 그대로 남아있어 용량 부족이 우려되는 상황이었습니다.

## 작업사항
- 매일 오전 4시, 사용자가 가장 적을 것으로 예상되는 시간에 `@Scheduler` cron을 이용하여 s3 버킷의 안쓰는 오브젝트들을 삭제하는 로직을 구현했습니다.
  - s3 버킷 객체를 지워주는 작업은 응답을 받을 필요가 없어 비동기로 처리하도록 구현했습니다. 

## 주의사항
- swagger에 임시 api를 만들어서 테스트해본 결과 성공적으로 삭제됨을 확인했습니다. `@Scheduler` cron 식이 올바른지 확인해주시면 될 것 같습니다.
- 오브젝트들이 삭제될 시점은, 최소한 `사용자가 이미지 수정을 한 이후`이기 때문에, 별도의 동시성 이슈는 없으리라 판단하여 트랜잭션 격리 레벨이나 락을 건드리지 않았습니다. 제가 놓친 동시성 이슈가 있는지 확인 부탁드립니다. 
