### PR TITLE
fix: 페이지네이션 API 응답 필드 `currentPage` -> `isEnd`로 변경

### DIFF
--- a/src/main/java/mocacong/server/dto/response/CafeImagesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeImagesResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CafeImagesResponse {
-    private int currentPage;
+
+    private Boolean isEnd;
     private List<CafeImageResponse> cafeImages;
 }

--- a/src/main/java/mocacong/server/dto/response/CommentsResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentsResponse.java
@@ -9,6 +9,6 @@ import lombok.*;
 @ToString
 public class CommentsResponse {
 
-    private int currentPage;
+    private Boolean isEnd;
     private List<CommentResponse> comments;
 }

--- a/src/main/java/mocacong/server/dto/response/MyCommentCafesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyCommentCafesResponse.java
@@ -10,6 +10,6 @@ import java.util.List;
 @ToString
 public class MyCommentCafesResponse {
 
-    private int currentPage;
+    private Boolean isEnd;
     private List<MyCommentCafeResponse> cafes;
 }

--- a/src/main/java/mocacong/server/dto/response/MyFavoriteCafesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyFavoriteCafesResponse.java
@@ -9,6 +9,6 @@ import lombok.*;
 @ToString
 public class MyFavoriteCafesResponse {
 
-    private int currentPage;
+    private Boolean isEnd;
     private List<MyFavoriteCafeResponse> cafes;
 }

--- a/src/main/java/mocacong/server/dto/response/MyReviewCafesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafesResponse.java
@@ -10,6 +10,6 @@ import java.util.List;
 @ToString
 public class MyReviewCafesResponse {
 
-    private int currentPage;
+    private Boolean isEnd;
     private List<MyReviewCafeResponse> cafes;
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,5 +1,9 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -25,11 +29,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.persistence.EntityManager;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -125,7 +124,7 @@ public class CafeService {
                 .stream()
                 .map(cafe -> new MyFavoriteCafeResponse(cafe.getName(), cafe.findAverageScore()))
                 .collect(Collectors.toList());
-        return new MyFavoriteCafesResponse(myFavoriteCafes.getNumber(), responses);
+        return new MyFavoriteCafesResponse(myFavoriteCafes.isLast(), responses);
     }
 
     @Transactional(readOnly = true)
@@ -141,7 +140,7 @@ public class CafeService {
                     return new MyReviewCafeResponse(cafe.getName(), score);
                 })
                 .collect(Collectors.toList());
-        return new MyReviewCafesResponse(myReviewCafes.getNumber(), responses);
+        return new MyReviewCafesResponse(myReviewCafes.isLast(), responses);
     }
 
     @Transactional(readOnly = true)
@@ -156,7 +155,7 @@ public class CafeService {
                         comment.getContent()
                 ))
                 .collect(Collectors.toList());
-        return new MyCommentCafesResponse(comments.getNumber(), responses);
+        return new MyCommentCafesResponse(comments.isLast(), responses);
     }
 
     @Transactional
@@ -296,7 +295,7 @@ public class CafeService {
                 })
                 .collect(Collectors.toList());
 
-        return new CafeImagesResponse(cafeImages.getNumber(), responses);
+        return new CafeImagesResponse(cafeImages.isLast(), responses);
     }
 
     @Transactional
@@ -306,7 +305,7 @@ public class CafeService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         CafeImage notUsedImage = cafeImageRepository.findById(cafeImageId)
-                        .orElseThrow(NotFoundCafeImageException::new);
+                .orElseThrow(NotFoundCafeImageException::new);
         notUsedImage.setIsUsed(false);
 
         String newImgUrl = awsS3Uploader.uploadImage(cafeImg);

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -1,5 +1,7 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
@@ -21,9 +23,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -52,7 +51,7 @@ public class CommentService {
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Comment> comments = commentRepository.findAllByCafeId(cafe.getId(), PageRequest.of(page, count));
         List<CommentResponse> responses = findCommentResponses(member, comments);
-        return new CommentsResponse(comments.getNumber(), responses);
+        return new CommentsResponse(comments.isLast(), responses);
     }
 
     @Transactional(readOnly = true)
