### PR TITLE
feat: 프로필 수정 페이지 조회 GET API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -3,7 +3,6 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
@@ -14,6 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
 
 @Tag(name = "Members", description = "회원")
 @RestController
@@ -123,6 +124,16 @@ public class MemberController {
     ) {
         memberService.updateProfileInfo(email, request);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "프로필 회원정보 수정 페이지 조회")
+    @SecurityRequirement(name = "JWT")
+    @PutMapping(value = "/info")
+    public ResponseEntity<GetUpdateProfileInfoResponse> getUpdateProfileInfo(
+            @LoginUserEmail String email
+    ) {
+        GetUpdateProfileInfoResponse response = memberService.getUpdateProfileInfo(email);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "비밀번호 확인 인증")

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -128,7 +128,7 @@ public class MemberController {
 
     @Operation(summary = "프로필 회원정보 수정 페이지 조회")
     @SecurityRequirement(name = "JWT")
-    @PutMapping(value = "/info")
+    @GetMapping(value = "/info")
     public ResponseEntity<GetUpdateProfileInfoResponse> getUpdateProfileInfo(
             @LoginUserEmail String email
     ) {

--- a/src/main/java/mocacong/server/dto/response/GetUpdateProfileInfoResponse.java
+++ b/src/main/java/mocacong/server/dto/response/GetUpdateProfileInfoResponse.java
@@ -1,0 +1,13 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class GetUpdateProfileInfoResponse {
+    private String email;
+    private String nickname;
+    private String phone;
+}

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -1,10 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.MemberProfileImage;
@@ -25,6 +20,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -216,4 +216,11 @@ public class MemberService {
 
         return new PasswordVerifyResponse(isSuccess);
     }
+
+    public GetUpdateProfileInfoResponse getUpdateProfileInfo(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NotFoundMemberException::new);
+
+        return new GetUpdateProfileInfoResponse(member.getEmail(), member.getNickname(), member.getPhone());
+    }
 }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import static java.lang.Integer.parseInt;
-import java.util.List;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.MemberProfileImage;
 import mocacong.server.domain.Platform;
@@ -16,19 +12,25 @@ import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
 import mocacong.server.support.AwsSESSender;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static java.lang.Integer.parseInt;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ServiceTest
 class MemberServiceTest {
@@ -506,5 +508,24 @@ class MemberServiceTest {
         PasswordVerifyResponse actual = memberService.verifyPassword(email, request);
 
         assertThat(actual.getIsSuccess()).isFalse();
+    }
+
+    @Test
+    @DisplayName("프로필 수정 페이지에서 정보를 조회한다")
+    void getUpdateProfileInfo() {
+        String email = "dlawotn3@naver.com";
+        String password = "jisu1234";
+        String nickname = "mery";
+        String phone = "010-1111-1111";
+        Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
+        memberRepository.save(member);
+
+        GetUpdateProfileInfoResponse actual = memberService.getUpdateProfileInfo(member.getEmail());
+
+        assertAll(
+                () -> assertThat(actual.getEmail()).isEqualTo(email),
+                () -> assertThat(actual.getNickname()).isEqualTo(nickname),
+                () -> assertThat(actual.getPhone()).isEqualTo(phone)
+        );
     }
 }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -511,7 +511,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("프로필 수정 페이지에서 정보를 조회한다")
+    @DisplayName("프로필 수정 페이지에서 내 정보를 조회한다")
     void getUpdateProfileInfo() {
         String email = "dlawotn3@naver.com";
         String password = "jisu1234";


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 프로필 수정 페이지에서 `email`, `nickname`, `phone` 를 조회하는 API를 구현했습니다.

## 작업사항
- 프로필 수정 페이지 조회 GET API 구현
- 프로필 수정 페이지 조회 테스트 코드 작성

## 주의사항
- 스웨거로 동작 확인해주세요
- 오타가 있는지 확인해주세요
