### PR TITLE
feat: 운영 서버 배포를 위한 develop 브랜치 트리거 삭제

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -3,7 +3,7 @@ name: Java CD with Gradle and Docker
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
## 개요
- 메인 브랜치 최종 배포를 진행해야 합니다. 배포 이후에는, 개발 서버(베타 서버)에 머지되는 내용들이 실제 운영서버에 바로 머지되면 안됩니다.

ex) 개발 서버에서 리프레시 토큰 기능 도입, 유저 안정성 목적 등으로 인해 아직 운영서버에는 도입 안할 예정인 경우 
         => 개발서버(develop 브랜치)에만 머지되고, 운영서버(main 브랜치)에는 머지되면 안됨.

## 작업사항
- 도커 자동 배포화 작업을 메인에서만 동작하도록 변경했습니다.

## 주의사항
- 도커 외에 develop 브랜치에서 수행되지 않도록 변경돼야 하는 것이 있는데 놓친 것이 있으면 리뷰해주세요
- 개발 서버와 운영 서버가 현재 다른점
  - ddl-auto
    - develop: update
    - main: validate
  - docker CD
    - develop: (이 PR이 머지되면) 미포함
    - main: 포함  