### PR TITLE
feat: 작성 코멘트 목록 조회 GET API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -3,7 +3,6 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.EmailVerifyCodeRequest;
 import mocacong.server.dto.request.MemberProfileUpdateRequest;
@@ -17,6 +16,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -79,6 +80,18 @@ public class MemberController {
             @RequestParam("count") final int count
     ) {
         MyFavoriteCafesResponse response = cafeService.findMyFavoriteCafes(email, page, count);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "마이페이지 - 코멘트 목록 조회")
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/mypage/comments")
+    public ResponseEntity<MyCommentCafesResponse> findMyComments(
+            @LoginUserEmail String email,
+            @RequestParam("page") final Integer page,
+            @RequestParam("count") final int count
+    ) {
+        MyCommentCafesResponse response = cafeService.findMyCommentCafes(email, page, count);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
@@ -1,0 +1,13 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class MyCommentCafeResponse {
+
+    private String name;
+    private String comment;
+}

--- a/src/main/java/mocacong/server/dto/response/MyCommentCafesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyCommentCafesResponse.java
@@ -1,0 +1,15 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class MyCommentCafesResponse {
+
+    private int currentPage;
+    private List<MyCommentCafeResponse> cafes;
+}

--- a/src/main/java/mocacong/server/repository/CommentRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentRepository.java
@@ -11,6 +11,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByMemberId(Long memberId);
 
+    Slice<Comment> findByMemberId(Long memberId, Pageable pageRequest);
+
     Slice<Comment> findAllByCafeId(Long cafeId, Pageable pageRequest);
 
     Slice<Comment> findAllByCafeIdAndMemberId(Long cafeId, Long memberId, Pageable pageRequest);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -39,6 +39,7 @@ public class CafeService {
     private final CafeRepository cafeRepository;
     private final MemberRepository memberRepository;
     private final ScoreRepository scoreRepository;
+    private final CommentRepository commentRepository;
     private final ReviewRepository reviewRepository;
     private final FavoriteRepository favoriteRepository;
     private final CafeImageRepository cafeImageRepository;
@@ -122,6 +123,22 @@ public class CafeService {
                 .map(cafe -> new MyFavoriteCafeResponse(cafe.getName(), cafe.findAverageScore()))
                 .collect(Collectors.toList());
         return new MyFavoriteCafesResponse(myFavoriteCafes.getNumber(), responses);
+    }
+
+    @Transactional(readOnly = true)
+    public MyCommentCafesResponse findMyCommentCafes(String email, int page, int count) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Slice<Comment> comments = commentRepository.findByMemberId(member.getId(), PageRequest.of(page, count));
+
+        List<MyCommentCafeResponse> responses = comments.stream()
+                .map(comment -> new MyCommentCafeResponse(
+                        comment.getCafe().getName(),
+                        comment.getContent()
+                ))
+                .collect(Collectors.toList());
+
+        return new MyCommentCafesResponse(comments.getNumber(), responses);
     }
 
     @Transactional

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -137,7 +137,6 @@ public class CafeService {
                         comment.getContent()
                 ))
                 .collect(Collectors.toList());
-
         return new MyCommentCafesResponse(comments.getNumber(), responses);
     }
 

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -310,6 +310,33 @@ class CafeServiceTest {
     }
 
     @Test
+    @DisplayName("회원이 댓글을 작성한 카페 목록들을 보여준다")
+    void findMyCommentCafes() {
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member1);
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        memberRepository.save(member2);
+        Cafe cafe1 = new Cafe("2143154352323", "케이카페");
+        Cafe cafe2 = new Cafe("1212121212121", "메리카페");
+        cafeRepository.save(cafe1);
+        cafeRepository.save(cafe2);
+        commentRepository.save(new Comment(cafe1, member1, "댓글1"));
+        commentRepository.save(new Comment(cafe1, member1, "댓글2"));
+        commentRepository.save(new Comment(cafe2, member1, "댓글3"));
+        commentRepository.save(new Comment(cafe2, member2, "댓글4"));
+
+        MyCommentCafesResponse actual = cafeService.findMyCommentCafes(member1.getEmail(), 0, 5);
+
+        assertAll(
+                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getCafes()).hasSize(3),
+                () -> assertThat(actual.getCafes().get(0).getComment()).isEqualTo("댓글1"),
+                () -> assertThat(actual.getCafes().get(1).getComment()).isEqualTo("댓글2"),
+                () -> assertThat(actual.getCafes().get(2).getComment()).isEqualTo("댓글3")
+        );
+    }
+
+    @Test
     @DisplayName("카페에 대한 리뷰를 작성하면 해당 카페 평점과 세부정보가 갱신된다")
     void saveCafeReview() {
         Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");


### PR DESCRIPTION
## 개요
- 마이페이지에서 자신이 작성한 코멘트 목록을 조회하는 API를 구현했습니다.

## 작업사항
- 작성 코멘트 목록 조회 GET API 구현
- 작성 코멘트 목록 조회 테스트 코드 작성

## 주의사항
- api spec과 동일하게 구현되었는지 확인해주세요
- 스웨거로 동작 확인해주세요
- 누락된 테스트가 있는지 확인해주세요
