### PR TITLE
fix: 카페 이미지 조회 GET API 로직 최근 순으로 정렬하도록 수정

### DIFF
--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -13,11 +13,6 @@ public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
     @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true " +
             "ORDER BY CASE WHEN ci.member.id = :memberId THEN 0 ELSE 1 END, " +
             "CASE WHEN ci.member.id = :memberId THEN ci.id END DESC, ci.id DESC")
-    List<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId, Long memberId);
-
-    @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true " +
-            "ORDER BY CASE WHEN ci.member.id = :memberId THEN 0 ELSE 1 END, " +
-            "CASE WHEN ci.member.id = :memberId THEN ci.id END DESC, ci.id DESC")
     Slice<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId, Long memberId, Pageable pageable);
 
     List<CafeImage> findAllByIsUsedFalse();

--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -1,13 +1,20 @@
 package mocacong.server.repository;
 
 import mocacong.server.domain.CafeImage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
 
-    List<CafeImage> findAllByCafeIdAndIsUsedTrue(Long cafeId);
+    @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true ORDER BY ci.id DESC")
+    List<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId);
+
+    @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true ORDER BY ci.id DESC")
+    Slice<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId, Pageable pageable);
 
     List<CafeImage> findAllByIsUsedFalse();
 }

--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -1,13 +1,11 @@
 package mocacong.server.repository;
 
-import java.util.List;
 import mocacong.server.domain.CafeImage;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
-    Slice<CafeImage> findAllByCafeIdAndIsUsedTrue(Long cafeId, Pageable pageRequest);
 
     List<CafeImage> findAllByCafeIdAndIsUsedTrue(Long cafeId);
 

--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -10,11 +10,15 @@ import java.util.List;
 
 public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
 
-    @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true ORDER BY ci.id DESC")
-    List<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId);
+    @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true " +
+            "ORDER BY CASE WHEN ci.member.id = :memberId THEN 0 ELSE 1 END, " +
+            "CASE WHEN ci.member.id = :memberId THEN ci.id END DESC, ci.id DESC")
+    List<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId, Long memberId);
 
-    @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true ORDER BY ci.id DESC")
-    Slice<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId, Pageable pageable);
+    @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true " +
+            "ORDER BY CASE WHEN ci.member.id = :memberId THEN 0 ELSE 1 END, " +
+            "CASE WHEN ci.member.id = :memberId THEN ci.id END DESC, ci.id DESC")
+    Slice<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId, Long memberId, Pageable pageable);
 
     List<CafeImage> findAllByIsUsedFalse();
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -129,18 +129,20 @@ public class CafeService {
     }
 
     private List<CafeImageResponse> findCafeImageResponses(Cafe cafe, Member member) {
-        List<CafeImage> cafeImages = cafeImageRepository.
-                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), member.getId());
-        List<CafeImageResponse> cafeImageResponses = cafeImages.stream()
+        Pageable pageable = PageRequest.of(0, 5);
+        Slice<CafeImage> cafeImages = cafeImageRepository.
+                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), member.getId(), pageable);
+
+        List<CafeImageResponse> cafeImageResponses = cafeImages
+                .getContent()
+                .stream()
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
                     return new CafeImageResponse(cafeImage.getId(), cafeImage.getImgUrl(), isMe);
                 })
                 .collect(Collectors.toList());
 
-        return cafeImageResponses.stream()
-                .limit(CAFE_SHOW_PAGE_IMAGE_LIMIT_COUNTS)
-                .collect(Collectors.toList());
+        return cafeImageResponses;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -39,7 +39,6 @@ public class CafeService {
 
     public static final int CAFE_IMAGES_PER_REQUEST_LIMIT_COUNTS = 3;
     private static final int CAFE_SHOW_PAGE_COMMENTS_LIMIT_COUNTS = 3;
-    private static final int CAFE_SHOW_PAGE_IMAGE_LIMIT_COUNTS = 5;
     private final CafeRepository cafeRepository;
     private final MemberRepository memberRepository;
     private final ScoreRepository scoreRepository;

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -130,7 +130,7 @@ public class CafeService {
 
     private List<CafeImageResponse> findCafeImageResponses(Cafe cafe, Member member) {
         List<CafeImage> cafeImages = cafeImageRepository.
-                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId());
+                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), member.getId());
         List<CafeImageResponse> cafeImageResponses = cafeImages.stream()
                 .map(cafeImage -> {
                     Boolean isMe = cafeImage.isOwned(member);
@@ -344,7 +344,7 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
         Pageable pageable = PageRequest.of(page, count);
         Slice<CafeImage> cafeImages = cafeImageRepository.
-                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), pageable);
+                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), member.getId(), pageable);
 
         List<CafeImageResponse> responses = cafeImages
                 .getContent()

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -132,7 +132,7 @@ public class CafeService {
         Slice<CafeImage> cafeImages = cafeImageRepository.
                 findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), member.getId(), pageable);
 
