### PR TITLE
feat: LoginInterceptor 적용 경로 변경

### DIFF
--- a/src/main/java/mocacong/server/config/AuthConfig.java
+++ b/src/main/java/mocacong/server/config/AuthConfig.java
@@ -19,11 +19,9 @@ public class AuthConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
-                .addPathPatterns("/**")
-                .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
+                .addPathPatterns("/members/**", "/cafes/**")
                 .excludePathPatterns("/members", "/members/oauth", "/members/all",
                         "/members/check-duplicate/**", "/members/email-verification")
-                .excludePathPatterns("/login/**")
                 .excludePathPatterns("/cafes");
     }
 

--- a/src/main/java/mocacong/server/security/auth/LoginInterceptor.java
+++ b/src/main/java/mocacong/server/security/auth/LoginInterceptor.java
@@ -1,11 +1,10 @@
 package mocacong.server.security.auth;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 @Component
 public class LoginInterceptor implements HandlerInterceptor {


### PR DESCRIPTION
## 개요
- 거의 30초~ 1분 간격으로 `LoginInterceptor.prehandle()`에서 에러가 발생하곤 했습니다.
<img width="480" alt="image" src="https://github.com/mocacong/Mocacong-Backend/assets/57135043/f53b917e-fb38-4308-8ea0-f2fed4532f25">

이는 aws의 로드밸런서에서 health-check(사이트가 안정적인지 주기마다 로드밸런서에서 요청을 보내는 작업)를 위해 루트 디렉토리에 접근하기 때문입니다. (target group에서 health-check target을 `/swagger-ui/index.html`로 변경함에도 `/`로 로드밸런싱 후에 작업해서인지 계속 위 에러로그가 찍히네요)

그 외에 /index.html, 존재하지 않는 도메인 등에 접근할 때마다 해당 에러가 뜹니다.

30초~1분마다 로그인이 필요한 서비스도 아님에도 불구하고 이러한 에러가 뜰 필요가 없다고 생각했습니다.

## 작업사항
- 우리 서비스에서 로그인 인증이 요구되는 도메인은 모두 `/members` 또는 `/cafes`로 시작합니다. 따라서 모든 path를 addPatterns 하는 방식에서 `/members/**` 또는 `/cafes/**`를 include하고 필요한 path만 제외하는 방식으로 변경했습니다.
  - 이렇게 변경함으로써 로그인해야되는 path가 아님에도 불구하고 에러가 뜨는 현상 및 health-check 에러로그가 사라졌습니다.

## 주의사항
- 보안적으로 이슈가 될만한 부분이 있는지 확인해주세요. 아무것도 없는 도메인에 접속한다 하더라도, 사실상 유저 입장에서 할 수 있는 건 없다고 생각돼서 보안 이슈가 없지 않을까 생각했습니다.