@@ -64,7 +63,7 @@ public class CommentService {
         Slice<Comment> comments =
                 commentRepository.findAllByCafeIdAndMemberId(cafe.getId(), member.getId(), PageRequest.of(page, count));
         List<CommentResponse> responses = findCommentResponses(member, comments);
-        return new CommentsResponse(comments.getNumber(), responses);
+        return new CommentsResponse(comments.isLast(), responses);
     }
 
     private List<CommentResponse> findCommentResponses(Member member, Slice<Comment> comments) {
@@ -73,7 +72,7 @@ public class CommentService {
                     if (comment.isWrittenByMember(member)) {
                         return new CommentResponse(comment.getId(), member.getImgUrl(), member.getNickname(), comment.getContent(), true);
                     } else {
-                        return new CommentResponse(comment.getId(),comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
+                        return new CommentResponse(comment.getId(), comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
                     }
                 })
                 .collect(Collectors.toList());

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -306,7 +306,7 @@ class CafeServiceTest {
         MyFavoriteCafesResponse actual = cafeService.findMyFavoriteCafes(member1.getEmail(), 0, 3);
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafes().get(0).getScore()).isEqualTo(1.5)
         );
     }
@@ -335,7 +335,7 @@ class CafeServiceTest {
         MyReviewCafesResponse actual = cafeService.findMyReviewCafes(member1.getEmail(), 0, 3);
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("케이카페"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(5),
@@ -343,7 +343,7 @@ class CafeServiceTest {
                 () -> assertThat(actual.getCafes()).hasSize(2)
         );
     }
-  
+
     @Test
     @DisplayName("회원이 댓글을 작성한 카페 목록들을 보여준다")
     void findMyCommentCafes() {
@@ -363,7 +363,7 @@ class CafeServiceTest {
         MyCommentCafesResponse actual = cafeService.findMyCommentCafes(member1.getEmail(), 0, 5);
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafes()).hasSize(3),
                 () -> assertThat(actual.getCafes().get(0).getComment()).isEqualTo("댓글1"),
                 () -> assertThat(actual.getCafes().get(1).getComment()).isEqualTo("댓글2"),
@@ -632,7 +632,7 @@ class CafeServiceTest {
         List<CafeImageResponse> cafeImages = actual.getCafeImages();
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(cafeImages).hasSize(3)
         );
     }
@@ -656,7 +656,7 @@ class CafeServiceTest {
         List<CafeImageResponse> cafeImages = actual.getCafeImages();
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(cafeImages).hasSize(2),
                 () -> assertThat(cafeImages.get(0).getIsMe()).isTrue(),
                 () -> assertThat(cafeImages.get(1).getIsMe()).isTrue()
@@ -686,7 +686,7 @@ class CafeServiceTest {
         List<CafeImageResponse> cafeImages = actual.getCafeImages();
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(cafeImages).hasSize(4),
                 () -> assertThat(cafeImages.get(0).getIsMe()).isFalse(),
                 () -> assertThat(cafeImages.get(1).getIsMe()).isFalse()
@@ -717,7 +717,7 @@ class CafeServiceTest {
         List<CafeImageResponse> cafeImages = actual.getCafeImages();
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafeImages().get(0).getId()).isNotEqualTo(oldFindImage.getCafeImages().get(0).getId()),
                 () -> assertThat(cafeImages.get(0).getImageUrl()).endsWith("test_img2.jpg"),
                 () -> assertThat(cafeImages).hasSize(1)

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -12,13 +12,13 @@ import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 @ServiceTest
 class CommentServiceTest {
@@ -95,7 +95,7 @@ class CommentServiceTest {
         CommentsResponse actual = commentService.findAll(email, mapId, 0, 3);
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isFalse(),
                 () -> assertThat(actual.getComments()).hasSize(3),
                 () -> assertThat(actual.getComments())
                         .extracting("content")
@@ -122,7 +122,7 @@ class CommentServiceTest {
         CommentsResponse actual = commentService.findCafeCommentsOnlyMyComments(email, mapId, 0, 3);
 
         assertAll(
-                () -> assertThat(actual.getCurrentPage()).isEqualTo(0),
+                () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getComments()).hasSize(2),
                 () -> assertThat(actual.getComments())
                         .extracting("content")


### PR DESCRIPTION
## 개요
- 무한 스크롤 방식일 경우, 현재 페이지를 알 필요가 없고 더 이상 내릴 페이지가 있는지의 여부가 중요합니다.

## 작업사항
- 페이지네이션이 요구되는 API 응답 필드를 `currentPage`에서 `isEnd`로 변경했습니다.

## 주의사항
- 미처 변경하지 못한 부분이거나 놓친 부분이 있다면 리뷰 부탁드려요.
- 의도대로 동작되지 않는 부분이 있다면 리뷰 주세요.