-        List<CafeImageResponse> cafeImageResponses = cafeImages
+        return cafeImages
                 .getContent()
                 .stream()
                 .map(cafeImage -> {
@@ -140,8 +140,6 @@ public class CafeService {
                     return new CafeImageResponse(cafeImage.getId(), cafeImage.getImgUrl(), isMe);
                 })
                 .collect(Collectors.toList());
-
-        return cafeImageResponses;
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/mocacong/server/repository/CafeImageRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeImageRepositoryTest.java
@@ -1,0 +1,64 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.CafeImage;
+import mocacong.server.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RepositoryTest
+public class CafeImageRepositoryTest {
+
+    @Autowired
+    private CafeImageRepository cafeImageRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("내가 올린 카페 이미지부터 최신순으로 조회한다")
+    void findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc() throws IOException {
+        Pageable pageable = PageRequest.of(0, 5);
+        Cafe cafe = cafeRepository.save(new Cafe("1", "케이카페"));
+        Member member1 = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이",
+                "010-1234-5678"));
+        Member member2 = memberRepository.save(new Member("dla@naver.com", "abcd1234", "메리",
+                "010-1234-5678"));
+        CafeImage cafeImage1 = new CafeImage("test_img.jpg", true, cafe, member1);
+        CafeImage cafeImage2 = new CafeImage("test_img2.jpg", true, cafe, member1);
+        CafeImage cafeImage3 = new CafeImage("test_img.jpg", true, cafe, member2);
+        CafeImage cafeImage4 = new CafeImage("test_img.jpg", true, cafe, member1);
+        CafeImage cafeImage5 = new CafeImage("test_img2.jpg", true, cafe, member1);
+        CafeImage cafeImage6 = new CafeImage("test_img.jpg", true, cafe, member2);
+        cafeImageRepository.save(cafeImage1);
+        cafeImageRepository.save(cafeImage2);
+        cafeImageRepository.save(cafeImage3);
+        cafeImageRepository.save(cafeImage4);
+        cafeImageRepository.save(cafeImage5);
+        cafeImageRepository.save(cafeImage6);
+
+        Slice<CafeImage> actual = cafeImageRepository.findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(),
+                member1.getId(), pageable); // member1로 카페 이미지 조회
+        List<CafeImage> cafeImages = actual.getContent();
+
+        assertAll(
+                () -> assertThat(cafeImages).hasSize(5),
+                () -> assertThat(cafeImages.get(0)).isEqualTo(cafeImage5),
+                () -> assertThat(cafeImages.get(1)).isEqualTo(cafeImage4),
+                () -> assertThat(cafeImages.get(2)).isEqualTo(cafeImage2),
+                () -> assertThat(cafeImages.get(3)).isEqualTo(cafeImage1),
+                () -> assertThat(cafeImages.get(4)).isEqualTo(cafeImage6)
+        );
+    }
+}

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1041,7 +1041,7 @@ class CafeServiceTest {
                 () -> assertThat(actual.getCafeImages().get(2).getIsMe()).isEqualTo(true),
                 () -> assertThat(actual.getCafeImages().get(3).getIsMe()).isEqualTo(true),
                 () -> assertThat(actual.getCafeImages().get(4).getIsMe()).isEqualTo(true),
-                () -> assertThat(actual.getCafeImages().get(4).getImageUrl()).endsWith("test_img2.jpg"),
+                () -> assertThat(actual.getCafeImages().get(4).getImageUrl()).endsWith("test_img.jpg"),
                 () -> assertThat(given.getCafeImages()).hasSize(6)
         );
     }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
