### PR TITLE
fix: 카페 이미지 등록 시 회원탈퇴가 불가능한 버그 수정

### DIFF
--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -71,7 +71,7 @@ public class MemberController {
     @Operation(summary = "마이페이지 - 즐겨찾기 조회")
     @SecurityRequirement(name = "JWT")
     @GetMapping("/mypage/stars")
-    public ResponseEntity<MyFavoriteCafesResponse> findMyInfo(
+    public ResponseEntity<MyFavoriteCafesResponse> findMyFavoriteCafes(
             @LoginUserEmail String email,
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -39,7 +39,11 @@ public class CafeImage extends BaseTime {
     }
 
     public boolean isOwned(Member member) {
-        return this.member.equals(member);
+        return this.member != null && this.member.equals(member);
+    }
+
+    public void removeMember() {
+        this.member = null;
     }
 
     public void setIsUsed(Boolean isUsed) {

--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -11,5 +11,7 @@ public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
 
     List<CafeImage> findAllByCafeIdAndIsUsedTrue(Long cafeId);
 
+    List<CafeImage> findAllByMemberId(Long memberId);
+
     List<CafeImage> findAllByIsUsedFalse();
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -18,7 +18,7 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
-import mocacong.server.service.event.MemberEvent;
+import mocacong.server.service.event.DeleteMemberEvent;
 import mocacong.server.support.AwsS3Uploader;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -270,7 +270,7 @@ public class CafeService {
     }
 
     @EventListener
-    public void updateReviewWhenMemberDelete(MemberEvent event) {
+    public void updateReviewWhenMemberDelete(DeleteMemberEvent event) {
         Long memberId = event.getMember()
                 .getId();
         reviewRepository.findAllByMemberId(memberId)
@@ -367,7 +367,7 @@ public class CafeService {
     }
 
     @EventListener
-    public void updateCafeImagesWhenMemberDelete(MemberEvent event) {
+    public void updateCafeImagesWhenMemberDelete(DeleteMemberEvent event) {
         Member member = event.getMember();
         cafeImageRepository.findAllByMemberId(member.getId())
                 .forEach(CafeImage::removeMember);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,5 +1,9 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -27,11 +31,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.persistence.EntityManager;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -365,6 +364,13 @@ public class CafeService {
         String newImgUrl = awsS3Uploader.uploadImage(cafeImg);
         CafeImage cafeImage = new CafeImage(newImgUrl, true, cafe, member);
         cafeImageRepository.save(cafeImage);
+    }
+
+    @EventListener
+    public void updateCafeImagesWhenMemberDelete(MemberEvent event) {
+        Member member = event.getMember();
+        cafeImageRepository.findAllByMemberId(member.getId())
+                .forEach(CafeImage::removeMember);
     }
 
     @Transactional

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -17,7 +17,7 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
-import mocacong.server.service.event.MemberEvent;
+import mocacong.server.service.event.DeleteMemberEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -113,7 +113,7 @@ public class CommentService {
     }
 
     @EventListener
-    public void updateCommentWhenMemberDelete(MemberEvent event) {
+    public void updateCommentWhenMemberDelete(DeleteMemberEvent event) {
         Member member = event.getMember();
         commentRepository.findAllByMemberId(member.getId())
                 .forEach(Comment::removeMember);

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -12,7 +12,7 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
-import mocacong.server.service.event.MemberEvent;
+import mocacong.server.service.event.DeleteMemberEvent;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.event.EventListener;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -65,7 +65,7 @@ public class FavoriteService {
     }
 
     @EventListener
-    public void deleteAllWhenMemberDelete(MemberEvent event) {
+    public void deleteAllWhenMemberDelete(DeleteMemberEvent event) {
         Member member = event.getMember();
         favoriteRepository.findAllByMemberId(member.getId()).forEach(Favorite::removeMember);
     }
@@ -73,7 +73,7 @@ public class FavoriteService {
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener
-    public void deleteFavoritesWhenMemberDeleted(MemberEvent event) {
+    public void deleteFavoritesWhenMemberDeleted(DeleteMemberEvent event) {
         favoriteRepository.deleteAllByMemberIdIsNull();
     }
 }

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -12,7 +12,7 @@ import mocacong.server.repository.MemberProfileImageRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.security.auth.JwtTokenProvider;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
-import mocacong.server.service.event.MemberEvent;
+import mocacong.server.service.event.DeleteMemberEvent;
 import mocacong.server.support.AwsS3Uploader;
 import mocacong.server.support.AwsSESSender;
 import org.springframework.beans.factory.annotation.Value;
@@ -85,7 +85,7 @@ public class MemberService {
         Member findMember = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         findMember.updateProfileImgUrl(null);
-        applicationEventPublisher.publishEvent(new MemberEvent(findMember));
+        applicationEventPublisher.publishEvent(new DeleteMemberEvent(findMember));
         memberRepository.delete(findMember);
     }
 

--- a/src/main/java/mocacong/server/service/event/DeleteMemberEvent.java
+++ b/src/main/java/mocacong/server/service/event/DeleteMemberEvent.java
@@ -6,7 +6,7 @@ import mocacong.server.domain.Member;
 
 @Getter
 @RequiredArgsConstructor
-public class MemberEvent {
+public class DeleteMemberEvent {
 
     private final Member member;
 }

--- a/src/test/java/mocacong/server/domain/CafeImageTest.java
+++ b/src/test/java/mocacong/server/domain/CafeImageTest.java
@@ -1,0 +1,53 @@
+package mocacong.server.domain;
+
+import java.util.stream.Stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CafeImageTest {
+
+    private static final Member member = new Member("kth@apple.com", Platform.APPLE, "1234");
+
+    private static Stream<Arguments> provideCafeImagesMember() {
+        Member otherMember = new Member("kth@naver.com", Platform.KAKAO, "1234321");
+
+        return Stream.of(
+                Arguments.of(member, true),
+                Arguments.of(otherMember, false)
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("해당 카페 이미지의 작성자가 해당 회원이 맞는지 여부를 반환한다")
+    @MethodSource("provideCafeImagesMember")
+    void isOwned(Member input, boolean expected) {
+        Cafe cafe = new Cafe("123454321", "케이카페");
+        CafeImage cafeImage = new CafeImage("test_url", true, cafe, member);
+
+        assertThat(cafeImage.isOwned(input)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("해당 카페 이미지 작성자가 없을 경우, 해당 회원이 맞는지 여부 반환은 항상 false 반환한다")
+    void isOwnedWhenMemberNull() {
+        Cafe cafe = new Cafe("123454321", "케이카페");
+        CafeImage cafeImage = new CafeImage("test_url", true, cafe, null);
+
+        assertThat(cafeImage.isOwned(member)).isFalse();
+    }
+
+    @Test
+    @DisplayName("카페 이미지 작성자를 null 처리한다")
+    void removeMember() {
+        Cafe cafe = new Cafe("123454321", "케이카페");
+        CafeImage cafeImage = new CafeImage("test_url", true, cafe, member);
+
+        cafeImage.removeMember();
+
+        assertThat(cafeImage.getMember()).isNull();
+    }
+}


### PR DESCRIPTION
## 개요
- 카페 이미지가 등록된 회원이 탈퇴하려 하면, 외래키 제약조건으로 인해 탈퇴가 불가능합니다. 

## 작업사항
- #44 PR과 마찬가지로 이벤트리스너로 프로필 이미지 작성자를 null 처리한 후에 회원탈퇴가 되도록 하였습니다.
- 탈퇴한 회원의 카페 이미지가 포함된, 카페 정보 조회 시에 문제가 없도록 카페이미지 엔티티 로직 null 처리로직을 변경했습니다.

## 주의사항
- 회원탈퇴가 올바르게 되는지, 그 이후에 다른 회원이 카페 이미지를 조회할 때 문제가 없는지 확인해주세요.
