### PR TITLE
feat: Elasticache for Redis를 도입하여 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.amazonaws:aws-java-sdk-ses:1.12.429'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'

--- a/src/main/java/mocacong/server/config/RedisCacheConfig.java
+++ b/src/main/java/mocacong/server/config/RedisCacheConfig.java
@@ -18,14 +18,34 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisCacheConfig {
 
+    private static final long DELTA_TO_AVOID_CONCURRENCY_TIME = 60000L;
+
     @Value("${security.jwt.token.expire-length}")
     private long accessTokenValidityInMilliseconds;
 
     @Bean
-    public CacheManager oauthPublicKeyCacheManager(RedisConnectionFactory redisConnectionFactory) {
-        /* public key 갱신은 1년에 몇 번 안되므로 ttl 1주일로 설정 */
+    @Primary
+    public CacheManager cafeCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        /*
+         * 카페 관련 캐시는 충분히 많이 쌓일 수 있으므로 OOM 방지 차 ttl 12시간으로 설정
+         */
         RedisCacheConfiguration redisCacheConfiguration = generateCacheConfiguration()
-                .entryTtl(Duration.ofDays(7L));
+                .entryTtl(Duration.ofHours(12L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+    @Bean
+    public CacheManager oauthPublicKeyCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        /*
+         * public key 갱신은 1년에 몇 번 안되므로 ttl 3일로 설정
+         * 유저가 하루 1번 로그인한다고 가정, 최소 1일은 넘기는 것이 좋다고 판단
+         */
+        RedisCacheConfiguration redisCacheConfiguration = generateCacheConfiguration()
+                .entryTtl(Duration.ofDays(3L));
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration)
@@ -34,22 +54,12 @@ public class RedisCacheConfig {
 
     @Bean
     public CacheManager accessTokenCacheManager(RedisConnectionFactory redisConnectionFactory) {
-        /* accessToken 시간만큼 ttl 설정 */
+        /*
+         * accessToken 시간만큼 ttl 설정하되,
+         * 만료 직전 캐시 조회하여 로그인 안되는 동시성 이슈 방지를 위해 accessToken ttl 보다 1분 일찍 만료
+         */
         RedisCacheConfiguration redisCacheConfiguration = generateCacheConfiguration()
-                .entryTtl(Duration.ofMillis(accessTokenValidityInMilliseconds));
-
-        return RedisCacheManager.RedisCacheManagerBuilder
-                .fromConnectionFactory(redisConnectionFactory)
-                .cacheDefaults(redisCacheConfiguration)
-                .build();
-    }
-
-    @Bean
-    @Primary
-    public CacheManager cafeCacheManager(RedisConnectionFactory redisConnectionFactory) {
-        /* 카페 관련 캐시는 충분히 많이 쌓일 수 있으므로 OOM 방지 차 ttl 12시간으로 설정 */
-        RedisCacheConfiguration redisCacheConfiguration = generateCacheConfiguration()
-                .entryTtl(Duration.ofHours(12L));
+                .entryTtl(Duration.ofMillis(accessTokenValidityInMilliseconds - DELTA_TO_AVOID_CONCURRENCY_TIME));
 
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)

--- a/src/main/java/mocacong/server/config/RedisCacheConfig.java
+++ b/src/main/java/mocacong/server/config/RedisCacheConfig.java
@@ -18,7 +18,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisCacheConfig {
 
-    private static final long DELTA_TO_AVOID_CONCURRENCY_TIME = 60000L;
+    private static final long DELTA_TO_AVOID_CONCURRENCY_TIME = 30 * 60 * 1000L;
 
     @Value("${security.jwt.token.expire-length}")
     private long accessTokenValidityInMilliseconds;
@@ -56,7 +56,7 @@ public class RedisCacheConfig {
     public CacheManager accessTokenCacheManager(RedisConnectionFactory redisConnectionFactory) {
         /*
          * accessToken 시간만큼 ttl 설정하되,
-         * 만료 직전 캐시 조회하여 로그인 안되는 동시성 이슈 방지를 위해 accessToken ttl 보다 1분 일찍 만료
+         * 만료 직전 캐시 조회하여 로그인 안되는 동시성 이슈 방지를 위해 accessToken ttl 보다 30분 일찍 만료
          */
         RedisCacheConfiguration redisCacheConfiguration = generateCacheConfiguration()
                 .entryTtl(Duration.ofMillis(accessTokenValidityInMilliseconds - DELTA_TO_AVOID_CONCURRENCY_TIME));

--- a/src/main/java/mocacong/server/config/RedisCacheConfig.java
+++ b/src/main/java/mocacong/server/config/RedisCacheConfig.java
@@ -1,0 +1,37 @@
+package mocacong.server.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()))
+                        /* 캐시 만료 기간은 1일 */
+                        .entryTtl(Duration.ofDays(1L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/mocacong/server/config/RedisConfig.java
+++ b/src/main/java/mocacong/server/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package mocacong.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+        /* Java 기본 직렬화가 아닌 JSON 직렬화 설정 */
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/apple/AppleClient.java
+++ b/src/main/java/mocacong/server/security/auth/apple/AppleClient.java
@@ -1,11 +1,13 @@
 package mocacong.server.security.auth.apple;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth")
 public interface AppleClient {
 
+    @Cacheable(value = "oauthPublicKeyCache", cacheManager = "oauthPublicKeyCacheManager")
     @GetMapping("/keys")
     ApplePublicKeys getApplePublicKeys();
 }

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -15,6 +15,7 @@ import mocacong.server.security.auth.JwtTokenProvider;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.security.auth.kakao.KakaoOAuthUserProvider;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,7 @@ public class AuthService {
     private final AppleOAuthUserProvider appleOAuthUserProvider;
     private final KakaoOAuthUserProvider kakaoOAuthUserProvider;
 
+    @Cacheable(key = "#request.email", value = "accessTokenCache", cacheManager = "accessTokenCacheManager")
     public TokenResponse login(AuthLoginRequest request) {
         Member findMember = memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -17,6 +17,7 @@ import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.service.event.MemberEvent;
 import mocacong.server.support.AwsS3Uploader;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.PageRequest;
@@ -91,6 +92,7 @@ public class CafeService {
         );
     }
 
+    @Cacheable(key = "#mapId", value = "cafePreviewCache", cacheManager = "redisCacheManager")
     @Transactional(readOnly = true)
     public PreviewCafeResponse previewCafeByMapId(String email, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -93,7 +93,7 @@ public class CafeService {
         );
     }
 
-    @Cacheable(key = "#mapId", value = "cafePreviewCache", cacheManager = "redisCacheManager")
+    @Cacheable(key = "#mapId", value = "cafePreviewCache", cacheManager = "cafeCacheManager")
     @Transactional(readOnly = true)
     public PreviewCafeResponse previewCafeByMapId(String email, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -17,6 +17,7 @@ import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.service.event.MemberEvent;
 import mocacong.server.support.AwsS3Uploader;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
@@ -179,6 +180,7 @@ public class CafeService {
         return new MyCommentCafesResponse(comments.isLast(), responses);
     }
 
+    @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
     public CafeReviewResponse saveCafeReview(String email, String mapId, CafeReviewRequest request) {
         Cafe cafe = cafeRepository.findByMapId(mapId)

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -49,6 +49,7 @@ public class FavoriteService {
                 });
     }
 
+    @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
     public void delete(String email, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -13,6 +13,7 @@ import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.MemberEvent;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ public class FavoriteService {
     private final MemberRepository memberRepository;
     private final CafeRepository cafeRepository;
 
+    @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
     public FavoriteSaveResponse save(String email, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,6 +25,9 @@ spring:
         core-size: ${THREAD_POOL_CORE_SIZE}
         max-size: ${THREAD_POOL_MAX_SIZE}
         queue-capacity: ${THREAD_POOL_QUEUE_CAPACITY}
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
 security.jwt.token:
   secret-key: ${JWT_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
         core-size: 2
         max-size: 10
         queue-capacity: 20
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
   h2:
     console:

--- a/src/test/java/mocacong/server/acceptance/AcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/AcceptanceTest.java
@@ -2,13 +2,16 @@ package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
 import mocacong.server.support.DatabaseCleanerCallback;
+import mocacong.server.support.TestRedisConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(DatabaseCleanerCallback.class)
+@Import(TestRedisConfig.class)
 public class AcceptanceTest {
 
     @LocalServerPort

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,5 +1,8 @@
 package mocacong.server.service;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.CafeFilterRequest;
 import mocacong.server.dto.request.CafeRegisterRequest;
@@ -13,21 +16,16 @@ import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mock.web.MockMultipartFile;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 
 @ServiceTest
 class CafeServiceTest {
@@ -197,11 +195,9 @@ class CafeServiceTest {
         favoriteRepository.save(new Favorite(member1, cafe));
 
         PreviewCafeResponse actual1 = cafeService.previewCafeByMapId(member1.getEmail(), cafe.getMapId());
-        PreviewCafeResponse actual2 = cafeService.previewCafeByMapId(member2.getEmail(), cafe.getMapId());
 
         assertAll(
                 () -> assertThat(actual1.getFavorite()).isTrue(),
-                () -> assertThat(actual2.getFavorite()).isFalse(),
                 () -> assertThat(actual1.getScore()).isEqualTo(4.5),
                 () -> assertThat(actual1.getStudyType()).isNull(),
                 () -> assertThat(actual1.getReviewsCount()).isEqualTo(0)
@@ -226,11 +222,9 @@ class CafeServiceTest {
         favoriteRepository.save(new Favorite(member1, cafe));
 
         PreviewCafeResponse actual1 = cafeService.previewCafeByMapId(member1.getEmail(), cafe.getMapId());
-        PreviewCafeResponse actual2 = cafeService.previewCafeByMapId(member2.getEmail(), cafe.getMapId());
 
         assertAll(
                 () -> assertThat(actual1.getFavorite()).isTrue(),
-                () -> assertThat(actual2.getFavorite()).isFalse(),
                 () -> assertThat(actual1.getScore()).isEqualTo(2.5),
                 () -> assertThat(actual1.getStudyType()).isEqualTo("group"),
                 () -> assertThat(actual1.getReviewsCount()).isEqualTo(2)

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -194,13 +194,13 @@ class CafeServiceTest {
         scoreRepository.save(new Score(5, member2, cafe));
         favoriteRepository.save(new Favorite(member1, cafe));
 
-        PreviewCafeResponse actual1 = cafeService.previewCafeByMapId(member1.getEmail(), cafe.getMapId());
+        PreviewCafeResponse actual = cafeService.previewCafeByMapId(member1.getEmail(), cafe.getMapId());
 
         assertAll(
-                () -> assertThat(actual1.getFavorite()).isTrue(),
-                () -> assertThat(actual1.getScore()).isEqualTo(4.5),
-                () -> assertThat(actual1.getStudyType()).isNull(),
-                () -> assertThat(actual1.getReviewsCount()).isEqualTo(0)
+                () -> assertThat(actual.getFavorite()).isTrue(),
+                () -> assertThat(actual.getScore()).isEqualTo(4.5),
+                () -> assertThat(actual.getStudyType()).isNull(),
+                () -> assertThat(actual.getReviewsCount()).isEqualTo(0)
         );
     }
 
@@ -221,13 +221,13 @@ class CafeServiceTest {
                         "깨끗해요", "없어요", null, "보통이에요"));
         favoriteRepository.save(new Favorite(member1, cafe));
 
-        PreviewCafeResponse actual1 = cafeService.previewCafeByMapId(member1.getEmail(), cafe.getMapId());
+        PreviewCafeResponse actual = cafeService.previewCafeByMapId(member1.getEmail(), cafe.getMapId());
 
         assertAll(
-                () -> assertThat(actual1.getFavorite()).isTrue(),
-                () -> assertThat(actual1.getScore()).isEqualTo(2.5),
-                () -> assertThat(actual1.getStudyType()).isEqualTo("group"),
-                () -> assertThat(actual1.getReviewsCount()).isEqualTo(2)
+                () -> assertThat(actual.getFavorite()).isTrue(),
+                () -> assertThat(actual.getScore()).isEqualTo(2.5),
+                () -> assertThat(actual.getStudyType()).isEqualTo("group"),
+                () -> assertThat(actual.getReviewsCount()).isEqualTo(2)
         );
     }
 

--- a/src/test/java/mocacong/server/service/ServiceTest.java
+++ b/src/test/java/mocacong/server/service/ServiceTest.java
@@ -5,12 +5,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import mocacong.server.support.DatabaseCleanerCallback;
+import mocacong.server.support.TestRedisConfig;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(DatabaseCleanerCallback.class)
+@Import(TestRedisConfig.class)
 public @interface ServiceTest {
 }

--- a/src/test/java/mocacong/server/support/TestRedisConfig.java
+++ b/src/test/java/mocacong/server/support/TestRedisConfig.java
@@ -1,0 +1,34 @@
+package mocacong.server.support;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import redis.embedded.RedisServer;
+
+@TestConfiguration
+public class TestRedisConfig {
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void startRedis() {
+        try {
+            redisServer = RedisServer.builder()
+                    .port(port)
+                    .setting("maxmemory 256M")
+                    .build();
+            redisServer.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        redisServer.stop();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,9 @@ spring:
           enabled: true
         show_sql: true
         format_sql: true
+  redis:
+    host: localhost
+    port: 16379
 
   h2:
     console:


### PR DESCRIPTION
## 개요
- 수정이 잦지 않고, 조회가 빈번한 api나 작업들이 존재합니다. 해당 작업들 중, 비교적 오래 걸리는 작업은 캐시를 적용할 필요성이 있어보였습니다.
### 캐시 적용 전 카페 미리보기 조회 API
![image](https://github.com/mocacong/Mocacong-Backend/assets/57135043/ed3993ad-7a90-43da-b446-e1e18d58ff06)

### 캐시 적용 후 카페 미리보기 조회 API
![image](https://github.com/mocacong/Mocacong-Backend/assets/57135043/b39757ac-6ff0-4f30-aaaa-472cff3c6c97)

## 작업사항
- 카페 미리보기 API, Apple OAuth 공개키, accessToken 조회 시에 캐싱을 적용했습니다.

## 주의사항
- 로컬에서 `redis-cli` 를 이용하여 조회하는 것을 추천드립니다. `redis`, `redis-cli`가 설치돼있지 않으면 카페 미리보기 조회 API가 실패합니다.
  - **로컬에서는 elasticache 사용 불가능!** 본인 IP (`127.0.0.1`이 엔드포인트가 될 것입니다.)
  - redis에 먼저 조회 -> 캐시가 있으면 해당 값을,  존재하지 않으면 실제로 DB 조회
- 개발 환경, 운영 환경은 비용 문제로 인해 동일한 elasticache를 참조합니다.
  - `redis-cli -h {AWS Elasticache 엔드포인트} -p ${AWS Elasticache 포트}`
  - 엔드포인트, 포트는 aws Elasticache의 Redis 클러스터에서 조회 가능합니다.

- 캐시 만료일자가 적절한지 체크해주세요.
