### PR TITLE
feat: 개발 서버와 운영 서버 분리

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,78 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${RDS_URL}
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        create_empty_composites:
+          enabled: true
+        show_sql: true
+        format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
+  task:
+    execution:
+      pool:
+        core-size: ${THREAD_POOL_CORE_SIZE}
+        max-size: ${THREAD_POOL_MAX_SIZE}
+        queue-capacity: ${THREAD_POOL_QUEUE_CAPACITY}
+
+security.jwt.token:
+  secret-key: ${JWT_SECRET_KEY}
+  expire-length: ${JWT_EXPIRE_LENGTH}
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    region:
+      static: ${S3_REGION}
+    stack:
+      auto: false
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+
+aws:
+  ses:
+    access-key: ${SES_ACCESS_KEY}
+    secret-key: ${SES_SECRET_KEY}
+
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}
+
+oauth:
+  apple:
+    iss: https://appleid.apple.com
+    client-id: ${OAUTH_APPLE_CLIENT_ID}
+    nonce: ${OAUTH_APPLE_NONCE}
+  kakao:
+    client-id: ${OAUTH_KAKAO_CLIENT_ID}
+    client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
+    redirect-uri: ${OAUTH_KAKAO_REDIRECT_URI}
+
+feign:
+  client:
+    config:
+      apple-public-key-client:
+        connectTimeout: 5000
+        readTimeout: 3000

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%C.%M:%line] - %msg%n"/>
 
-    <springProfile name="!prod">
+    <springProfile name="default">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                 <layout class="mocacong.server.support.logging.MaskingPatternLayout">
@@ -27,8 +27,8 @@
         </root>
     </springProfile>
 
-    <springProfile name="prod">
-        <!-- 운영 환경에서는 로그를 파일로 저장 -->
+    <springProfile name="!default">
+        <!-- 개발 환경과 운영 환경에서는 로그를 파일로 저장 -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PATH}/mocacong-${BY_DATE}.log</file>
             <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">


### PR DESCRIPTION
## 개요
- 기존에는 운영 서버가 개발 서버 역할을 했습니다.
  - 테스트를 실제 운영되고 있는 서버에 직접 해야 했습니다. 따라서 불필요한 알림이 전송됐었고, 서버 트래픽도 테스트와 실제 환경이 같이 감당했어야 했습니다.

## 작업사항
- 개발 서버와 운영 서버를 분리했습니다. (subnet, ec2, rds, s3 버킷 생성)
- 아직 실제 앱 배포를 하지 않은 상태이기 때문에 CD(지속적 배포) 자동화 스크립트는 건드리지 않았습니다. 따라서 develop 브랜치에 머지가 되면 운영 서버도 develop 브랜치 코드를, 개발 서버는 수동으로 `run.sh`를 돌려야 develop 브랜치 코드를 가지게 했습니다. 단, DB는 개발 서버와 운영 서버가 분리돼있습니다. 따라서 데이터는 공유하지 않습니다. 
  - 실제 앱 배포가 이루어지면 운영서버는 main 브랜치, 개발 서버는 develop 브랜치 코드를 가지도록 변경 필수
- 해당 PR이 머지가 되면 개발 DB에 더미 데이터를 많이 넣어둘 예정입니다. 

## 주의사항
- aws 궁금한 세부적인 사항(가용 영역, IP 등)은 보안 관련 내용이므로 DM으로 부탁드립니다.
- 개발 서버는 별도의 도커 자동 배포를 설정하지 않았습니다. (docker hub private registry는 1개까지만 무료) 따라서 개발 서버 ec2에 기존처럼 `run.sh`를 만들어놓았습니다. 
  - 하지만 **해당 PR이 머지되기 전에 `run.sh`를 실행하면 안됩니다**. 해당 PR 머지 전에는 스크립트 수행 시 `application-dev.yml` 이 없어서 `application.yml`이 수행될 것이며, `ddl-auto: create-drop`이 발생해 DB가 롤백될 수 있습니다. (다행히 개발 서버 DB에 데이터가 하나도 없긴 합니다만, 그래도 혹시 모르니)
- 누락된 변경이 있으면 리뷰 부탁드립니다.
