### PR TITLE
feat: 비밀번호 확인 인증 POST API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -104,7 +104,7 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "프로필 이미지 수정")
+    @Operation(summary = "마이페이지 - 프로필 이미지 수정")
     @SecurityRequirement(name = "JWT")
     @PutMapping(value = "/mypage/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> updateProfileImage(
@@ -133,7 +133,7 @@ public class MemberController {
             @LoginUserEmail String email,
             @RequestBody @Valid PasswordVerifyRequest request
     ) {
-        PasswordVerifyResponse response = memberService.verifyPassword(email, request.getPassword());
+        PasswordVerifyResponse response = memberService.verifyPassword(email, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import mocacong.server.dto.request.EmailVerifyCodeRequest;
-import mocacong.server.dto.request.MemberProfileUpdateRequest;
-import mocacong.server.dto.request.MemberSignUpRequest;
-import mocacong.server.dto.request.OAuthMemberSignUpRequest;
+import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.CafeService;
@@ -127,6 +124,17 @@ public class MemberController {
     ) {
         memberService.updateProfileInfo(email, request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비밀번호 확인 인증")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping("/info/password")
+    public ResponseEntity<PasswordVerifyResponse> passwordVerify(
+            @LoginUserEmail String email,
+            @RequestBody @Valid PasswordVerifyRequest request
+    ) {
+        PasswordVerifyResponse response = memberService.verifyPassword(email, request.getPassword());
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "회원탈퇴")

--- a/src/main/java/mocacong/server/dto/request/PasswordVerifyRequest.java
+++ b/src/main/java/mocacong/server/dto/request/PasswordVerifyRequest.java
@@ -1,0 +1,14 @@
+package mocacong.server.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class PasswordVerifyRequest {
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String password;
+}

--- a/src/main/java/mocacong/server/dto/response/PasswordVerifyResponse.java
+++ b/src/main/java/mocacong/server/dto/response/PasswordVerifyResponse.java
@@ -1,0 +1,11 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class PasswordVerifyResponse {
+    private Boolean isSuccess;
+}

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -7,6 +7,7 @@ import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.MemberProfileUpdateRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.request.OAuthMemberSignUpRequest;
+import mocacong.server.dto.request.PasswordVerifyRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.*;
 import mocacong.server.exception.notfound.NotFoundMemberException;
@@ -184,11 +185,11 @@ public class MemberService {
         memberProfileImageRepository.deleteAllByIdInBatch(ids);
     }
 
-    public PasswordVerifyResponse verifyPassword(String email, String password) {
+    public PasswordVerifyResponse verifyPassword(String email, PasswordVerifyRequest request) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         String storedPassword = member.getPassword();
-        String encodedPassword = passwordEncoder.encode(password);
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
         Boolean isSuccess = storedPassword.equals(encodedPassword);
 
         return new PasswordVerifyResponse(isSuccess);

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -1,10 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.MemberProfileImage;
@@ -26,6 +21,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -181,5 +182,15 @@ public class MemberService {
                 .map(MemberProfileImage::getId)
                 .collect(Collectors.toList());
         memberProfileImageRepository.deleteAllByIdInBatch(ids);
+    }
+
+    public PasswordVerifyResponse verifyPassword(String email, String password) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        String storedPassword = member.getPassword();
+        String encodedPassword = passwordEncoder.encode(password);
+        Boolean isSuccess = storedPassword.equals(encodedPassword);
+
+        return new PasswordVerifyResponse(isSuccess);
     }
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -3,10 +3,7 @@ package mocacong.server.acceptance;
 import io.restassured.RestAssured;
 import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.*;
-import mocacong.server.dto.response.ErrorResponse;
-import mocacong.server.dto.response.MyCommentCafesResponse;
-import mocacong.server.dto.response.MyPageResponse;
-import mocacong.server.dto.response.MyReviewCafesResponse;
+import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.support.AwsSESSender;
@@ -388,5 +385,47 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(actual.getNickname()).isEqualTo("메리"),
                 () -> assertThat(로그인_토큰_발급(memberSignUpRequest.getEmail(), newPassword)).isNotNull()
         );
+    }
+
+    @Test
+    @DisplayName("회원이 옳은 비밀번호로 비밀번호 인증한다")
+    void verifyPasswordWithTrue() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(memberSignUpRequest);
+        String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
+        PasswordVerifyRequest request = new PasswordVerifyRequest("a1b2c3d4");
+
+        PasswordVerifyResponse actual = RestAssured.given().log().all()
+                .auth().oauth2(token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/members/info/password")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(PasswordVerifyResponse.class);
+
+        assertThat(actual.getIsSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("회원이 잘못된 비밀번호로 비밀번호 인증한다")
+    void verifyPasswordWithFalse() {
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(memberSignUpRequest);
+        String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
+        PasswordVerifyRequest request = new PasswordVerifyRequest("wrongpwd123");
+
+        PasswordVerifyResponse actual = RestAssured.given().log().all()
+                .auth().oauth2(token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when().post("/members/info/password")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(PasswordVerifyResponse.class);
+
+        assertThat(actual.getIsSuccess()).isFalse();
     }
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -409,7 +409,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("회원이 잘못된 비밀번호로 비밀번호 인증한다")
+    @DisplayName("회원이 틀린 비밀번호로 비밀번호 인증한다")
     void verifyPasswordWithFalse() {
         MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
         회원_가입(memberSignUpRequest);

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -408,7 +408,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("회원이 정상 비밀번호로 비밀번호 확인 인증을 성공한다")
+    @DisplayName("회원이 옳은 비밀번호로 비밀번호 확인 인증을 성공한다")
     void verifyPasswordReturnTrue() {
         String email = "dlawotn3@naver.com";
         String password = "jisu1234";

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -6,6 +6,7 @@ import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.MemberProfileUpdateRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.request.OAuthMemberSignUpRequest;
+import mocacong.server.dto.request.PasswordVerifyRequest;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.*;
 import mocacong.server.exception.notfound.NotFoundMemberException;
@@ -416,8 +417,9 @@ class MemberServiceTest {
         String phone = "010-1111-1111";
         Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
         memberRepository.save(member);
+        PasswordVerifyRequest request = new PasswordVerifyRequest("jisu1234");
 
-        PasswordVerifyResponse actual = memberService.verifyPassword(email, password);
+        PasswordVerifyResponse actual = memberService.verifyPassword(email, request);
 
         assertThat(actual.getIsSuccess()).isTrue();
     }
@@ -431,8 +433,9 @@ class MemberServiceTest {
         String phone = "010-1111-1111";
         Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
         memberRepository.save(member);
+        PasswordVerifyRequest request = new PasswordVerifyRequest("wrongpwd123");
 
-        PasswordVerifyResponse actual = memberService.verifyPassword(email, "wrongpwd123");
+        PasswordVerifyResponse actual = memberService.verifyPassword(email, request);
 
         assertThat(actual.getIsSuccess()).isFalse();
     }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import static java.lang.Integer.parseInt;
-import java.util.List;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.MemberProfileImage;
 import mocacong.server.domain.Platform;
@@ -18,19 +14,25 @@ import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
 import mocacong.server.support.AwsSESSender;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static java.lang.Integer.parseInt;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ServiceTest
 class MemberServiceTest {
@@ -403,5 +405,35 @@ class MemberServiceTest {
                 () -> assertThat(actual).extracting("imgUrl")
                         .containsExactlyInAnyOrder("test_img.jpg")
         );
+    }
+
+    @Test
+    @DisplayName("회원이 정상 비밀번호로 비밀번호 확인 인증을 성공한다")
+    void verifyPasswordReturnTrue() {
+        String email = "dlawotn3@naver.com";
+        String password = "jisu1234";
+        String nickname = "mery";
+        String phone = "010-1111-1111";
+        Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
+        memberRepository.save(member);
+
+        PasswordVerifyResponse actual = memberService.verifyPassword(email, password);
+
+        assertThat(actual.getIsSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("회원이 틀린 비밀번호로 비밀번호 확인 인증을 실패한다")
+    void verifyPasswordReturnFalse() {
+        String email = "dlawotn3@naver.com";
+        String password = "jisu1234";
+        String nickname = "mery";
+        String phone = "010-1111-1111";
+        Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
+        memberRepository.save(member);
+
+        PasswordVerifyResponse actual = memberService.verifyPassword(email, "wrongpwd123");
+
+        assertThat(actual.getIsSuccess()).isFalse();
     }
 }


### PR DESCRIPTION
## 개요
- 회원정보를 수정하기 전 비밀번호 확인 인증을 하는 API를 구현했습니다.

## 작업사항
- 비밀번호 확인 인증 API 구현
- 비밀번호 확인 인증 테스트 코드 작성

## 주의사항
- api 스펙과 동일하게 구현되었는지 확인해주세요
- 스웨거로 동작 확인해주세요
- 오타가 있는지 확인해주세요
