### PR TITLE
fix: 카페 세부정보 수정 후 결과 반환 시 null 허용

### DIFF
--- a/src/main/java/mocacong/server/domain/Score.java
+++ b/src/main/java/mocacong/server/domain/Score.java
@@ -8,7 +8,9 @@ import mocacong.server.exception.badrequest.InvalidScoreException;
 import javax.persistence.*;
 
 @Entity
-@Table(name = "score")
+@Table(name = "score", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "member_id", "cafe_id" })
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Score extends BaseTime {

--- a/src/main/java/mocacong/server/dto/response/CafeReviewUpdateResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeReviewUpdateResponse.java
@@ -27,12 +27,12 @@ public class CafeReviewUpdateResponse {
         return new CafeReviewUpdateResponse(
                 score,
                 cafeDetail.getStudyTypeValue(),
-                cafeDetail.getWifi().getValue(),
-                cafeDetail.getParking().getValue(),
-                cafeDetail.getToilet().getValue(),
-                cafeDetail.getPower().getValue(),
-                cafeDetail.getSound().getValue(),
-                cafeDetail.getDesk().getValue(),
+                cafeDetail.getWifiValue(),
+                cafeDetail.getParkingValue(),
+                cafeDetail.getToiletValue(),
+                cafeDetail.getPowerValue(),
+                cafeDetail.getSoundValue(),
+                cafeDetail.getDeskValue(),
                 reviewsCount
         );
     }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -205,7 +205,6 @@ public class CafeService {
 
     private void saveCafeDetails(CafeReviewRequest request, Cafe cafe, Member member) {
         Score score = new Score(request.getMyScore(), member, cafe);
-        scoreRepository.save(score);
         CafeDetail cafeDetail = new CafeDetail(
                 StudyType.from(request.getMyStudyType()),
                 Wifi.from(request.getMyWifi()),
@@ -217,6 +216,7 @@ public class CafeService {
         );
         Review review = new Review(member, cafe, cafeDetail);
         try {
+            scoreRepository.save(score);
             reviewRepository.save(review);
         } catch (DataIntegrityViolationException e) {
             throw new AlreadyExistsCafeReview();

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -594,6 +594,34 @@ class CafeServiceTest {
     }
 
     @Test
+    @DisplayName("등록한 카페 리뷰를 수정할 때 세부정보를 모두 null 값으로 성공적으로 수정한다")
+    public void updateCafeReviewWhenDetailsNull() {
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        cafeService.saveCafeReview(member.getEmail(), cafe.getMapId(),
+                new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
+                        "깨끗해요", "충분해요", "조용해요", "편해요"));
+
+        CafeReviewUpdateResponse actual = cafeService.updateCafeReview(member.getEmail(), cafe.getMapId(),
+                new CafeReviewUpdateRequest(5, "group", null, null,
+                        null, null, null, null));
+
+        assertAll(
+                () -> assertThat(actual.getScore()).isEqualTo(5.0),
+                () -> assertThat(actual.getStudyType()).isEqualTo("group"),
+                () -> assertThat(actual.getWifi()).isNull(),
+                () -> assertThat(actual.getParking()).isNull(),
+                () -> assertThat(actual.getToilet()).isNull(),
+                () -> assertThat(actual.getPower()).isNull(),
+                () -> assertThat(actual.getSound()).isNull(),
+                () -> assertThat(actual.getDesk()).isNull(),
+                () -> assertThat(actual.getReviewsCount()).isEqualTo(1)
+        );
+    }
+
+    @Test
     @DisplayName("카페 리뷰를 등록한 적이 없다면 리뷰 수정은 불가능하다")
     public void updateCafeReviewNotFoundReview() {
         Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");


### PR DESCRIPTION
## 개요
- 카페 세부정보를 수정할 때 null로 수정하면 NPE가 발생합니다.

## 작업사항
- 세부정보 수정 후 결과 반환 시 Null을 허용하여 반환할 수 있도록 변경했습니다.

## 주의사항
아래 형식대로 수정이 잘 되는지 확인 후, 조회까지 체크해주세요
```coffeescript
{
  "myScore": 4,
  "myStudyType": "group",
  "myWifi": null,
  "myParking": null,
  "myToilet": null,
  "myPower": null,
  "mySound": null,
  "myDesk": null
}
```
