### PR TITLE
feat: 즐겨찾기한 카페 필터링 조회 POST API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import mocacong.server.dto.request.CafeFilterRequest;
-import mocacong.server.dto.request.CafeRegisterRequest;
-import mocacong.server.dto.request.CafeReviewRequest;
-import mocacong.server.dto.request.CafeReviewUpdateRequest;
+import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.LoginUserEmail;
 import mocacong.server.service.CafeService;
@@ -96,6 +93,14 @@ public class CafeController {
     public ResponseEntity<CafeFilterResponse> getCafesByStudyType(@RequestParam(required = false) String studytype,
                                                                   @RequestBody CafeFilterRequest request) {
         CafeFilterResponse responseBody = cafeService.filterCafesByStudyType(studytype, request);
+        return ResponseEntity.ok(responseBody);
+    }
+
+    @Operation(summary = "즐겨찾기가 등록된 카페 조회")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping("/favorites")
+    public ResponseEntity<CafeFilterFavoritesResponse> getCafesByFavorites(@RequestBody CafeFilterFavoritesRequest request) {
+        CafeFilterFavoritesResponse responseBody = cafeService.filterCafesByFavorites(request);
         return ResponseEntity.ok(responseBody);
     }
 

--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -99,8 +99,11 @@ public class CafeController {
     @Operation(summary = "즐겨찾기가 등록된 카페 조회")
     @SecurityRequirement(name = "JWT")
     @PostMapping("/favorites")
-    public ResponseEntity<CafeFilterFavoritesResponse> getCafesByFavorites(@RequestBody CafeFilterFavoritesRequest request) {
-        CafeFilterFavoritesResponse responseBody = cafeService.filterCafesByFavorites(request);
+    public ResponseEntity<CafeFilterFavoritesResponse> getCafesByFavorites(
+            @LoginUserEmail String email,
+            @RequestBody CafeFilterFavoritesRequest request
+    ) {
+        CafeFilterFavoritesResponse responseBody = cafeService.filterCafesByFavorites(email, request);
         return ResponseEntity.ok(responseBody);
     }
 

--- a/src/main/java/mocacong/server/dto/request/CafeFilterFavoritesRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeFilterFavoritesRequest.java
@@ -1,0 +1,13 @@
+package mocacong.server.dto.request;
+
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class CafeFilterFavoritesRequest {
+    private List<String> mapIds;
+}

--- a/src/main/java/mocacong/server/dto/response/CafeFilterFavoritesResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeFilterFavoritesResponse.java
@@ -1,0 +1,13 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class CafeFilterFavoritesResponse {
+    private List<String> mapIds;
+}

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -20,6 +20,12 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
             "join f.cafe c " +
             "join f.member m " +
             "where m.email = :email")
+    List<Cafe> findByFavoriteCafes(String email);
+
+    @Query("select c from Favorite f " +
+            "join f.cafe c " +
+            "join f.member m " +
+            "where m.email = :email")
     Slice<Cafe> findByMyFavoriteCafes(String email, Pageable pageRequest);
 
     @Query("select c from Review r " +

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -16,11 +16,10 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
     @Query("SELECT c FROM Cafe c WHERE c.cafeDetail.studyType = :studyType")
     List<Cafe> findByStudyTypeValue(StudyType studyType);
 
-    @Query("select c from Favorite f " +
-            "join f.cafe c " +
-            "join f.member m " +
-            "where m.email = :email")
-    List<Cafe> findByFavoriteCafes(String email);
+    @Query("select c.mapId from Favorite f " +
+            "join f.cafe c join f.member m " +
+            "where c.mapId in :mapIds and m.email = :email")
+    List<String> findNearCafeMapIdsByMyFavoriteCafes(String email, List<String> mapIds);
 
     @Query("select c from Favorite f " +
             "join f.cafe c " +

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -3,10 +3,7 @@ package mocacong.server.service;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
-import mocacong.server.dto.request.CafeFilterRequest;
-import mocacong.server.dto.request.CafeRegisterRequest;
-import mocacong.server.dto.request.CafeReviewRequest;
-import mocacong.server.dto.request.CafeReviewUpdateRequest;
+import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
 import mocacong.server.exception.notfound.NotFoundCafeException;
@@ -271,17 +268,30 @@ public class CafeService {
                 .forEach(Score::removeMember);
     }
 
-    public CafeFilterResponse filterCafesByStudyType(String studyTypeValue, CafeFilterRequest requestBody) {
+    public CafeFilterResponse filterCafesByStudyType(String studyTypeValue, CafeFilterRequest request) {
         List<Cafe> cafes = cafeRepository.findByStudyTypeValue(StudyType.from(studyTypeValue));
         Set<String> filteredCafeMapIds = cafes.stream()
                 .map(Cafe::getMapId)
                 .collect(Collectors.toSet());
 
-        List<String> filteredIds = requestBody.getMapIds().stream()
+        List<String> filteredIds = request.getMapIds().stream()
                 .filter(filteredCafeMapIds::contains)
                 .collect(Collectors.toList());
 
         return new CafeFilterResponse(filteredIds);
+    }
+
+    public CafeFilterFavoritesResponse filterCafesByFavorites(String email, CafeFilterFavoritesRequest request) {
+        List<Cafe> cafes = cafeRepository.findByFavoriteCafes(email);
+        Set<String> filteredCafeMapIds = cafes.stream()
+                .map(Cafe::getMapId)
+                .collect(Collectors.toSet());
+
+        List<String> filteredIds = request.getMapIds().stream()
+                .filter(filteredCafeMapIds::contains)
+                .collect(Collectors.toList());
+
+        return new CafeFilterFavoritesResponse(filteredIds);
     }
 
     @Transactional

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -282,14 +282,8 @@ public class CafeService {
     }
 
     public CafeFilterFavoritesResponse filterCafesByFavorites(String email, CafeFilterFavoritesRequest request) {
-        List<Cafe> cafes = cafeRepository.findByFavoriteCafes(email);
-        Set<String> filteredCafeMapIds = cafes.stream()
-                .map(Cafe::getMapId)
-                .collect(Collectors.toSet());
-
-        List<String> filteredIds = request.getMapIds().stream()
-                .filter(filteredCafeMapIds::contains)
-                .collect(Collectors.toList());
+        List<String> mapIds = request.getMapIds();
+        List<String> filteredIds = cafeRepository.findNearCafeMapIdsByMyFavoriteCafes(email, mapIds);
 
         return new CafeFilterFavoritesResponse(filteredIds);
     }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -274,7 +274,7 @@ public class CafeService {
                 .map(Cafe::getMapId)
                 .collect(Collectors.toSet());
 
-        List<String> filteredIds = request.getMapIds().stream()
+        List<String> filteredIds = requestBody.getMapIds().stream()
                 .filter(filteredCafeMapIds::contains)
                 .collect(Collectors.toList());
 

--- a/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
@@ -2,6 +2,7 @@ package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
 import mocacong.server.dto.request.*;
+import mocacong.server.dto.response.CafeFilterFavoritesResponse;
 import mocacong.server.dto.response.CafeFilterResponse;
 import mocacong.server.dto.response.CafeReviewResponse;
 import mocacong.server.dto.response.CafeReviewUpdateResponse;
@@ -203,7 +204,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
 
     @Test
     @DisplayName("studyTypeValue가 solo로 주어진 경우 해당 카페 목록을 필터링한다")
-    void getCafesFilter() {
+    void getCafesFilterStudyType() {
         String mapId1 = "12332312";
         String mapId2 = "12355412";
         String mapId3 = "18486512";
@@ -233,6 +234,36 @@ public class CafeAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract()
                 .as(CafeFilterResponse.class);
+
+        assertThat(actual.getMapIds()).containsExactlyInAnyOrder(mapId1, mapId3);
+    }
+
+    @Test
+    @DisplayName("즐겨찾기가 등록된 카페 목록을 필터링한다")
+    void getCafesFilterFavorites() {
+        String mapId1 = "12332312";
+        String mapId2 = "12355412";
+        String mapId3 = "18486512";
+        카페_등록(new CafeRegisterRequest(mapId1, "메리네 카페 본점"));
+        카페_등록(new CafeRegisterRequest(mapId2, "메리네 카페 2호점"));
+        카페_등록(new CafeRegisterRequest(mapId3, "메리네 카페 3호점"));
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+
+        즐겨찾기_등록(token, mapId1);
+        즐겨찾기_등록(token, mapId3);
+        CafeFilterFavoritesRequest request = new CafeFilterFavoritesRequest(List.of(mapId1, mapId2, mapId3));
+
+        CafeFilterFavoritesResponse actual = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .body(request)
+                .when().post("/cafes/favorites")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(CafeFilterFavoritesResponse.class);
 
         assertThat(actual.getMapIds()).containsExactlyInAnyOrder(mapId1, mapId3);
     }

--- a/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -22,6 +24,33 @@ class CafeRepositoryTest {
     private FavoriteRepository favoriteRepository;
     @Autowired
     private ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("내가 즐겨찾기에 등록한 카페 mapId 목록을 조회한다.")
+    void findNearCafeMapIdsByMyFavoriteCafes() {
+        String mapId1 = "1";
+        String mapId2 = "2";
+        String mapId3 = "3";
+        String mapId4 = "4";
+        Cafe savedCafe1 = cafeRepository.save(new Cafe(mapId1, "케이카페1"));
+        Cafe savedCafe2 = cafeRepository.save(new Cafe(mapId2, "케이카페2"));
+        Cafe savedCafe3 = cafeRepository.save(new Cafe(mapId3, "케이카페3"));
+        Cafe savedCafe4 = cafeRepository.save(new Cafe(mapId4, "케이카페4"));
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        favoriteRepository.save(new Favorite(member, savedCafe1));
+        favoriteRepository.save(new Favorite(member, savedCafe2));
+        favoriteRepository.save(new Favorite(member, savedCafe3));
+        List<String> mapIds = List.of(mapId1, mapId2, mapId3, mapId4);
+
+        List<String> actual = cafeRepository.findNearCafeMapIdsByMyFavoriteCafes(member.getEmail(), mapIds);
+
+        assertAll(
+                () -> assertThat(actual).hasSize(3),
+                () -> assertThat(actual.get(0)).isEqualTo(mapId1),
+                () -> assertThat(actual.get(1)).isEqualTo(mapId2),
+                () -> assertThat(actual.get(2)).isEqualTo(mapId3)
+        );
+    }
 
     @Test
     @DisplayName("내가 즐겨찾기에 등록한 카페 목록을 조회한다")

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -641,10 +641,8 @@ class CafeServiceTest {
     @Test
     @DisplayName("즐겨찾기가 등록된 카페가 있는 경우 해당 카페 목록을 필터링한다")
     void getCafesFilterFavorites() {
-        Member member1 = new Member("dlawotn3@naver.com", "encodePassword", "메리", "010-1234-5678");
-        Member member2 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
-        memberRepository.save(member1);
-        memberRepository.save(member2);
+        Member member = new Member("dlawotn3@naver.com", "encodePassword", "메리", "010-1234-5678");
+        memberRepository.save(member);
         Cafe cafe1 = new Cafe("2143154352323", "케이카페");
         Cafe cafe2 = new Cafe("2143154311111", "메리카페");
         Cafe cafe3 = new Cafe("2111111125885", "메리카페 2호점");
@@ -653,15 +651,13 @@ class CafeServiceTest {
         cafeRepository.save(cafe2);
         cafeRepository.save(cafe3);
         cafeRepository.save(cafe4);
-        favoriteRepository.save(new Favorite(member1, cafe1));
-        favoriteRepository.save(new Favorite(member1, cafe2));
-        favoriteRepository.save(new Favorite(member2, cafe3));
-        favoriteRepository.save(new Favorite(member2, cafe4));
+        favoriteRepository.save(new Favorite(member, cafe1));
+        favoriteRepository.save(new Favorite(member, cafe2));
         CafeFilterFavoritesRequest requestBody = new CafeFilterFavoritesRequest(
                 List.of(cafe1.getMapId(), cafe2.getMapId(), cafe3.getMapId(), cafe4.getMapId())
         );
 
-        CafeFilterFavoritesResponse filteredCafes = cafeService.filterCafesByFavorites(member1.getEmail(), requestBody);
+        CafeFilterFavoritesResponse filteredCafes = cafeService.filterCafesByFavorites(member.getEmail(), requestBody);
 
         assertThat(filteredCafes.getMapIds())
                 .containsExactlyInAnyOrder(cafe1.getMapId(), cafe2.getMapId());

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -631,7 +631,7 @@ class CafeServiceTest {
         cafeService.saveCafeReview(member.getEmail(), cafe.getMapId(),
                 new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
                         "깨끗해요", "충분해요", "조용해요", "편해요"));
-        CafeFilterStudyTypeRequest requestBody = new CafeFilterStudyTypeRequest(List.of(cafe1.getMapId()));
+        CafeFilterStudyTypeRequest requestBody = new CafeFilterStudyTypeRequest(List.of(cafe.getMapId()));
 
         CafeFilterStudyTypeResponse filteredCafes = cafeService.filterCafesByStudyType("group", requestBody);
 


### PR DESCRIPTION
## 개요
- 즐겨찾기한 카페를 필터링하여 카페 목록을 조회하는 API를 구현했습니다.

## 작업사항
- 즐겨찾기한 카페 필터링 조회 POST API 구현
- 즐겨찾기한 카페 필터링 조회 테스트코드 작성

## 주의사항
- api spec에 맞게 구현되었는지 확인해주세요
- 스웨거로 동작 확인해주세요
- 오타가 있는지 확인해주세요
- 더 나은 로직이 있다면 알려주세요
