### PR TITLE
fix: 나의 스터디타입 필드 null 불가능하도록 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -77,7 +77,7 @@ public class Cafe extends BaseTime {
             StudyType studyType = review.getStudyType();
             if (studyType == StudyType.SOLO) solo++;
             else if (studyType == StudyType.GROUP) group++;
-            else {
+            else if (studyType == StudyType.BOTH) {
                 solo++;
                 group++;
             }

--- a/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
@@ -1,5 +1,6 @@
 package mocacong.server.dto.request;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.*;
 
@@ -11,7 +12,10 @@ public class CafeReviewRequest {
 
     @NotNull(message = "3009:공백일 수 없습니다.")
     private Integer myScore;
+
+    @NotBlank(message = "3009:공백일 수 없습니다.")
     private String myStudyType;
+
     private String myWifi;
     private String myParking;
     private String myToilet;

--- a/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
@@ -1,5 +1,6 @@
 package mocacong.server.dto.request;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.*;
 
@@ -11,7 +12,10 @@ public class CafeReviewUpdateRequest {
 
     @NotNull(message = "3009:공백일 수 없습니다.")
     private Integer myScore;
+
+    @NotBlank(message = "3009:공백일 수 없습니다.")
     private String myStudyType;
+
     private String myWifi;
     private String myParking;
     private String myToilet;


### PR DESCRIPTION
## 개요
- 리뷰 작성 시, 스터디타입과 평점은 필수로 입력해야 합니다. 따라서 스터디타입에 null을 허용하지 않도록 해야 합니다.

## 작업사항
- 리뷰 작성 한정, 스터디타입에 `@NotBlank`를 추가했습니다.
  - 카페 자체의 studyType은 Null이 될 수 있으므로 column 자체에 `nullable=false`는 걸지 않았습니다.
- 카페 세부정보 갱신 로직을 엄밀하게 변경했습니다.
- 리뷰에 null이 들어오는 경우의 검증은 DTO 단에서 해주므로 테스트 코드의 변경은 하지 않았습니다.  

## 주의사항
- Swagger로 리뷰 스터디타입 이것저것 넣어서 테스트 부탁드려요
