### PR TITLE
feat: 응답값을 로그에 남기도록 구현

### DIFF
--- a/src/main/java/mocacong/server/support/logging/LoggingAspect.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingAspect.java
@@ -70,10 +70,11 @@ public class LoggingAspect {
             returning = "result"
     )
     public void allControllerResponse(JoinPoint joinPoint, Object result) {
+        String taskId = loggingStatusManager.getTaskId();
         MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
         String controllerMethodName = methodSignature.getMethod()
                 .getName();
 
-        log.info("method: {}, result: {}", controllerMethodName, result);
+        log.info("[{}] method: {}, result: {}", taskId, controllerMethodName, result);
     }
 }

--- a/src/main/java/mocacong/server/support/logging/LoggingAspect.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingAspect.java
@@ -3,10 +3,13 @@ package mocacong.server.support.logging;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -60,5 +63,17 @@ public class LoggingAspect {
         } finally {
             loggingStatusManager.release();
         }
+    }
+
+    @AfterReturning(
+            value = "execution(public * mocacong.server.controller..*Controller.*(..))",
+            returning = "result"
+    )
+    public void allControllerResponse(JoinPoint joinPoint, Object result) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        String controllerMethodName = methodSignature.getMethod()
+                .getName();
+
+        log.info("method: {}, result: {}", controllerMethodName, result);
     }
 }

--- a/src/main/java/mocacong/server/support/logging/LoggingAspect.java
+++ b/src/main/java/mocacong/server/support/logging/LoggingAspect.java
@@ -33,7 +33,7 @@ public class LoggingAspect {
     }
 
     @Around("allComponents()")
-    public Object doLogTrace(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object trace(ProceedingJoinPoint joinPoint) throws Throwable {
         final String message = joinPoint.getSignature().toShortString();
         final Object[] args = joinPoint.getArgs();
         try {
@@ -48,7 +48,7 @@ public class LoggingAspect {
     }
 
     @Around("allController()")
-    public Object doLogRequest(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object request(ProceedingJoinPoint joinPoint) throws Throwable {
         loggingStatusManager.syncStatus();
         String taskId = loggingStatusManager.getTaskId();
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
@@ -69,7 +69,7 @@ public class LoggingAspect {
             value = "execution(public * mocacong.server.controller..*Controller.*(..))",
             returning = "result"
     )
-    public void allControllerResponse(JoinPoint joinPoint, Object result) {
+    public void response(JoinPoint joinPoint, Object result) {
         String taskId = loggingStatusManager.getTaskId();
         MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
         String controllerMethodName = methodSignature.getMethod()


### PR DESCRIPTION
## 개요
- 기존 로그에는 request 메서드, request Body, response time, exception 정도를 알 수 있었습니다. 
- 하지만, **응답값이 무엇인지는 알기 어렵습니다.** 아래 사진은 오늘 QA를 진행하면서 발생한 로그입니다.
<img width="488" alt="image" src="https://github.com/mocacong/Mocacong-Backend/assets/57135043/daf3efa7-9d70-4063-a316-cb4f098cdc49">

response body가 무엇인지 알기 어렵습니다.

## 작업사항
- response body가 로그에 남도록 Spring AOP의 `@AfterReturning`으로 구현했습니다. 예외 발생 시 트리거가 발생하는 `@AfterThrowing`는 진행하지 않았습니다. 현재 로그 정책으로도 에러 원인 파악은 무난하다고 생각했기 때문이에요.

```coffeescript
[2023-06-07 23:48:50:254514] [http-nio-8080-exec-2] INFO  [mocacong.server.support.logging.LoggingAspect.allControllerResponse:77] - method: findComments, result: <200 OK OK,CommentsResponse(isEnd=true, comments=[CommentResponse(id=1, imgUrl=null, nickname=케이, content=혼코딩하기 좋고, 그리고 개인적으론 음료도 나쁘지 않았어요, isMe=true)]),[]>
[2023-06-07 23:48:50:254516] [http-nio-8080-exec-2] INFO  [mocacong.server.support.logging.LoggingTracer.end:33] - [b7734bea] <--- CommentController.findComments(..) time=28ms
```

## 주의사항
- 로그가 잘 남는지 확인해주세요.
- 개발서버 및 운영서버에서 별도로 처리해야되는 로그 정책이 있으면 리뷰해주세요.
