### PR TITLE
fix: studyType별 카페 필터링 로직 both 함께 반환하도록 변경

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -3,8 +3,6 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
@@ -14,6 +12,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
+import java.util.List;
 
 @Tag(name = "Cafes", description = "카페")
 @RestController
@@ -91,7 +92,7 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = "/studytypes")
     public ResponseEntity<CafeFilterStudyTypeResponse> getCafesByStudyType(
-            @RequestParam(required = false) String studytype,
+            @RequestParam String studytype,
             @RequestBody CafeFilterStudyTypeRequest request
     ) {
         CafeFilterStudyTypeResponse responseBody = cafeService.filterCafesByStudyType(studytype, request);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -31,6 +27,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -282,6 +283,7 @@ public class CafeService {
     public CafeFilterStudyTypeResponse filterCafesByStudyType(String studyTypeValue,
                                                               CafeFilterStudyTypeRequest request) {
         List<Cafe> cafes = cafeRepository.findByStudyTypeValue(StudyType.from(studyTypeValue));
+        cafes.addAll(cafeRepository.findByStudyTypeValue(StudyType.BOTH));
         Set<String> filteredCafeMapIds = cafes.stream()
                 .map(Cafe::getMapId)
                 .collect(Collectors.toSet());

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
@@ -16,16 +12,22 @@ import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mock.web.MockMultipartFile;
 
 @ServiceTest
 class CafeServiceTest {
@@ -646,10 +648,12 @@ class CafeServiceTest {
         Cafe cafe2 = new Cafe("2143154311111", "메리카페");
         Cafe cafe3 = new Cafe("2111111125885", "메리카페 2호점");
         Cafe cafe4 = new Cafe("1585656565441", "메리벅스");
+        Cafe cafe5 = new Cafe("1582212121441", "메리설빙");
         cafeRepository.save(cafe1);
         cafeRepository.save(cafe2);
         cafeRepository.save(cafe3);
         cafeRepository.save(cafe4);
+        cafeRepository.save(cafe5);
         cafeService.saveCafeReview(member1.getEmail(), cafe1.getMapId(),
                 new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
                         "깨끗해요", "충분해요", "조용해요", "편해요"));
@@ -662,14 +666,17 @@ class CafeServiceTest {
         cafeService.saveCafeReview(member2.getEmail(), cafe4.getMapId(),
                 new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
                         "깨끗해요", "충분해요", "조용해요", "편해요"));
+        cafeService.saveCafeReview(member2.getEmail(), cafe5.getMapId(),
+                new CafeReviewRequest(4, "both", "빵빵해요", "여유로워요",
+                        "깨끗해요", "충분해요", "조용해요", "편해요"));
         CafeFilterStudyTypeRequest requestBody = new CafeFilterStudyTypeRequest(
-                List.of(cafe1.getMapId(), cafe2.getMapId(), cafe3.getMapId(), cafe4.getMapId())
+                List.of(cafe1.getMapId(), cafe2.getMapId(), cafe3.getMapId(), cafe4.getMapId(), cafe5.getMapId())
         );
 
         CafeFilterStudyTypeResponse filteredCafes = cafeService.filterCafesByStudyType("solo", requestBody);
 
         assertThat(filteredCafes.getMapIds())
-                .containsExactlyInAnyOrder(cafe1.getMapId(), cafe3.getMapId(), cafe4.getMapId());
+                .containsExactlyInAnyOrder(cafe1.getMapId(), cafe3.getMapId(), cafe4.getMapId(), cafe5.getMapId());
     }
 
     @Test


### PR DESCRIPTION
## 개요
- 기존 studyType별 카페 필터링은 인자로 넘어온 studyType에 해당하는 카페들만 반환했습니다. 이제는 `solo` 나 `group` 카페를 필터링 할 때도 `both` 에 해당하는 카페도 함께 반환하도록 수정했습니다.

## 작업사항
- studyType별 카페 필터링 로직 변경
- studyType별 카페 필터링 테스트 코드 변경

## 주의사항
- swagger로 정상 동작되는지 확인 부탁해요
