### PR TITLE
feat: 카페 이미지를 요청 당 3개까지 올릴 수 있도록 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -3,8 +3,9 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.LoginUserEmail;
@@ -13,8 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.validation.Valid;
 
 @Tag(name = "Cafes", description = "카페")
 @RestController
@@ -116,9 +115,9 @@ public class CafeController {
     public ResponseEntity<Void> saveCafeImage(
             @LoginUserEmail String email,
             @PathVariable String mapId,
-            @RequestParam(value = "file") MultipartFile multipartFile
+            @RequestParam(value = "files") List<MultipartFile> multipartFiles
     ) {
-        cafeService.saveCafeImage(email, mapId, multipartFile);
+        cafeService.saveCafeImage(email, mapId, multipartFiles);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/mocacong/server/exception/badrequest/ExceedCafeImagesCountsException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/ExceedCafeImagesCountsException.java
@@ -1,0 +1,11 @@
+package mocacong.server.exception.badrequest;
+
+import lombok.Getter;
+
+@Getter
+public class ExceedCafeImagesCountsException extends BadRequestException {
+
+    public ExceedCafeImagesCountsException() {
+        super("카페 이미지는 한 번에 최대 3개까지만 업로드 가능합니다.", 2008);
+    }
+}


### PR DESCRIPTION
## 개요
- 한 요청 당 이미지를 여러 개 올릴 수 있도록 변경 수요가 존재합니다.

## 작업사항
- 카페 이미지를 요청 당 3개까지 올릴 수 있도록 구현했습니다.
- aws측에서 `putObjects` 벌크 연산을 지원하지 않습니다. (파일마다 메타데이터가 다르기 때문인 것으로 추측 중)
  - for문으로 처리하였습니다.

## 주의사항
- swagger로 동작 확인 부탁드려요
