### PR TITLE
feat: 회원 탈퇴 시, 프로필 이미지 연동 해제 기능 구현

### DIFF
--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -92,6 +92,7 @@ public class MemberService {
     public void delete(String email) {
         Member findMember = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
+        findMember.updateProfileImgUrl(null);
         applicationEventPublisher.publishEvent(new MemberEvent(findMember));
         memberRepository.delete(findMember);
     }

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -1,5 +1,9 @@
 package mocacong.server.service;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import static java.lang.Integer.parseInt;
+import java.util.List;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.MemberProfileImage;
 import mocacong.server.domain.Platform;
@@ -12,25 +16,19 @@ import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
 import mocacong.server.support.AwsSESSender;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.List;
-
-import static java.lang.Integer.parseInt;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 @ServiceTest
 class MemberServiceTest {
@@ -450,6 +448,22 @@ class MemberServiceTest {
                 () -> assertThat(actual).extracting("imgUrl")
                         .containsExactlyInAnyOrder("test_img.jpg")
         );
+    }
+
+    @Test
+    @DisplayName("프로필 이미지가 등록된 회원이 탈퇴하면 해당 프로필 이미지는 사용되지 않는 것으로 변경된다")
+    void deleteMemberAndProfileImage() {
+        MemberProfileImage memberProfileImage = new MemberProfileImage("test_img.jpg");
+        memberProfileImageRepository.save(memberProfileImage);
+        Member member = memberRepository.save(
+                new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678", memberProfileImage)
+        );
+
+        memberService.delete(member.getEmail());
+
+        MemberProfileImage actual = memberProfileImageRepository.findById(memberProfileImage.getId())
+                .orElseThrow();
+        assertThat(actual.getIsUsed()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## 개요
- 회원 탈퇴 시에, 해당 회원의 프로필 이미지 또한 삭제시켜주어야 합니다.

## 작업사항
- 회원탈퇴가 발생하면 해당 프로필 이미지의 `isUsed`를 false로 변경시키는 기능을 추가했습니다.
  - 해당 이미지는 새벽 4시에 스케줄러로 인해 삭제됩니다.
  - 다시 재가입한다 하더라도, 해당 이미지가 보여지지 않습니다. 

## 주의사항
- 회원 탈퇴 시에 이미지의 `isUsed` 값이 `false`로 바뀌는지 확인해주세요.
- 회원 탈퇴 후 재가입 시, 프로필 이미지가 null 로 설정되는지 확인해주세요.
- 개발용 S3 로 테스트 후에, 테스트한 이미지는 S3 버킷에 접속 후 지워주세요.