### PR TITLE
feat: 에러 발생 시 슬랙 알람을 비동기로 보내도록 구현

### DIFF
--- a/src/main/java/mocacong/server/support/SlackAlarmGenerator.java
+++ b/src/main/java/mocacong/server/support/SlackAlarmGenerator.java
@@ -1,0 +1,62 @@
+package mocacong.server.support;
+
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import static com.slack.api.webhook.WebhookPayloads.payload;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SlackAlarmGenerator {
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+
+    @Async
+    public void sendSlackAlertErrorLog(Exception e, HttpServletRequest request) {
+        try {
+            slackClient.send(webhookUrl, payload(p -> p
+                    .text("서버 에러 발생! 백엔드 측의 빠른 확인 요망")
+                    .attachments(
+                            List.of(generateSlackAttachment(e, request))
+                    )
+            ));
+        } catch (IOException slackError) {
+            log.error("Slack 통신과의 예외 발생");
+        }
+    }
+
+    private Attachment generateSlackAttachment(Exception e, HttpServletRequest request) {
+        String requestTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        String xffHeader = request.getHeader("X-FORWARDED-FOR");
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + " 발생 에러 로그")
+                .fields(List.of(
+                                generateSlackField("Request IP", xffHeader == null ? request.getRemoteAddr() : xffHeader),
+                                generateSlackField("Request URL", request.getRequestURL() + " " + request.getMethod()),
+                                generateSlackField("Error Message", e.getMessage())
+                        )
+                )
+                .build();
+    }
+
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요
- 에러 발생 시 슬랙 알람이 비동기가 아닌 동기로 작동하여 발생하고 있었습니다.
  - 여러 사용자가 에러를 동시다발적으로 겪을 때 슬랙 알람 작업으로 인해 서버가 다운될 수 있습니다. 

## 작업사항
- 슬랙 알람을 비동기로 구현했습니다. `@Async`는 AOP여서 private method에 작성하지 못하므로 슬랙 알람 클래스를 별도 분리했습니다. 오히려 책임 분리를 통해 코드가 깔끔해진 듯하네요.

## 주의사항
- 에러 발생 시 슬랙에 알림이 잘 가는지 테스트해주세요. (실제 슬랙 채널에 테스트보내도 괜찮습니다.)
