### PR TITLE
fix: 이메일 인증 및 비밀번호 변경 API 에서 token 필요하도록 변경

### DIFF
--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -136,12 +136,14 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "비밀번호 찾기 및 변경")
+    @Operation(summary = "비밀번호 변경")
+    @SecurityRequirement(name = "JWT")
     @PutMapping("/info/reset-password")
     public ResponseEntity<Void> findAndResetPassword(
+            @LoginUserEmail String email,
             @RequestBody @Valid ResetPasswordRequest request
     ) {
-        memberService.resetPassword(request);
+        memberService.resetPassword(email, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/mocacong/server/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/mocacong/server/dto/request/ResetPasswordRequest.java
@@ -1,6 +1,5 @@
 package mocacong.server.dto.request;
 
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -12,9 +11,6 @@ public class ResetPasswordRequest {
 
     @NotBlank(message = "1012:공백일 수 없습니다.")
     private String nonce;
-
-    @Min(value = 1, message = "1017:요청 회원 id는 자연수여야 합니다.")
-    private Long memberId;
 
     @NotBlank(message = "1012:공백일 수 없습니다.")
     private String password;

--- a/src/main/java/mocacong/server/dto/response/EmailVerifyCodeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/EmailVerifyCodeResponse.java
@@ -8,6 +8,6 @@ import lombok.*;
 @ToString
 public class EmailVerifyCodeResponse {
 
-    private Long id;
+    private String token;
     private String code;
 }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -169,11 +169,13 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     void findAndResetPassword() {
         String email = "kth990303@naver.com";
         MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
-        Long memberId = 회원_가입(memberSignUpRequest).as(MemberSignUpResponse.class).getId();
-        ResetPasswordRequest request = new ResetPasswordRequest(NONCE, memberId, "password123");
+        회원_가입(memberSignUpRequest);
+        String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
+        ResetPasswordRequest request = new ResetPasswordRequest(NONCE, "password123");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
                 .body(request)
                 .when().put("/members/info/reset-password")
                 .then().log().all()

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -177,9 +177,9 @@ class MemberServiceTest {
         String email = "kth990303@naver.com";
         String updatePassword = "password123";
         Member member = memberRepository.save(new Member(email, Platform.MOCACONG, "1234"));
-        ResetPasswordRequest request = new ResetPasswordRequest(NONCE, member.getId(), updatePassword);
+        ResetPasswordRequest request = new ResetPasswordRequest(NONCE, updatePassword);
 
-        memberService.resetPassword(request);
+        memberService.resetPassword(email, request);
 
         Member actual = memberRepository.findById(member.getId())
                 .orElseThrow();
@@ -191,32 +191,24 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("올바르지 않은 member id로 비밀번호 찾기 요청을 받을 경우 예외를 반환한다")
-    void findAndResetPasswordWhenInvalidMemberId() {
-        ResetPasswordRequest request = new ResetPasswordRequest(NONCE, 9999L, "password123");
-
-        assertThatThrownBy(() -> memberService.resetPassword(request))
-                .isInstanceOf(NotFoundMemberException.class);
-    }
-
-    @Test
     @DisplayName("올바르지 않은 비밀번호로 비밀번호 찾기 요청을 받을 경우 예외를 반환한다")
     void findAndResetPasswordWhenInvalidPassword() {
         String email = "kth990303@naver.com";
-        Member member = memberRepository.save(new Member(email, Platform.MOCACONG, "1234"));
-        ResetPasswordRequest request = new ResetPasswordRequest(NONCE, member.getId(), "123");
+        memberRepository.save(new Member(email, Platform.MOCACONG, "1234"));
+        ResetPasswordRequest request = new ResetPasswordRequest(NONCE, "123");
 
-        assertThatThrownBy(() -> memberService.resetPassword(request))
+        assertThatThrownBy(() -> memberService.resetPassword(email, request))
                 .isInstanceOf(InvalidPasswordException.class);
     }
 
     @Test
     @DisplayName("nonce 값이 올바르지 않은, 유효한 비밀번호 찾기 요청이 아닌 경우 비밀번호 변경이 안되고 예외를 반환한다")
     void findAndResetPasswordWhenInvalidNonce() {
-        Member member = memberRepository.save(new Member("test@naver.com", Platform.MOCACONG, "1234"));
-        ResetPasswordRequest request = new ResetPasswordRequest("invalid_nonce", member.getId(), "password123");
+        String email = "kth990303@naver.com";
+        memberRepository.save(new Member(email, Platform.MOCACONG, "1234"));
+        ResetPasswordRequest request = new ResetPasswordRequest("invalid_nonce", "password123");
 
-        assertThatThrownBy(() -> memberService.resetPassword(request))
+        assertThatThrownBy(() -> memberService.resetPassword(email, request))
                 .isInstanceOf(InvalidNonceException.class);
     }
 


### PR DESCRIPTION
## 개요
- 프론트 측에서 비밀번호 변경 API를 별도로 만들고 싶어하며, memberId가 아닌 token으로 처리할 수 있는 방향을 원했습니다.

## 작업사항
- 이메일 인증 응답으로 사용가능한 token을 발급해주도록 변경했습니다. 이메일 인증이 완료되면 그 이후 요청부터는 프론트 측에서 헤더에 해당 토큰을 붙여줍니다.
- 비밀번호 변경 API에서 `memberId`가 아닌 header에 토큰을 담아서 요청하는 것으로 요청자의 식별을 가능하게 변경했습니다.

## 주의사항
- API 변경사항에 적합하게 변경했는지, 동작에 문제는 없는지 확인해주세요
