### PR TITLE
fix: 누락된 `@Valid` 추가

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -58,7 +58,7 @@ public class CafeController {
     public ResponseEntity<CafeReviewResponse> saveCafeReview(
             @LoginUserEmail String email,
             @PathVariable String mapId,
-            @RequestBody CafeReviewRequest request
+            @RequestBody @Valid CafeReviewRequest request
     ) {
         CafeReviewResponse response = cafeService.saveCafeReview(email, mapId, request);
         return ResponseEntity.ok(response);
@@ -81,7 +81,7 @@ public class CafeController {
     public ResponseEntity<CafeReviewUpdateResponse> updateCafeReview(
             @LoginUserEmail String email,
             @PathVariable String mapId,
-            @RequestBody CafeReviewUpdateRequest request
+            @RequestBody @Valid CafeReviewUpdateRequest request
     ) {
         CafeReviewUpdateResponse response = cafeService.updateCafeReview(email, mapId, request);
         return ResponseEntity.ok(response);

--- a/src/main/java/mocacong/server/controller/CommentController.java
+++ b/src/main/java/mocacong/server/controller/CommentController.java
@@ -3,6 +3,7 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.CommentSaveRequest;
 import mocacong.server.dto.request.CommentUpdateRequest;
@@ -27,7 +28,7 @@ public class CommentController {
     public ResponseEntity<CommentSaveResponse> saveComment(
             @LoginUserEmail String email,
             @PathVariable String mapId,
-            @RequestBody CommentSaveRequest request
+            @RequestBody @Valid CommentSaveRequest request
     ) {
         CommentSaveResponse response = commentService.save(email, mapId, request.getContent());
         return ResponseEntity.ok(response);
@@ -66,7 +67,7 @@ public class CommentController {
             @LoginUserEmail String email,
             @PathVariable String mapId,
             @PathVariable Long commentId,
-            @RequestBody CommentUpdateRequest request
+            @RequestBody @Valid CommentUpdateRequest request
     ) {
         commentService.update(email, mapId, request.getContent(), commentId);
         return ResponseEntity.ok().build();

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -26,7 +26,7 @@ public class Comment extends BaseTime {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "content", nullable = false, length = MAXIMUM_COMMENT_LENGTH + 2)
+    @Column(name = "content", nullable = false, length = MAXIMUM_COMMENT_LENGTH)
     private String content;
 
     public Comment(Cafe cafe, Member member, String content) {

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -26,7 +26,7 @@ public class Comment extends BaseTime {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "content", nullable = false, length = 200)
+    @Column(name = "content", nullable = false, length = MAXIMUM_COMMENT_LENGTH + 2)
     private String content;
 
     public Comment(Cafe cafe, Member member, String content) {

--- a/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
@@ -1,8 +1,7 @@
 package mocacong.server.dto.request;
 
+import javax.validation.constraints.NotNull;
 import lombok.*;
-
-import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -10,8 +9,8 @@ import javax.validation.constraints.NotBlank;
 @ToString
 public class CafeReviewRequest {
 
-    @NotBlank(message = "3009:공백일 수 없습니다.")
-    private int myScore;
+    @NotNull(message = "3009:공백일 수 없습니다.")
+    private Integer myScore;
     private String myStudyType;
     private String myWifi;
     private String myParking;

--- a/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
@@ -1,8 +1,7 @@
 package mocacong.server.dto.request;
 
+import javax.validation.constraints.NotNull;
 import lombok.*;
-
-import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -10,8 +9,8 @@ import javax.validation.constraints.NotBlank;
 @ToString
 public class CafeReviewUpdateRequest {
 
-    @NotBlank(message = "3009:공백일 수 없습니다.")
-    private int myScore;
+    @NotNull(message = "3009:공백일 수 없습니다.")
+    private Integer myScore;
     private String myStudyType;
     private String myWifi;
     private String myParking;


### PR DESCRIPTION
## 개요
- DTO 단에서 공백 예외처리 등 일부 예외처리를 진행하고 있지 않은 케이스가 있었습니다.

## 작업사항
- 누락된 `@Valid`를 추가했습니다.
- 필터링 관련 API는 `@Valid`를 사용하는 DTO가 없어서 `@Valid`를 추가하지 않았습니다. 그 외 API의 requestbody에는 모두 붙여주었습니다.

## 주의사항
- 리뷰 작성 및 수정, 코멘트 작성 및 수정 시에 모카콩 프로세스 로직대로 예외 핸들링 잘 되는지 확인해주세요.
- 누락된 `@Valid`가 있는지 확인해주세요.
