### PR TITLE
fix: 이메일과 플랫폼 일치 여부를 확인하는 회원 중복 체크로 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -10,7 +10,9 @@ import javax.persistence.*;
 import java.util.regex.Pattern;
 
 @Entity
-@Table(name = "member")
+@Table(name = "member", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "platform", "email" })
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTime {
@@ -23,7 +25,7 @@ public class Member extends BaseTime {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "email", unique = true, nullable = false)
+    @Column(name = "email", nullable = false)
     private String email;
 
     @Column(name = "password")

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -14,7 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 
-    Optional<Member> findByEmailAndPlatform(String email, Platform platform);
+    Boolean existsByPlatformAndEmail(String email, Platform platform);
 
     @Query("select m.id from Member m where m.platform = :platform and m.platformId = :platformId")
     Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -14,7 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 
-    Boolean existsByPlatformAndEmail(String email, Platform platform);
+    Boolean existsByEmailAndPlatform(String email, Platform platform);
 
     @Query("select m.id from Member m where m.platform = :platform and m.platformId = :platformId")
     Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -10,11 +10,11 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByNickname(String nickname);
-
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 
     Boolean existsByEmailAndPlatform(String email, Platform platform);
+
+    Boolean existsByNickname(String nickname);
 
     @Query("select m.id from Member m where m.platform = :platform and m.platformId = :platformId")
     Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -1,10 +1,11 @@
 package mocacong.server.repository;
 
-import java.util.Optional;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
@@ -12,6 +13,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
 
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
+
+    Optional<Member> findByEmailAndPlatform(String email, Platform platform);
 
     @Query("select m.id from Member m where m.platform = :platform and m.platformId = :platformId")
     Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -8,6 +8,7 @@ import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.request.KakaoLoginRequest;
 import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
+import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
@@ -40,6 +41,10 @@ public class AuthService {
     public OAuthTokenResponse appleOAuthLogin(AppleLoginRequest request) {
         OAuthPlatformMemberResponse applePlatformMember =
                 appleOAuthUserProvider.getApplePlatformMember(request.getToken());
+        memberRepository.findByEmailAndPlatform(applePlatformMember.getEmail(), Platform.APPLE)
+                .ifPresent(member -> {
+                    throw new DuplicateMemberException();
+                });
         return generateOAuthTokenResponse(
                 Platform.APPLE,
                 applePlatformMember.getEmail(),
@@ -50,6 +55,10 @@ public class AuthService {
     public OAuthTokenResponse kakaoOAuthLogin(KakaoLoginRequest request) {
         OAuthPlatformMemberResponse kakaoPlatformMember =
                 kakaoOAuthUserProvider.getKakaoPlatformMember(request.getCode());
+        memberRepository.findByEmailAndPlatform(kakaoPlatformMember.getEmail(), Platform.KAKAO)
+                .ifPresent(member -> {
+                    throw new DuplicateMemberException();
+                });
         return generateOAuthTokenResponse(
                 Platform.KAKAO,
                 kakaoPlatformMember.getEmail(),

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -8,7 +8,6 @@ import mocacong.server.dto.request.AuthLoginRequest;
 import mocacong.server.dto.request.KakaoLoginRequest;
 import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
-import mocacong.server.exception.badrequest.DuplicateMemberException;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.MemberRepository;
@@ -41,10 +40,6 @@ public class AuthService {
     public OAuthTokenResponse appleOAuthLogin(AppleLoginRequest request) {
         OAuthPlatformMemberResponse applePlatformMember =
                 appleOAuthUserProvider.getApplePlatformMember(request.getToken());
-        memberRepository.findByEmailAndPlatform(applePlatformMember.getEmail(), Platform.APPLE)
-                .ifPresent(member -> {
-                    throw new DuplicateMemberException();
-                });
         return generateOAuthTokenResponse(
                 Platform.APPLE,
                 applePlatformMember.getEmail(),
@@ -55,10 +50,6 @@ public class AuthService {
     public OAuthTokenResponse kakaoOAuthLogin(KakaoLoginRequest request) {
         OAuthPlatformMemberResponse kakaoPlatformMember =
                 kakaoOAuthUserProvider.getKakaoPlatformMember(request.getCode());
-        memberRepository.findByEmailAndPlatform(kakaoPlatformMember.getEmail(), Platform.KAKAO)
-                .ifPresent(member -> {
-                    throw new DuplicateMemberException();
-                });
         return generateOAuthTokenResponse(
                 Platform.KAKAO,
                 kakaoPlatformMember.getEmail(),

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -66,10 +66,8 @@ public class MemberService {
     }
 
     private void validateDuplicateNickname(String nickname) {
-        memberRepository.findByNickname(nickname)
-                .ifPresent(member -> {
-                    throw new DuplicateNicknameException();
-                });
+        if (memberRepository.existsByNickname(nickname))
+            throw new DuplicateNicknameException();
     }
 
     @Transactional
@@ -152,8 +150,8 @@ public class MemberService {
     public IsDuplicateNicknameResponse isDuplicateNickname(String nickname) {
         validateNickname(nickname);
 
-        Optional<Member> findMember = memberRepository.findByNickname(nickname);
-        return new IsDuplicateNicknameResponse(findMember.isPresent());
+        Boolean isPresent = memberRepository.existsByNickname(nickname);
+        return new IsDuplicateNicknameResponse(isPresent);
     }
 
     private void validateNickname(String nickname) {

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -59,10 +59,10 @@ public class MemberService {
     }
 
     private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {
-        if (memberRepository.existsByPlatformAndEmail(memberSignUpRequest.getEmail(), Platform.MOCACONG)) {
+        if (memberRepository.existsByEmailAndPlatform(memberSignUpRequest.getEmail(), Platform.MOCACONG)) {
             throw new DuplicateMemberException();
         }
-        validateNickname(memberSignUpRequest.getNickname());
+        validateDuplicateNickname(memberSignUpRequest.getNickname());
     }
 
     private void validateDuplicateNickname(String nickname) {

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -59,10 +59,9 @@ public class MemberService {
     }
 
     private void validateDuplicateMember(Platform platform, MemberSignUpRequest memberSignUpRequest) {
-        memberRepository.findByEmailAndPlatform(memberSignUpRequest.getEmail(), platform)
-                .ifPresent(member -> {
-                    throw new DuplicateMemberException();
-                });
+        if (memberRepository.existsByPlatformAndEmail(memberSignUpRequest.getEmail(), platform)) {
+            throw new DuplicateMemberException();
+        }
         memberRepository.findByNickname(memberSignUpRequest.getNickname())
                 .ifPresent(member -> {
                     throw new DuplicateNicknameException();

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -23,9 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -49,7 +47,7 @@ public class MemberService {
 
     public MemberSignUpResponse signUp(MemberSignUpRequest request) {
         validatePassword(request.getPassword());
-        validateDuplicateMember(request);
+        validateDuplicateMember(Platform.MOCACONG, request);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         try{
@@ -60,8 +58,8 @@ public class MemberService {
         }
     }
 
-    private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {
-        memberRepository.findByEmail(memberSignUpRequest.getEmail())
+    private void validateDuplicateMember(Platform platform, MemberSignUpRequest memberSignUpRequest) {
+        memberRepository.findByEmailAndPlatform(memberSignUpRequest.getEmail(), platform)
                 .ifPresent(member -> {
                     throw new DuplicateMemberException();
                 });

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -47,7 +47,7 @@ public class MemberService {
 
     public MemberSignUpResponse signUp(MemberSignUpRequest request) {
         validatePassword(request.getPassword());
-        validateDuplicateMember(Platform.MOCACONG, request);
+        validateDuplicateMember(request);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         try{
@@ -58,14 +58,11 @@ public class MemberService {
         }
     }
 
-    private void validateDuplicateMember(Platform platform, MemberSignUpRequest memberSignUpRequest) {
-        if (memberRepository.existsByPlatformAndEmail(memberSignUpRequest.getEmail(), platform)) {
+    private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {
+        if (memberRepository.existsByPlatformAndEmail(memberSignUpRequest.getEmail(), Platform.MOCACONG)) {
             throw new DuplicateMemberException();
         }
-        memberRepository.findByNickname(memberSignUpRequest.getNickname())
-                .ifPresent(member -> {
-                    throw new DuplicateNicknameException();
-                });
+        validateNickname(memberSignUpRequest.getNickname());
     }
 
     private void validateDuplicateNickname(String nickname) {

--- a/src/test/java/mocacong/server/service/AuthServiceTest.java
+++ b/src/test/java/mocacong/server/service/AuthServiceTest.java
@@ -150,4 +150,23 @@ class AuthServiceTest {
                 () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
         );
     }
+
+    @Test
+    @DisplayName("OAuth 로그인을 진행한 이메일로 자체 회원가입을 한다")
+    void signUpWithAppleEmail() {
+        String email = "kth@apple.com";
+        String platformId = "1234321";
+        when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
+                .thenReturn(new OAuthPlatformMemberResponse(platformId, email));
+        OAuthTokenResponse response = authService.appleOAuthLogin(new AppleLoginRequest("token"));
+        String encodedPassword = passwordEncoder.encode("a1b2c3d4");
+
+        Member member = new Member(email, encodedPassword, "케이", "010-1234-5678");
+        memberRepository.save(member);
+
+        assertAll(
+                () -> assertThat(response.getToken()).isNotNull(),
+                () -> assertThat(response.getEmail()).isEqualTo(member.getEmail())
+        );
+    }
 }

--- a/src/test/java/mocacong/server/service/AuthServiceTest.java
+++ b/src/test/java/mocacong/server/service/AuthServiceTest.java
@@ -8,17 +8,18 @@ import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
 import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.repository.MemberRepository;
-import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
 class AuthServiceTest {
@@ -124,6 +125,27 @@ class AuthServiceTest {
         assertAll(
                 () -> assertThat(actual.getToken()).isNotNull(),
                 () -> assertThat(actual.getEmail()).isEqualTo(expected),
+                () -> assertThat(actual.getIsRegistered()).isFalse(),
+                () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
+        );
+    }
+
+    @Test
+    @DisplayName("자체 회원가입을 진행한 이메일로 정상적으로 OAuth 로그인을 한다")
+    void loginOAuthWithMocacongEmail() {
+        String email = "kth@apple.com";
+        String encodedPassword = passwordEncoder.encode("a1b2c3d4");
+        Member member = new Member(email, encodedPassword, "케이", "010-1234-5678");
+        memberRepository.save(member);
+        String platformId = "1234321";
+        when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
+                .thenReturn(new OAuthPlatformMemberResponse(platformId, email));
+
+        OAuthTokenResponse actual = authService.appleOAuthLogin(new AppleLoginRequest("token"));
+
+        assertAll(
+                () -> assertThat(actual.getToken()).isNotNull(),
+                () -> assertThat(actual.getEmail()).isEqualTo(email),
                 () -> assertThat(actual.getIsRegistered()).isFalse(),
                 () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
         );


### PR DESCRIPTION
## 개요
- 기존 회원가입 로직에서는 회원 중복 체크를 할 때 이메일로만 검증했으므로 OAuth 이메일과 동일한 이메일로 회원가입을 진행할 시 `DuplicateMemberException`이 터졌습니다. 이를 방지하기 위해 uniqueConstraints를 적용해 회원가입 시, `email` 과 `platform` 이 함께 일치하는 경우에만 `DuplicateMemberException`를 던지도록 변경했습니다.

## 작업사항
- Member 엔티티에 uniqueConstraints 추가
- 회원 중복 체크 로직 수정
- 회원가입을 진행한 이메일로 OAuth 로그인을 시도할 때 정상적으로 작동하는 지 검증하는 테스트 코드 추가

## 주의사항
- 회원 중복 체크 로직이 올바른지 확인해주세요
- Kakao OAuth 로그인으로 uniqueConstraints가 적용되었음을 확인했습니다
- 추가된 테스트 코드가 올바른지 확인해주세요
