### PR TITLE
feat: 카페 코멘트 삭제 DELETE API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CommentController.java
+++ b/src/main/java/mocacong/server/controller/CommentController.java
@@ -71,4 +71,16 @@ public class CommentController {
         commentService.update(email, mapId, request.getContent(), commentId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "카페 코멘트 삭제")
+    @SecurityRequirement(name = "JWT")
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @LoginUserEmail String email,
+            @PathVariable String mapId,
+            @PathVariable Long commentId
+    ) {
+        commentService.delete(email, mapId, commentId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidCommentDeleteException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidCommentDeleteException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class InvalidCommentDeleteException extends BadRequestException {
+
+    public InvalidCommentDeleteException() {
+        super("코멘트 삭제는 작성자만 가능합니다.", 4005);
+    }
+}

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -7,6 +7,7 @@ import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentResponse;
 import mocacong.server.dto.response.CommentSaveResponse;
 import mocacong.server.dto.response.CommentsResponse;
+import mocacong.server.exception.badrequest.InvalidCommentDeleteException;
 import mocacong.server.exception.badrequest.InvalidCommentUpdateException;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
@@ -105,10 +106,13 @@ public class CommentService {
                 .filter(c -> c.getId().equals(commentId))
                 .findFirst()
                 .orElseThrow(NotFoundCommentException::new);
+
         if (!comment.isWrittenByMember(member)) {
-            throw new InvalidCommentUpdateException();
+            throw new InvalidCommentDeleteException();
         }
+        commentRepository.delete(comment);
     }
+
     @EventListener
     public void updateCommentWhenMemberDelete(MemberEvent event) {
         Member member = event.getMember();

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -95,6 +95,20 @@ public class CommentService {
         comment.updateComment(content);
     }
 
+    @Transactional
+    public void delete(String email, String mapId, Long commentId) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Comment comment = cafe.getComments().stream()
+                .filter(c -> c.getId().equals(commentId))
+                .findFirst()
+                .orElseThrow(NotFoundCommentException::new);
+        if (!comment.isWrittenByMember(member)) {
+            throw new InvalidCommentUpdateException();
+        }
+    }
     @EventListener
     public void updateCommentWhenMemberDelete(MemberEvent event) {
         Member member = event.getMember();

--- a/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
+++ b/src/test/java/mocacong/server/acceptance/AcceptanceFixtures.java
@@ -95,6 +95,16 @@ public class AcceptanceFixtures {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 카페_코멘트_삭제(String token, String mapId, Long commentId) {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().delete("/cafes/" + mapId + "/comments/" + commentId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 즐겨찾기_등록(String token, String mapId) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
@@ -3,8 +3,6 @@ package mocacong.server.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.List;
-import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import mocacong.server.dto.request.CafeRegisterRequest;
 import mocacong.server.dto.request.CommentSaveRequest;
 import mocacong.server.dto.request.CommentUpdateRequest;
@@ -13,13 +11,17 @@ import mocacong.server.dto.response.CommentResponse;
 import mocacong.server.dto.response.CommentSaveResponse;
 import mocacong.server.dto.response.CommentsResponse;
 import mocacong.server.dto.response.FindCafeResponse;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommentAcceptanceTest extends AcceptanceTest {
 
@@ -130,5 +132,33 @@ public class CommentAcceptanceTest extends AcceptanceTest {
                 () -> assertEquals(1, comments.size()),
                 () -> assertEquals(expected, comments.get(0).getContent())
         );
+    }
+
+    @Test
+    @DisplayName("카페에 작성한 코멘트를 삭제한다")
+    void deleteComment() {
+        String content = "공부하기 좋아요~🥰";
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
+
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        CommentSaveRequest saveRequest = new CommentSaveRequest(content);
+        ExtractableResponse<Response> response = 카페_코멘트_작성(token, mapId, saveRequest);
+        Long commentId = response.as(CommentSaveResponse.class).getId();
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().delete("/cafes/" + mapId + "/comments/" + commentId)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+        List<CommentResponse> comments = 카페_조회(token, mapId)
+                .as(FindCafeResponse.class)
+                .getComments();
+
+        assertThat(comments.size()).isEqualTo(0);
     }
 }

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -198,8 +198,8 @@ class CommentServiceTest {
         CommentSaveResponse response = commentService.save(email, mapId, "공부하기 좋아요~🥰");
 
         commentService.delete(email, mapId, response.getId());
-
         CommentsResponse actual = commentService.findAll(email, mapId, 0, 3);
+
         assertThat(actual.getComments()).hasSize(0);
     }
 

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -5,19 +5,20 @@ import mocacong.server.domain.Comment;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentSaveResponse;
 import mocacong.server.dto.response.CommentsResponse;
+import mocacong.server.exception.badrequest.InvalidCommentDeleteException;
 import mocacong.server.exception.badrequest.InvalidCommentUpdateException;
 import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ServiceTest
 class CommentServiceTest {
@@ -183,5 +184,54 @@ class CommentServiceTest {
 
         assertThatThrownBy(() -> commentService.update(email2, mapId, "몰래 이 코멘트를 바꿔", savedComment.getId()))
                 .isInstanceOf(InvalidCommentUpdateException.class);
+    }
+
+    @Test
+    @DisplayName("사용자가 작성한 댓글을 삭제할 수 있다")
+    void delete() {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        CommentSaveResponse response = commentService.save(email, mapId, "공부하기 좋아요~🥰");
+
+        commentService.delete(email, mapId, response.getId());
+
+        CommentsResponse actual = commentService.findAll(email, mapId, 0, 3);
+        assertThat(actual.getComments()).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 삭제를 시도할 시 예외를 반환한다")
+    void deleteNotExistsComment() {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+
+        assertThatThrownBy(() -> commentService.delete(email, mapId, 9999L))
+                .isInstanceOf(NotFoundCommentException.class);
+    }
+
+    @Test
+    @DisplayName("타 사용자가 작성한 댓글 삭제를 시도할 시 예외를 반환한다")
+    void deleteNotMyComment() {
+        String email1 = "kth990303@naver.com";
+        String email2 = "dlawotn3@naver.com";
+        String mapId = "2143154352323";
+        Member member1 = new Member(email1, "encodePassword", "케이", "010-1234-5678");
+        Member member2 = new Member(email2, "encodePassword", "메리", "010-1234-5678");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        CommentSaveResponse response = commentService.save(email1, mapId, "공부하기 좋아요~🥰");
+
+        assertThatThrownBy(() -> commentService.delete(email2, mapId, response.getId()))
+                .isInstanceOf(InvalidCommentDeleteException.class);
     }
 }


### PR DESCRIPTION
## 개요
- 카페 코멘트 삭제 DELETE API를 구현했습니다.

## 작업사항
- 카페 코멘트 삭제 DELETE API 구현
- 카페 코멘트 삭제 테스트 코드 작성

## 주의사항
- api 스펙과 동일한지 확인해주세요
- 누락된 테스트가 있는지 확인해주세요
