### PR TITLE
fix: 마이페이지 참여 카페 반환 시 `mapId` 필드 추가하도록 수정

### DIFF
--- a/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
@@ -8,6 +8,7 @@ import lombok.*;
 @ToString
 public class MyCommentCafeResponse {
 
+    private String mapId;
     private String name;
     private String comment;
 }

--- a/src/main/java/mocacong/server/dto/response/MyFavoriteCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyFavoriteCafeResponse.java
@@ -8,6 +8,7 @@ import lombok.*;
 @ToString
 public class MyFavoriteCafeResponse {
 
+    private String mapId;
     private String name;
     private double score;
 }

--- a/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
@@ -8,6 +8,7 @@ import lombok.*;
 @ToString
 public class MyReviewCafeResponse {
 
+    private String mapId;
     private String name;
     private int myScore;
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -123,7 +123,7 @@ public class CafeService {
         List<MyFavoriteCafeResponse> responses = myFavoriteCafes
                 .getContent()
                 .stream()
-                .map(cafe -> new MyFavoriteCafeResponse(cafe.getName(), cafe.findAverageScore()))
+                .map(cafe -> new MyFavoriteCafeResponse(cafe.getMapId(), cafe.getName(), cafe.findAverageScore()))
                 .collect(Collectors.toList());
         return new MyFavoriteCafesResponse(myFavoriteCafes.getNumber(), responses);
     }
@@ -138,7 +138,7 @@ public class CafeService {
                 .stream()
                 .map(cafe -> {
                     int score = scoreRepository.findScoreByCafeIdAndMemberId(cafe.getId(), member.getId());
-                    return new MyReviewCafeResponse(cafe.getName(), score);
+                    return new MyReviewCafeResponse(cafe.getMapId(), cafe.getName(), score);
                 })
                 .collect(Collectors.toList());
         return new MyReviewCafesResponse(myReviewCafes.getNumber(), responses);
@@ -152,6 +152,7 @@ public class CafeService {
 
         List<MyCommentCafeResponse> responses = comments.stream()
                 .map(comment -> new MyCommentCafeResponse(
+                        comment.getCafe().getMapId(),
                         comment.getCafe().getName(),
                         comment.getContent()
                 ))


### PR DESCRIPTION
## 개요
- 마이페이지에서 자신이 참여(리뷰, 댓글, 즐겨찾기)한 카페를 클릭 시에 해당 카페로 이동돼야 합니다. 그러기 위해선 해당 카페의 식별자가 필요합니다. 프론트 입장에서의 카페 식별자는 `mapId`입니다.

## 작업사항
- 응답 API response에 `mapId`를 추가했습니다. 
- 비즈니스 로직이 변경된 부분이 없어서 테스트 코드의 수정 및 추가는 존재하지 않습니다.

## 주의사항
- 제대로 변경됐는지 확인해주세요.