@@ -16,16 +12,22 @@ import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mock.web.MockMultipartFile;
 
 @ServiceTest
 class CafeServiceTest {
@@ -917,6 +919,42 @@ class CafeServiceTest {
                 () -> assertThat(cafeImages).hasSize(4),
                 () -> assertThat(cafeImages.get(0).getIsMe()).isFalse(),
                 () -> assertThat(cafeImages.get(1).getIsMe()).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("자신이 등록한 이미지부터 최신 순으로 이미지를 조회한다")
+    void findCafeImagesReturnOrderedImages() throws IOException {
+        String expected = "test_img.jpg";
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Member member1 = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        memberRepository.save(member1);
+        Member member2 = new Member("kth990303@naver.com", "a1b2c3d4", "다른사람", "010-1111-2222", null);
+        memberRepository.save(member2);
+        String mapId = cafe.getMapId();
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg",
+                fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member1.getEmail(), mapId, List.of(mockMultipartFile));
+        cafeService.saveCafeImage(member1.getEmail(), mapId, List.of(mockMultipartFile));
+        cafeService.saveCafeImage(member2.getEmail(), mapId, List.of(mockMultipartFile));
+        cafeService.saveCafeImage(member2.getEmail(), mapId, List.of(mockMultipartFile));
+        CafeImagesResponse actual = cafeService.findCafeImages(member2.getEmail(), mapId, 0, 10);
+
+        List<CafeImageResponse> cafeImages = actual.getCafeImages();
+
+        assertAll(
+                () -> assertThat(actual.getIsEnd()).isTrue(),
+                () -> assertThat(cafeImages).hasSize(4),
+                // 최신 순으로 정렬되었는지 검증
+                () -> assertThat(cafeImages.get(0).getId()).isEqualTo(4),
+                () -> assertThat(cafeImages.get(1).getId()).isEqualTo(3),
+                () -> assertThat(cafeImages.get(2).getId()).isEqualTo(2),
+                () -> assertThat(cafeImages.get(3).getId()).isEqualTo(1),
+                () -> assertThat(cafeImages.get(0).getIsMe()).isTrue(),
+                () -> assertThat(cafeImages.get(2).getIsMe()).isFalse()
         );
     }
 

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -964,6 +964,44 @@ class CafeServiceTest {
     }
 
     @Test
+    @DisplayName("타인이 나중에 이미지를 등록해도 자신이 등록한 이미지부터 최신 순으로 조회한다")
+    void findCafeImagesReturnOrderedMyImages() throws IOException {
+        String expected = "test_img.jpg";
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Member member1 = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리",
+                "010-1234-5678", null);
+        memberRepository.save(member1);
+        Member member2 = new Member("kth990303@naver.com", "a1b2c3d4", "다른사람",
+                "010-1111-2222", null);
+        memberRepository.save(member2);
+        String mapId = cafe.getMapId();
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg",
+                fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member2.getEmail(), mapId, List.of(mockMultipartFile));
+        cafeService.saveCafeImage(member1.getEmail(), mapId, List.of(mockMultipartFile));
+        cafeService.saveCafeImage(member2.getEmail(), mapId, List.of(mockMultipartFile));
+        cafeService.saveCafeImage(member1.getEmail(), mapId, List.of(mockMultipartFile));
+        CafeImagesResponse actual = cafeService.findCafeImages(member2.getEmail(), mapId, 0, 10);
+
+        List<CafeImageResponse> cafeImages = actual.getCafeImages();
+
+        assertAll(
+                () -> assertThat(actual.getIsEnd()).isTrue(),
+                () -> assertThat(cafeImages).hasSize(4),
+                // 자신이 올린 사진부터 최신 순으로 정렬되었는지 검증
+                () -> assertThat(cafeImages.get(0).getId()).isEqualTo(3),
+                () -> assertThat(cafeImages.get(1).getId()).isEqualTo(1),
+                () -> assertThat(cafeImages.get(2).getId()).isEqualTo(4),
+                () -> assertThat(cafeImages.get(3).getId()).isEqualTo(2),
+                () -> assertThat(cafeImages.get(0).getIsMe()).isTrue(),
+                () -> assertThat(cafeImages.get(2).getIsMe()).isFalse()
+        );
+    }
+
+    @Test
     @DisplayName("카페 이미지를 성공적으로 수정한다")
     void updateCafeImage() throws IOException {
         String oldImage = "test_img.jpg";


### PR DESCRIPTION
## 개요
- 기존 카페 이미지 조회 기능에서는 카페 이미지들을 카페 이미지 id 기준 오름차순으로 정렬하여 반환했습니다. 하지만 프론트의 요청으로 카페 이미지를 조회할 시, 먼저 자신이 올린 이미지를 최근 순으로 정렬하고 타인이 올린 이미지를 최근 순으로 정렬하여 반환하도록 수정했습니다.

## 작업사항
- 카페 이미지 조회 로직을 자신이 올린 사진부터 최근 순으로 정렬하도록 수정
- 카페 이미지 조회할 시, 최근 순으로 정렬이 되는지 검증하는 테스트 코드 추가
- 카페 이미지 조회 로직 수정에 따른 기존 카페 이미지 관련 테스트 코드 수정

## 주의사항
- 스웨거로 `특정 카페 조회`, `카페 이미지 조회` 두가지 기능이 정상적으로 동작되는지 확인해주세요
- 더 나은 로직이 있다면 추천해주세요
