### PR TITLE
fix: 내가 작성한 특정 카페 리뷰 조회 GET API 수정

### DIFF
--- a/src/main/java/mocacong/server/dto/response/CafeMyReviewResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeMyReviewResponse.java
@@ -4,7 +4,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mocacong.server.domain.CafeDetail;
 import mocacong.server.domain.Review;
 import mocacong.server.domain.Score;
 
@@ -23,16 +22,15 @@ public class CafeMyReviewResponse {
     private String myDesk;
 
     public static CafeMyReviewResponse of(Score score, Review review) {
-        CafeDetail cafeDetail = review.getCafeDetail();
         return new CafeMyReviewResponse(
                 score != null ? score.getScore() : null,
-                cafeDetail.getStudyTypeValue(),
-                cafeDetail.getWifiValue(),
-                cafeDetail.getParkingValue(),
-                cafeDetail.getToiletValue(),
-                cafeDetail.getPowerValue(),
-                cafeDetail.getSoundValue(),
-                cafeDetail.getDeskValue()
+                review != null ? review.getCafeDetail().getStudyTypeValue() : null,
+                review != null ? review.getCafeDetail().getWifiValue() : null,
+                review != null ? review.getCafeDetail().getParkingValue() : null,
+                review != null ? review.getCafeDetail().getToiletValue() : null,
+                review != null ? review.getCafeDetail().getPowerValue() : null,
+                review != null ? review.getCafeDetail().getSoundValue() : null,
+                review != null ? review.getCafeDetail().getDeskValue() : null
         );
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -224,7 +224,7 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
 
         Review review = reviewRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
-                .orElseThrow(NotFoundReviewException::new);
+                .orElse(null);
         Score score = scoreRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
         return CafeMyReviewResponse.of(score, review);

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,8 +1,5 @@
 package mocacong.server.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
@@ -13,16 +10,21 @@ import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
 class CafeServiceTest {
@@ -514,6 +516,28 @@ class CafeServiceTest {
                 () -> assertThat(actual.getMyPower()).isEqualTo("충분해요"),
                 () -> assertThat(actual.getMySound()).isEqualTo("조용해요"),
                 () -> assertThat(actual.getMyDesk()).isEqualTo("편해요")
+        );
+    }
+
+    @Test
+    @DisplayName("작성하지 않은 카페에 대한 리뷰를 조회하는 경우 null을 반환한다")
+    void findNotRegisteredCafeReview() {
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+
+        CafeMyReviewResponse actual = cafeService.findMyCafeReview(member.getEmail(), cafe.getMapId());
+
+        assertAll(
+                () -> assertThat(actual.getMyScore()).isNull(),
+                () -> assertThat(actual.getMyStudyType()).isNull(),
+                () -> assertThat(actual.getMyWifi()).isNull(),
+                () -> assertThat(actual.getMyParking()).isNull(),
+                () -> assertThat(actual.getMyToilet()).isNull(),
+                () -> assertThat(actual.getMyPower()).isNull(),
+                () -> assertThat(actual.getMySound()).isNull(),
+                () -> assertThat(actual.getMyDesk()).isNull()
         );
     }
 

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -1,6 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
@@ -10,13 +9,16 @@ import mocacong.server.exception.notfound.NotFoundFavoriteException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @ServiceTest
 class FavoriteServiceTest {


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 내가 작성하지 않은 특정 카페 리뷰에 대해 조회 할 때, 예외 대신 null을 보내주도록 변경했습니다
![image](https://github.com/mocacong/Mocacong-Backend/assets/69844138/01d9fc83-1cdf-4f8a-a598-ccfa46fcb87f)


## 작업사항
- 리뷰를 작성하지 않은 카페에 대해 내가 작성한 카페 리뷰 조회를 하는 경우 response에 null을 반환하도록 API 수정
![image](https://github.com/mocacong/Mocacong-Backend/assets/69844138/5dd1175b-1e28-4a27-9c84-5bdfdeee3f93)

- 해당 변경사항에 대해 테스트 코드 추가

## 주의사항
- 더 좋은 로직이 있다면 추천해주세요
- 스웨거로 동작 확인해주세요
