### PR TITLE
fix: 마이페이지 조회 GET API response 수정

### DIFF
--- a/src/main/java/mocacong/server/dto/response/MyPageResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyPageResponse.java
@@ -8,6 +8,8 @@ import lombok.*;
 @ToString
 public class MyPageResponse {
 
+    private String email;
     private String nickname;
+    private String phone;
     private String imgUrl;
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -1,7 +1,6 @@
 package mocacong.server.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.MemberProfileImage;
 import mocacong.server.domain.Platform;
@@ -167,7 +166,7 @@ public class MemberService {
     public MyPageResponse findMyInfo(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
-        return new MyPageResponse(member.getNickname(), member.getImgUrl());
+        return new MyPageResponse(member.getEmail(), member.getNickname(), member.getPhone(), member.getImgUrl());
     }
 
     @Transactional

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -303,7 +303,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .as(MyPageResponse.class);
 
         assertAll(
+                () -> assertThat(actual.getEmail()).isEqualTo("kth990303@naver.com"),
                 () -> assertThat(actual.getNickname()).isEqualTo("케이"),
+                () -> assertThat(actual.getPhone()).isEqualTo("010-1234-5678"),
                 () -> assertThat(actual.getImgUrl()).isNull()
         );
     }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -298,17 +298,21 @@ class MemberServiceTest {
     @DisplayName("마이페이지로 내 정보를 조회한다")
     void findMyInfo() {
         String imgUrl = "test_img.jpg";
+        String email = "kth990303@naver.com";
         String nickname = "케이";
+        String phone = "010-1234-5678";
         MemberProfileImage memberProfileImage = new MemberProfileImage(imgUrl);
         memberProfileImageRepository.save(memberProfileImage);
-        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678",
-                memberProfileImage, Platform.MOCACONG, "1234");
+        Member member = new Member(email, "a1b2c3d4", "케이", phone, memberProfileImage,
+                Platform.MOCACONG, "1234");
         memberRepository.save(member);
 
-        MyPageResponse actual = memberService.findMyInfo(member.getEmail());
+        MyPageResponse actual = memberService.findMyInfo(email);
 
         assertAll(
+                () -> assertThat(actual.getEmail()).isEqualTo(email),
                 () -> assertThat(actual.getImgUrl()).isEqualTo(imgUrl),
+                () -> assertThat(actual.getPhone()).isEqualTo(phone),
                 () -> assertThat(actual.getNickname()).isEqualTo(nickname)
         );
     }


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 마이페이지 조회 시, email과 phone 필드도 같이 넘겨주도록 API를 수정했습니다.

## 작업사항
- 마이페이지 조회 response 수정
- 마이페이지 조회 테스트 코드 수정

## 주의사항
- api spec과 동일하게 구현되었는지 확인해주세요
- 오타가 있는지 확인해주세요