### PR TITLE
feat: MaxUploadSizeExceededException 예외 처리 추가

### DIFF
--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -13,7 +13,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
@@ -60,8 +60,8 @@ public class ControllerAdvice {
         return ResponseEntity.badRequest().body(new ErrorResponse(9002, "해당 Http Method에 맞는 API가 존재하지 않습니다."));
     }
 
-    @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ErrorResponse> handleFileSizeLimitExceeded(MaxUploadSizeExceededException e) {
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ErrorResponse> handleFileSizeLimitExceeded(MultipartException e) {
         log.warn("File Size Limit Exception ErrMessage={}\n", e.getMessage());
 
         return ResponseEntity.badRequest().body(new ErrorResponse(9003, "이미지 용량이 10MB를 초과합니다."));

--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -61,8 +61,8 @@ public class ControllerAdvice {
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
-        log.warn("Max Upload Size Exception ErrMessage={}\n", e.getMessage());
+    public ResponseEntity<ErrorResponse> handleFileSizeLimitExceeded(MaxUploadSizeExceededException e) {
+        log.warn("File Size Limit Exception ErrMessage={}\n", e.getMessage());
 
         return ResponseEntity.badRequest().body(new ErrorResponse(9003, "이미지 용량이 10MB를 초과합니다."));
     }

--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -1,7 +1,5 @@
 package mocacong.server.controller;
 
-import java.util.Objects;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mocacong.server.dto.response.ErrorResponse;
@@ -15,6 +13,10 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -56,6 +58,13 @@ public class ControllerAdvice {
         log.warn("Http Method not supported Exception ErrMessage={}\n", e.getMessage());
 
         return ResponseEntity.badRequest().body(new ErrorResponse(9002, "해당 Http Method에 맞는 API가 존재하지 않습니다."));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.warn("Max Upload Size Exception ErrMessage={}\n", e.getMessage());
+
+        return ResponseEntity.badRequest().body(new ErrorResponse(9003, "이미지 용량이 10MB를 초과합니다."));
     }
 
     @ExceptionHandler(MocacongException.class)

--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -62,7 +62,7 @@ public class ControllerAdvice {
 
     @ExceptionHandler(MultipartException.class)
     public ResponseEntity<ErrorResponse> handleFileSizeLimitExceeded(MultipartException e) {
-        log.warn("File Size Limit Exception ErrMessage={}\n", e.getMessage());
+        log.error("File Size Limit Exception ErrMessage={}\n", e.getMessage());
 
         return ResponseEntity.badRequest().body(new ErrorResponse(9003, "이미지 용량이 10MB를 초과합니다."));
     }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -37,7 +37,6 @@ public class CafeService {
 
     private static final int CAFE_SHOW_PAGE_COMMENTS_LIMIT_COUNTS = 3;
     private static final int CAFE_SHOW_PAGE_IMAGE_LIMIT_COUNTS = 5;
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
     private final CafeRepository cafeRepository;
     private final MemberRepository memberRepository;

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -37,6 +37,7 @@ public class CafeService {
 
     private static final int CAFE_SHOW_PAGE_COMMENTS_LIMIT_COUNTS = 3;
     private static final int CAFE_SHOW_PAGE_IMAGE_LIMIT_COUNTS = 5;
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
     private final CafeRepository cafeRepository;
     private final MemberRepository memberRepository;

--- a/src/main/java/mocacong/server/support/AwsS3Uploader.java
+++ b/src/main/java/mocacong/server/support/AwsS3Uploader.java
@@ -2,11 +2,6 @@ package mocacong.server.support;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
@@ -15,6 +10,12 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Component

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -77,7 +77,3 @@ feign:
       apple-public-key-client:
         connectTimeout: 5000
         readTimeout: 3000
-
-server:
-  tomcat:
-    max-swallow-size: -1

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,6 +18,7 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 20MB
+      resolve-lazily: true
   task:
     execution:
       pool:
@@ -76,3 +77,7 @@ feign:
       apple-public-key-client:
         connectTimeout: 5000
         readTimeout: 3000
+
+server:
+  tomcat:
+    max-swallow-size: -1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,7 +81,3 @@ feign:
       apple-public-key-client:
         connectTimeout: 5000
         readTimeout: 3000
-
-server:
-  tomcat:
-    max-swallow-size: -1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 20MB
+      resolve-lazily: true
 
 security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttesttest
@@ -80,3 +81,7 @@ feign:
       apple-public-key-client:
         connectTimeout: 5000
         readTimeout: 3000
+
+server:
+  tomcat:
+    max-swallow-size: -1

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,7 +26,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -616,24 +616,6 @@ class CafeServiceTest {
     }
 
     @Test
-    @DisplayName("10MB를 초과하는 카페 이미지를 저장할 시 예외를 반환한다")
-    void saveOverSizedCafeImage() throws IOException {
-        String expected = "oversized_img.jpg";
-        Cafe cafe = new Cafe("2143154352323", "케이카페");
-        cafeRepository.save(cafe);
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
-        memberRepository.save(member);
-        String mapId = cafe.getMapId();
-        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
-        MockMultipartFile mockMultipartFile = new MockMultipartFile("oversized_img", expected, "jpg", fileInputStream);
-        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("oversized_img.jpg");
-
-        assertThrows(MaxUploadSizeExceededException.class, () -> {
-            cafeService.saveCafeImage(member.getEmail(), mapId, mockMultipartFile);
-        });
-    }
-
-    @Test
     @DisplayName("사용자가 카페 이미지를 조회한다")
     void findCafeImages() throws IOException {
         String expected = "test_img.jpg";

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,11 @@ spring:
           enabled: true
         show_sql: true
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
+      resolve-lazily: true
   h2:
     console:
       enabled: true
@@ -53,3 +58,7 @@ oauth:
     client-id: test
     client-secret: test
     redirect-uri: test
+
+server:
+  tomcat:
+    max-swallow-size: -1

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,10 +12,7 @@ spring:
           enabled: true
         show_sql: true
         format_sql: true
-  servlet:
-    multipart:
-      max-file-size: 10MB
-      max-request-size: 20MB
+
   h2:
     console:
       enabled: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,7 +16,6 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 20MB
-      resolve-lazily: true
   h2:
     console:
       enabled: true
@@ -58,7 +57,3 @@ oauth:
     client-id: test
     client-secret: test
     redirect-uri: test
-
-server:
-  tomcat:
-    max-swallow-size: -1


### PR DESCRIPTION
## 개요
- 카페 이미지 저장/수정 그리고 회원 프로필 이미지를 수정할 때 따로 10MB 이상의 대용량 크기의 이미지 제한 예외가 따로 없었기에 추가하였습니다.

## 작업사항
- application.yml 에 `resolve-lazily` , `max-swallow-size` 설정 추가
- `ExceptionHandler`에 `MaxUploadSizeExceededException` 핸들러 추가

## 주의사항
- 스웨거를 통해 해당 예외가 반환되는 지 확인해주세요
- 로직이 제대로 구현됐는지 확인해주세요
- 해당 기능은 MockMVC로 테스트를 못하기에 테스트 코드 작성을 생략했습니다
