### PR TITLE
feat: 카페 정보 미리보기 조회 GET API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -44,6 +44,17 @@ public class CafeController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "특정 카페 미리보기 조회")
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/{mapId}/preview")
+    public ResponseEntity<PreviewCafeResponse> previewCafeByMapId(
+            @LoginUserEmail String email,
+            @PathVariable String mapId
+    ) {
+        PreviewCafeResponse response = cafeService.previewCafeByMapId(email, mapId);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "특정 카페 리뷰 작성")
     @SecurityRequirement(name = "JWT")
     @PostMapping("/{mapId}")

--- a/src/main/java/mocacong/server/dto/response/PreviewCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/PreviewCafeResponse.java
@@ -1,0 +1,15 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class PreviewCafeResponse {
+
+    private Boolean favorite;
+    private double score;
+    private String studyType;
+    private int reviewsCount;
+}

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -29,6 +25,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -87,6 +88,23 @@ public class CafeService {
                 cafe.getComments().size(),
                 commentResponses,
                 cafeImageResponses
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PreviewCafeResponse previewCafeByMapId(String email, String mapId) {
+        Cafe cafe = cafeRepository.findByMapId(mapId)
+                .orElseThrow(NotFoundCafeException::new);
+        CafeDetail cafeDetail = cafe.getCafeDetail();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+        Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
+                .orElse(null);
+        return new PreviewCafeResponse(
+                favoriteId != null,
+                cafe.findAverageScore(),
+                cafeDetail.getStudyTypeValue(),
+                cafe.getReviews().size()
         );
     }
 


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 카페 평점, 스터디타입, 즐겨찾기 여부, 리뷰 개수를 보여주는 카페 미리보기 조회 기능을 구현했습니다.

## 작업사항
- 카페 미리보기 조회 기능 구현
- 카페 미리보기 조회 테스트 코드 작성
- 카페 미리보기 조회 인수테스트 코드 작성

## 주의사항
- api 스펙과 동일한지 확인해주세요
- 누락된 테스트가 있는지 확인해주세요
