### PR TITLE
fix: studyType별로 카페 필터링 조회 API - POST API로 수정

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -92,7 +92,7 @@ public class CafeController {
 
     @Operation(summary = "StudyType별로 카페 조회")
     @SecurityRequirement(name = "JWT")
-    @PostMapping(value = "/studytype")
+    @PostMapping(value = "/studytypes")
     public ResponseEntity<CafeFilterStudyTypeResponse> getCafesByStudyType(
             @RequestParam(required = false) String studytype,
             @RequestBody CafeFilterStudyTypeRequest request

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -93,8 +93,10 @@ public class CafeController {
     @Operation(summary = "StudyType별로 카페 조회")
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = "/studytype")
-    public ResponseEntity<CafeFilterStudyTypeResponse> getCafesByStudyType(@RequestParam(required = false) String studytype,
-                                                                           @RequestBody CafeFilterStudyTypeRequest request) {
+    public ResponseEntity<CafeFilterStudyTypeResponse> getCafesByStudyType(
+            @RequestParam(required = false) String studytype,
+            @RequestBody CafeFilterStudyTypeRequest request
+    ) {
         CafeFilterStudyTypeResponse responseBody = cafeService.filterCafesByStudyType(studytype, request);
         return ResponseEntity.ok(responseBody);
     }

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -92,7 +92,7 @@ public class CafeController {
 
     @Operation(summary = "StudyType별로 카페 조회")
     @SecurityRequirement(name = "JWT")
-    @PostMapping(value = "/studyType")
+    @PostMapping(value = "/studytype")
     public ResponseEntity<CafeFilterResponse> getCafesByStudyType(@RequestParam(required = false) String studytype,
                                                                   @RequestBody CafeFilterRequest request) {
         CafeFilterResponse responseBody = cafeService.filterCafesByStudyType(studytype, request);

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import mocacong.server.dto.request.CafeFilterRequest;
+import mocacong.server.dto.request.CafeFilterStudyTypeRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
 import mocacong.server.dto.request.CafeReviewRequest;
 import mocacong.server.dto.request.CafeReviewUpdateRequest;
@@ -93,9 +93,9 @@ public class CafeController {
     @Operation(summary = "StudyType별로 카페 조회")
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = "/studytype")
-    public ResponseEntity<CafeFilterResponse> getCafesByStudyType(@RequestParam(required = false) String studytype,
-                                                                  @RequestBody CafeFilterRequest request) {
-        CafeFilterResponse responseBody = cafeService.filterCafesByStudyType(studytype, request);
+    public ResponseEntity<CafeFilterStudyTypeResponse> getCafesByStudyType(@RequestParam(required = false) String studytype,
+                                                                           @RequestBody CafeFilterStudyTypeRequest request) {
+        CafeFilterStudyTypeResponse responseBody = cafeService.filterCafesByStudyType(studytype, request);
         return ResponseEntity.ok(responseBody);
     }
 

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -92,7 +92,7 @@ public class CafeController {
 
     @Operation(summary = "StudyType별로 카페 조회")
     @SecurityRequirement(name = "JWT")
-    @GetMapping
+    @PostMapping(value = "/studyType")
     public ResponseEntity<CafeFilterResponse> getCafesByStudyType(@RequestParam(required = false) String studytype,
                                                                   @RequestBody CafeFilterRequest request) {
         CafeFilterResponse responseBody = cafeService.filterCafesByStudyType(studytype, request);

--- a/src/main/java/mocacong/server/dto/request/CafeFilterStudyTypeRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeFilterStudyTypeRequest.java
@@ -8,6 +8,6 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 @ToString
-public class CafeFilterRequest {
+public class CafeFilterStudyTypeRequest {
     private List<String> mapIds;
 }

--- a/src/main/java/mocacong/server/dto/response/CafeFilterStudyTypeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeFilterStudyTypeResponse.java
@@ -8,6 +8,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @ToString
-public class CafeFilterResponse {
+public class CafeFilterStudyTypeResponse {
     private List<String> mapIds;
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -3,7 +3,7 @@ package mocacong.server.service;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
-import mocacong.server.dto.request.CafeFilterRequest;
+import mocacong.server.dto.request.CafeFilterStudyTypeRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
 import mocacong.server.dto.request.CafeReviewRequest;
 import mocacong.server.dto.request.CafeReviewUpdateRequest;
@@ -271,7 +271,7 @@ public class CafeService {
                 .forEach(Score::removeMember);
     }
 
-    public CafeFilterResponse filterCafesByStudyType(String studyTypeValue, CafeFilterRequest requestBody) {
+    public CafeFilterStudyTypeResponse filterCafesByStudyType(String studyTypeValue, CafeFilterStudyTypeRequest requestBody) {
         List<Cafe> cafes = cafeRepository.findByStudyTypeValue(StudyType.from(studyTypeValue));
         Set<String> filteredCafeMapIds = cafes.stream()
                 .map(Cafe::getMapId)
@@ -281,7 +281,7 @@ public class CafeService {
                 .filter(filteredCafeMapIds::contains)
                 .collect(Collectors.toList());
 
-        return new CafeFilterResponse(filteredIds);
+        return new CafeFilterStudyTypeResponse(filteredIds);
     }
 
     @Transactional

--- a/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
@@ -2,7 +2,7 @@ package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
 import mocacong.server.dto.request.*;
-import mocacong.server.dto.response.CafeFilterResponse;
+import mocacong.server.dto.response.CafeFilterStudyTypeResponse;
 import mocacong.server.dto.response.CafeReviewResponse;
 import mocacong.server.dto.response.CafeReviewUpdateResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -222,9 +222,9 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         카페_리뷰_작성(token, mapId1, request1);
         카페_리뷰_작성(token, mapId2, request2);
         카페_리뷰_작성(token, mapId3, request3);
-        CafeFilterRequest request = new CafeFilterRequest(List.of(mapId1, mapId2, mapId3));
+        CafeFilterStudyTypeRequest request = new CafeFilterStudyTypeRequest(List.of(mapId1, mapId2, mapId3));
 
-        CafeFilterResponse actual = RestAssured.given().log().all()
+        CafeFilterStudyTypeResponse actual = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .body(request)
@@ -232,7 +232,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .as(CafeFilterResponse.class);
+                .as(CafeFilterStudyTypeResponse.class);
 
         assertThat(actual.getMapIds()).containsExactlyInAnyOrder(mapId1, mapId3);
     }

--- a/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
@@ -228,7 +228,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .body(request)
-                .when().post("/cafes/studytype?studytype=solo")
+                .when().post("/cafes/studytypes?studytype=solo")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()

--- a/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
@@ -228,7 +228,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .body(request)
-                .when().get("/cafes?studytype=solo")
+                .when().post("/cafes/studyType?studytype=solo")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()

--- a/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
@@ -228,7 +228,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .auth().oauth2(token)
                 .body(request)
-                .when().post("/cafes/studyType?studytype=solo")
+                .when().post("/cafes/studytype?studytype=solo")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract()

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,7 +1,7 @@
 package mocacong.server.service;
 
 import mocacong.server.domain.*;
-import mocacong.server.dto.request.CafeFilterRequest;
+import mocacong.server.dto.request.CafeFilterStudyTypeRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
 import mocacong.server.dto.request.CafeReviewRequest;
 import mocacong.server.dto.request.CafeReviewUpdateRequest;
@@ -614,11 +614,11 @@ class CafeServiceTest {
         cafeService.saveCafeReview(member2.getEmail(), cafe4.getMapId(),
                 new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
                         "깨끗해요", "충분해요", "조용해요", "편해요"));
-        CafeFilterRequest requestBody = new CafeFilterRequest(
+        CafeFilterStudyTypeRequest requestBody = new CafeFilterStudyTypeRequest(
                 List.of(cafe1.getMapId(), cafe2.getMapId(), cafe3.getMapId(), cafe4.getMapId())
         );
 
-        CafeFilterResponse filteredCafes = cafeService.filterCafesByStudyType("solo", requestBody);
+        CafeFilterStudyTypeResponse filteredCafes = cafeService.filterCafesByStudyType("solo", requestBody);
 
         assertThat(filteredCafes.getMapIds())
                 .containsExactlyInAnyOrder(cafe1.getMapId(), cafe3.getMapId(), cafe4.getMapId());
@@ -634,9 +634,9 @@ class CafeServiceTest {
         cafeService.saveCafeReview(member.getEmail(), cafe1.getMapId(),
                 new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
                         "깨끗해요", "충분해요", "조용해요", "편해요"));
-        CafeFilterRequest requestBody = new CafeFilterRequest(List.of(cafe1.getMapId()));
+        CafeFilterStudyTypeRequest requestBody = new CafeFilterStudyTypeRequest(List.of(cafe1.getMapId()));
 
-        CafeFilterResponse filteredCafes = cafeService.filterCafesByStudyType("group", requestBody);
+        CafeFilterStudyTypeResponse filteredCafes = cafeService.filterCafesByStudyType("group", requestBody);
 
         assertThat(filteredCafes.getMapIds()).isEmpty();
     }


### PR DESCRIPTION
## 개요
- `studyType` 별로 카페 필터링을 할 때 GET인 경우에는 json 에러가 발생하여POST 로 변경했습니다.

## 작업사항
- `studyType` 별 카페 필터링 조회 POST API로 변경
- 변경 사항에 따라 해당 테스트 코드 수정

## 주의사항
- 스웨거로 동작 확인해주세요
- 오타가 있는지 확인해주세요.
- api spec과 동일한지 확인해주세요