### PR TITLE
feat: 전화번호 컬럼 삭제

### DIFF
--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -1,24 +1,21 @@
 package mocacong.server.domain;
 
+import java.util.regex.Pattern;
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
-import mocacong.server.exception.badrequest.InvalidPhoneException;
-
-import javax.persistence.*;
-import java.util.regex.Pattern;
 
 @Entity
 @Table(name = "member", uniqueConstraints = {
-        @UniqueConstraint(columnNames = { "platform", "email" })
+        @UniqueConstraint(columnNames = {"platform", "email"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTime {
 
     private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,6}$");
-    private static final Pattern PHONE_REGEX = Pattern.compile("^01[\\d\\-]{8,12}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,9 +31,6 @@ public class Member extends BaseTime {
     @Column(name = "nickname", unique = true)
     private String nickname;
 
-    @Column(name = "phone")
-    private String phone;
-
     @OneToOne
     @JoinColumn(name = "member_profile_image_id")
     private MemberProfileImage memberProfileImage;
@@ -49,33 +43,31 @@ public class Member extends BaseTime {
     private String platformId;
 
     public Member(
-            String email, String password, String nickname, String phone, MemberProfileImage memberProfileImage,
+            String email, String password, String nickname, MemberProfileImage memberProfileImage,
             Platform platform, String platformId
     ) {
-        validateMemberInfo(nickname, phone);
+        validateNickname(nickname);
         this.email = email;
         this.password = password;
         this.nickname = nickname;
-        this.phone = phone;
         this.memberProfileImage = memberProfileImage;
         this.platform = platform;
         this.platformId = platformId;
     }
 
-    public Member(String email, String password, String nickname, String phone, MemberProfileImage memberProfileImage) {
+    public Member(String email, String password, String nickname, MemberProfileImage memberProfileImage) {
         this(
                 email,
                 password,
                 nickname,
-                phone,
                 memberProfileImage,
                 Platform.MOCACONG,
                 null
         );
     }
 
-    public Member(String email, String password, String nickname, String phone) {
-        this(email, password, nickname, phone, null, Platform.MOCACONG, null);
+    public Member(String email, String password, String nickname) {
+        this(email, password, nickname, null, Platform.MOCACONG, null);
     }
 
     public Member(String email, Platform platform, String platformId) {
@@ -107,26 +99,14 @@ public class Member extends BaseTime {
         }
     }
 
-    public void updateProfileInfo(String nickname, String phone) {
-        validateMemberInfo(nickname, phone);
-        this.nickname = nickname;
-        this.phone = phone;
-    }
-
-    private void validateMemberInfo(String nickname, String phone) {
+    public void updateProfileInfo(String nickname) {
         validateNickname(nickname);
-        validatePhone(phone);
+        this.nickname = nickname;
     }
 
     private void validateNickname(String nickname) {
         if (!NICKNAME_REGEX.matcher(nickname).matches()) {
             throw new InvalidNicknameException();
-        }
-    }
-
-    private void validatePhone(String phone) {
-        if (!PHONE_REGEX.matcher(phone).matches()) {
-            throw new InvalidPhoneException();
         }
     }
 

--- a/src/main/java/mocacong/server/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/MemberProfileUpdateRequest.java
@@ -14,7 +14,4 @@ public class MemberProfileUpdateRequest {
 
     @NotBlank(message = "1012:공백일 수 없습니다.")
     private String nickname;
-
-    @NotBlank(message = "1012:공백일 수 없습니다.")
-    private String phone;
 }

--- a/src/main/java/mocacong/server/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/mocacong/server/dto/request/MemberSignUpRequest.java
@@ -19,7 +19,4 @@ public class MemberSignUpRequest {
 
     @NotBlank(message = "1012:공백일 수 없습니다.")
     private String nickname;
-
-    @NotBlank(message = "1012:공백일 수 없습니다.")
-    private String phone;
 }

--- a/src/main/java/mocacong/server/dto/response/GetUpdateProfileInfoResponse.java
+++ b/src/main/java/mocacong/server/dto/response/GetUpdateProfileInfoResponse.java
@@ -9,5 +9,4 @@ import lombok.*;
 public class GetUpdateProfileInfoResponse {
     private String email;
     private String nickname;
-    private String phone;
 }

--- a/src/main/java/mocacong/server/dto/response/MemberGetResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MemberGetResponse.java
@@ -11,5 +11,4 @@ public class MemberGetResponse {
     private Long id;
     private String email;
     private String nickname;
-    private String phone;
 }

--- a/src/main/java/mocacong/server/dto/response/MyPageResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyPageResponse.java
@@ -10,6 +10,5 @@ public class MyPageResponse {
 
     private String email;
     private String nickname;
-    private String phone;
     private String imgUrl;
 }

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidPhoneException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidPhoneException.java
@@ -1,8 +1,0 @@
-package mocacong.server.exception.badrequest;
-
-public class InvalidPhoneException extends BadRequestException {
-
-    public InvalidPhoneException() {
-        super("전화번호 형식이 올바르지 않습니다.", 1011);
-    }
-}

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -1,5 +1,10 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.MemberProfileImage;
@@ -22,10 +27,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -50,8 +51,8 @@ public class MemberService {
         validateDuplicateMember(request);
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
-        try{
-            Member member = new Member(request.getEmail(), encodedPassword, request.getNickname(), request.getPhone());
+        try {
+            Member member = new Member(request.getEmail(), encodedPassword, request.getNickname());
             return new MemberSignUpResponse(memberRepository.save(member).getId());
         } catch (DataIntegrityViolationException e) {
             throw new DuplicateMemberException();
@@ -93,8 +94,7 @@ public class MemberService {
     public MemberGetAllResponse getAllMembers() {
         List<Member> members = memberRepository.findAll();
         List<MemberGetResponse> memberGetResponses = members.stream()
-                .map(member -> new MemberGetResponse(member.getId(), member.getEmail(),
-                        member.getNickname(), member.getPhone()))
+                .map(member -> new MemberGetResponse(member.getId(), member.getEmail(), member.getNickname()))
                 .collect(Collectors.toList());
         return new MemberGetAllResponse(memberGetResponses);
     }
@@ -164,7 +164,7 @@ public class MemberService {
     public MyPageResponse findMyInfo(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
-        return new MyPageResponse(member.getEmail(), member.getNickname(), member.getPhone(), member.getImgUrl());
+        return new MyPageResponse(member.getEmail(), member.getNickname(), member.getImgUrl());
     }
 
     @Transactional
@@ -184,11 +184,10 @@ public class MemberService {
     @Transactional
     public void updateProfileInfo(String email, MemberProfileUpdateRequest request) {
         String updateNickname = request.getNickname();
-        String updatePhone = request.getPhone();
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
         validateDuplicateNickname(updateNickname);
-        member.updateProfileInfo(updateNickname, updatePhone);
+        member.updateProfileInfo(updateNickname);
     }
 
     @Transactional
@@ -219,6 +218,6 @@ public class MemberService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(NotFoundMemberException::new);
 
-        return new GetUpdateProfileInfoResponse(member.getEmail(), member.getNickname(), member.getPhone());
+        return new GetUpdateProfileInfoResponse(member.getEmail(), member.getNickname());
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -10,11 +10,7 @@
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                 <layout class="mocacong.server.support.logging.MaskingPatternLayout">
-                    <maskPattern>email\s*=\s*([^,)\s]+)</maskPattern> <!-- Email Arg pattern -->
-                    <maskPattern>password\s*=\s*([^,)\s]+)</maskPattern> <!-- Password Arg pattern -->
-                    <maskPattern>phone\s*=\s*([^,)\s]+)</maskPattern> <!-- Phone Arg pattern -->
                     <maskPattern>(\d+\.\d+\.\d+\.\d+)</maskPattern> <!-- Ip address IPv4 pattern -->
-                    <maskPattern>(\w+@\w+\.\w+)</maskPattern> <!-- Email pattern -->
                     <pattern>${LOG_PATTERN}</pattern>
                 </layout>
             </encoder>
@@ -34,8 +30,6 @@
                 <layout class="mocacong.server.support.logging.MaskingPatternLayout">
                     <maskPattern>email\s*=\s*([^,)\s]+)</maskPattern> <!-- Email Arg pattern -->
                     <maskPattern>password\s*=\s*([^,)\s]+)</maskPattern> <!-- Password Arg pattern -->
-                    <maskPattern>phone\s*=\s*([^,)\s]+)</maskPattern> <!-- Phone Arg pattern -->
-                    <maskPattern>platformId\s*=\s*([^,)\s]+)</maskPattern> <!-- PlatformId Arg pattern -->
                     <maskPattern>nonce\s*=\s*([^,)\s]+)</maskPattern> <!-- Nonce Arg pattern -->
                     <maskPattern>(\d+\.\d+\.\d+\.\d+)</maskPattern> <!-- Ip address IPv4 pattern -->
                     <maskPattern>(\w+@\w+\.\w+)</maskPattern> <!-- Email pattern -->
@@ -67,8 +61,6 @@
                 <layout class="mocacong.server.support.logging.MaskingPatternLayout">
                     <maskPattern>email\s*=\s*([^,)\s]+)</maskPattern> <!-- Email Arg pattern -->
                     <maskPattern>password\s*=\s*([^,)\s]+)</maskPattern> <!-- Password Arg pattern -->
-                    <maskPattern>phone\s*=\s*([^,)\s]+)</maskPattern> <!-- Phone Arg pattern -->
-                    <maskPattern>platformId\s*=\s*([^,)\s]+)</maskPattern> <!-- PlatformId Arg pattern -->
                     <maskPattern>nonce\s*=\s*([^,)\s]+)</maskPattern> <!-- Nonce Arg pattern -->
                     <maskPattern>(\d+\.\d+\.\d+\.\d+)</maskPattern> <!-- Ip address IPv4 pattern -->
                     <maskPattern>(\w+@\w+\.\w+)</maskPattern> <!-- Email pattern -->

--- a/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/AuthAcceptanceTest.java
@@ -7,8 +7,8 @@ import mocacong.server.dto.request.KakaoLoginRequest;
 import mocacong.server.dto.request.MemberSignUpRequest;
 import mocacong.server.dto.response.OAuthTokenResponse;
 import mocacong.server.dto.response.TokenResponse;
-import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
+import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.security.auth.kakao.KakaoOAuthUserProvider;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,7 +33,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원이 정상적으로 로그인한다")
     void login() {
-        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리");
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(request)

--- a/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CafeAcceptanceTest.java
@@ -1,22 +1,20 @@
 package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
+import java.util.List;
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.CafeFilterFavoritesResponse;
 import mocacong.server.dto.response.CafeFilterStudyTypeResponse;
 import mocacong.server.dto.response.CafeReviewResponse;
 import mocacong.server.dto.response.CafeReviewUpdateResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.List;
-
-import static mocacong.server.acceptance.AcceptanceFixtures.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class CafeAcceptanceTest extends AcceptanceTest {
 
@@ -40,7 +38,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
 
@@ -59,7 +57,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CafeReviewRequest request = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
@@ -87,7 +85,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         카페_리뷰_작성(token, mapId, new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
@@ -107,7 +105,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CafeReviewRequest request = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
@@ -129,7 +127,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
     void updateCafeReview() {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CafeReviewRequest request1 = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
@@ -160,7 +158,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
     void updateCafeReviewNotFoundReview() {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CafeReviewUpdateRequest request = new CafeReviewUpdateRequest(3, "solo", "빵빵해요", "여유로워요",
@@ -182,8 +180,8 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
-        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1111-1111");
+        MemberSignUpRequest signUpRequest1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리");
         회원_가입(signUpRequest1);
         회원_가입(signUpRequest2);
         String token1 = 로그인_토큰_발급(signUpRequest1.getEmail(), signUpRequest1.getPassword());
@@ -211,7 +209,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         카페_등록(new CafeRegisterRequest(mapId1, "메리네 카페 본점"));
         카페_등록(new CafeRegisterRequest(mapId2, "메리네 카페 2호점"));
         카페_등록(new CafeRegisterRequest(mapId3, "메리네 카페 3호점"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CafeReviewRequest request1 = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
@@ -247,7 +245,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
         카페_등록(new CafeRegisterRequest(mapId1, "메리네 카페 본점"));
         카페_등록(new CafeRegisterRequest(mapId2, "메리네 카페 2호점"));
         카페_등록(new CafeRegisterRequest(mapId3, "메리네 카페 3호점"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
 
@@ -273,7 +271,7 @@ public class CafeAcceptanceTest extends AcceptanceTest {
     void getCafeImages() {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페 본점"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
 

--- a/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
@@ -3,6 +3,8 @@ package mocacong.server.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import mocacong.server.dto.request.CafeRegisterRequest;
 import mocacong.server.dto.request.CommentSaveRequest;
 import mocacong.server.dto.request.CommentUpdateRequest;
@@ -11,17 +13,13 @@ import mocacong.server.dto.response.CommentResponse;
 import mocacong.server.dto.response.CommentSaveResponse;
 import mocacong.server.dto.response.CommentsResponse;
 import mocacong.server.dto.response.FindCafeResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.List;
-
-import static mocacong.server.acceptance.AcceptanceFixtures.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommentAcceptanceTest extends AcceptanceTest {
 
@@ -32,7 +30,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CommentSaveRequest request = new CommentSaveRequest(expected);
@@ -59,7 +57,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         카페_코멘트_작성(token, mapId, new CommentSaveRequest("댓글"));
@@ -79,9 +77,9 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
-        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("mery@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("mery@naver.com", "a1b2c3d4", "메리");
         회원_가입(signUpRequest2);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         String token2 = 로그인_토큰_발급(signUpRequest2.getEmail(), signUpRequest.getPassword());
@@ -107,7 +105,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CommentSaveRequest saveRequest = new CommentSaveRequest(content);
@@ -141,7 +139,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
 
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         CommentSaveRequest saveRequest = new CommentSaveRequest(content);

--- a/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/FavoriteAcceptanceTest.java
@@ -18,7 +18,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
     void saveFavoriteCafe() {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
 
@@ -35,7 +35,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
     void deleteFavoriteCafe() {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         RestAssured.given().log().all()

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -1,26 +1,25 @@
 package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import mocacong.server.domain.Platform;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.support.AwsSESSender;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-
-import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -34,7 +33,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원을 정상적으로 가입한다")
     void signUp() {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -72,7 +71,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원이 정상적으로 탈퇴한다")
     void delete() {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(request);
         String token = 로그인_토큰_발급(request.getEmail(), request.getPassword());
 
@@ -88,7 +87,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("리뷰나 코멘트를 달은 회원이 정상적으로 탈퇴한다")
     void deleteWhenSaveReviewsAndComments() {
         String mapId = "1234";
-        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(memberSignUpRequest);
         String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
 
@@ -109,7 +108,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("즐겨찾기를 등록한 회원이 정상적으로 탈퇴한다")
     void deleteWhenSaveFavorites() {
         String mapId = "1234";
-        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(memberSignUpRequest);
         String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
 
@@ -127,7 +126,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원은 올바르지 않은 형식의 필드로 가입할 수 없다")
     void signUpInvalidInputField() {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "abcdefgh", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "abcdefgh", "케이");
         ErrorResponse response = 회원_가입(request)
                 .as(ErrorResponse.class);
 
@@ -138,7 +137,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("회원가입이 된 이메일로 이메일 인증을 요청할 수 있다")
     void verifyEmail() {
         String email = "kth990303@naver.com";
-        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(email, "a1b2c3d4", "케이");
         회원_가입(memberSignUpRequest);
         doNothing().when(awsSESSender).sendToVerifyEmail(anyString(), anyString());
         EmailVerifyCodeRequest request = new EmailVerifyCodeRequest(NONCE, email);
@@ -169,7 +168,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("비밀번호 찾기 요청으로 새로운 비밀번호로 변경한다")
     void findAndResetPassword() {
         String email = "kth990303@naver.com";
-        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(email, "a1b2c3d4", "케이");
         회원_가입(memberSignUpRequest);
         String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
         ResetPasswordRequest request = new ResetPasswordRequest(NONCE, "password123");
@@ -186,7 +185,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("가입되어 있지 않은 이메일은 이메일 중복검사에서 걸리지 않는다")
     void isDuplicateWithNonExistingEmail() {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -200,7 +199,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("이미 가입된 이메일은 이메일 중복검사에서 걸린다")
     void isDuplicateWithExistingEmail() {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
 
         회원_가입(request);
 
@@ -216,7 +215,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("길이가 0인 이메일은 이메일 중복검사에서 예외를 던진다")
     void emailLengthIs0ReturnException() {
-        MemberSignUpRequest request = new MemberSignUpRequest("", "a1b2c3d4", "메리", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("", "a1b2c3d4", "메리");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -230,7 +229,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("존재하지 않는 닉네임은 닉네임 중복검사에서 걸리지 않는다")
     void isDuplicateWithNonExistingNickname() {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -244,7 +243,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("이미 존재하는 닉네임은 닉네임 중복검사에서 걸린다")
     void isDuplicateWithExistingNickname() {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -258,7 +257,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("길이가 0인 닉네임은 닉네임 중복검사에서 예외를 던진다")
     void nicknameLengthIs0ReturnException() {
-        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -272,9 +271,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원을 전체 조회한다")
     void getAllMembers() {
-        MemberSignUpRequest request1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(request1);
-        MemberSignUpRequest request2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
+        MemberSignUpRequest request2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리");
         회원_가입(request2);
 
         RestAssured.given().log().all()
@@ -289,7 +288,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("마이페이지로 내 정보를 조회한다")
     void findMyInfo() {
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
 
@@ -305,7 +304,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(actual.getEmail()).isEqualTo("kth990303@naver.com"),
                 () -> assertThat(actual.getNickname()).isEqualTo("케이"),
-                () -> assertThat(actual.getPhone()).isEqualTo("010-1234-5678"),
                 () -> assertThat(actual.getImgUrl()).isNull()
         );
     }
@@ -315,7 +313,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     void findMyFavoriteCafes() {
         String mapId = "12332312";
         카페_등록(new CafeRegisterRequest(mapId, "메리네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         즐겨찾기_등록(token, mapId);
@@ -336,8 +334,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String mapId2 = "12121212";
         카페_등록(new CafeRegisterRequest(mapId1, "메리네 카페"));
         카페_등록(new CafeRegisterRequest(mapId2, "케이네 카페"));
-        MemberSignUpRequest signUpRequest1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
-        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1111-1111");
+        MemberSignUpRequest signUpRequest1 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", "메리");
         회원_가입(signUpRequest1);
         회원_가입(signUpRequest2);
         String token1 = 로그인_토큰_발급(signUpRequest1.getEmail(), signUpRequest1.getPassword());
@@ -376,9 +374,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String mapId2 = "12121212";
         카페_등록(new CafeRegisterRequest(mapId1, "메리네 카페"));
         카페_등록(new CafeRegisterRequest(mapId2, "케이네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
-        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("mery@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("mery@naver.com", "a1b2c3d4", "메리");
         회원_가입(signUpRequest2);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
         String token2 = 로그인_토큰_발급(signUpRequest2.getEmail(), signUpRequest.getPassword());
@@ -402,12 +400,11 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원이 정상적으로 회원정보를 수정한다")
     void updateProfileInfo() {
-        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(memberSignUpRequest);
         String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
         String newNickname = "메리";
-        String newPhone = "010-1234-5678";
-        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname, newPhone);
+        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname);
 
         RestAssured.given().log().all()
                 .auth().oauth2(token)
@@ -427,7 +424,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원이 옳은 비밀번호로 비밀번호 인증한다")
     void verifyPasswordWithTrue() {
-        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(memberSignUpRequest);
         String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
         PasswordVerifyRequest request = new PasswordVerifyRequest("a1b2c3d4");
@@ -448,7 +445,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("회원이 틀린 비밀번호로 비밀번호 인증한다")
     void verifyPasswordWithFalse() {
-        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(memberSignUpRequest);
         String token = 로그인_토큰_발급(memberSignUpRequest.getEmail(), memberSignUpRequest.getPassword());
         PasswordVerifyRequest request = new PasswordVerifyRequest("wrongpwd123");
@@ -469,7 +466,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("프로필 수정 페이지에서 내 정보를 조회한다")
     void getUpdateProfileInfo() {
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         회원_가입(signUpRequest);
         String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
 
@@ -484,8 +481,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         assertAll(
                 () -> assertThat(actual.getEmail()).isEqualTo("kth990303@naver.com"),
-                () -> assertThat(actual.getNickname()).isEqualTo("케이"),
-                () -> assertThat(actual.getPhone()).isEqualTo("010-1234-5678")
+                () -> assertThat(actual.getNickname()).isEqualTo("케이")
         );
     }
 }

--- a/src/test/java/mocacong/server/domain/BaseTimeTest.java
+++ b/src/test/java/mocacong/server/domain/BaseTimeTest.java
@@ -26,7 +26,7 @@ class BaseTimeTest {
     @Test
     @DisplayName("멤버를 저장하면 생성 시각이 자동으로 저장된다")
     public void memberCreatedAtNow() {
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678");
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리");
 
         memberRepository.save(member);
 
@@ -36,7 +36,7 @@ class BaseTimeTest {
     @Test
     @DisplayName("카페 객체를 수정하면 수정 시각이 자동으로 저장된다")
     public void updateCafeAtNow() {
-        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);

--- a/src/test/java/mocacong/server/domain/CafeTest.java
+++ b/src/test/java/mocacong/server/domain/CafeTest.java
@@ -21,7 +21,7 @@ class CafeTest {
     @Test
     @DisplayName("카페의 평점을 올바르게 계산하여 반환한다")
     void findScore() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
         Cafe cafe = new Cafe("1", "케이카페");
         Score score1 = new Score(5, member, cafe);
         Score score2 = new Score(2, member, cafe);
@@ -34,7 +34,7 @@ class CafeTest {
     @Test
     @DisplayName("카페 세부정보 갱신이 올바르게 작동한다")
     void updateCafeDetails() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
 
         Cafe cafe = new Cafe("1", "케이카페");
 
@@ -65,7 +65,7 @@ class CafeTest {
     @Test
     @DisplayName("카페 세부정보 리뷰로 both가 작성될 경우 solo, group 포인트가 모두 1씩 증가한다")
     void updateCafeDetailsWhenStudyTypesAddBoth() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
         Cafe cafe = new Cafe("1", "케이카페");
 
         // BOTH 리뷰 추가 -> SOLO, GROUP 모두 1포인트
@@ -99,7 +99,7 @@ class CafeTest {
     @Test
     @DisplayName("카페 세부정보 중 study type은 같은 개수일 경우 solo나 group이 아닌 both를 반환한다")
     void updateCafeDetailsWhenStudyTypesEqual() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
 
         Cafe cafe = new Cafe("1", "케이카페");
 
@@ -119,7 +119,7 @@ class CafeTest {
     @Test
     @DisplayName("카페에 일부 세부정보 리뷰가 하나도 없을 경우 해당 세부정보는 null을 반환한다")
     void updateCafeDetailsWhenSomeTypesNoReviews() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
 
         Cafe cafe = new Cafe("1", "케이카페");
         CafeDetail cafeDetail = new CafeDetail(StudyType.SOLO, Wifi.FAST, null, Toilet.CLEAN, null, Power.MANY, Sound.LOUD);

--- a/src/test/java/mocacong/server/domain/CommentTest.java
+++ b/src/test/java/mocacong/server/domain/CommentTest.java
@@ -12,7 +12,7 @@ class CommentTest {
     @Test
     @DisplayName("코멘트 길이가 200자를 초과하면 예외를 반환한다")
     void validateCommentLength() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
         Cafe cafe = new Cafe("1", "케이카페");
         assertThatThrownBy(() -> new Comment(cafe, member, createLongComment(201)))
                 .isInstanceOf(ExceedCommentLengthException.class);
@@ -29,7 +29,7 @@ class CommentTest {
     @Test
     @DisplayName("댓글 작성자 닉네임을 반환한다")
     void getWriterNickname() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
         Cafe cafe = new Cafe("1", "케이카페");
         Comment comment = new Comment(cafe, member, "안녕하세요");
 
@@ -39,7 +39,7 @@ class CommentTest {
     @Test
     @DisplayName("댓글 작성자 프로필 이미지 url을 반환한다")
     void getWriterImgUrl() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678", new MemberProfileImage("test_img.jpg"));
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", new MemberProfileImage("test_img.jpg"));
         Cafe cafe = new Cafe("1", "케이카페");
         Comment comment = new Comment(cafe, member, "안녕하세요");
 
@@ -49,8 +49,8 @@ class CommentTest {
     @Test
     @DisplayName("코멘트가 해당 회원이 작성한 게 맞는지 여부를 반환한다")
     void isWrittenByMember() {
-        Member member1 = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
-        Member member2 = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member1 = new Member("kth@naver.com", "a1b2c3d4", "케이");
+        Member member2 = new Member("kth@naver.com", "a1b2c3d4", "케이");
         Cafe cafe = new Cafe("1", "케이카페");
         Comment comment = new Comment(cafe, member1, "안녕하세요");
 

--- a/src/test/java/mocacong/server/domain/MemberTest.java
+++ b/src/test/java/mocacong/server/domain/MemberTest.java
@@ -1,7 +1,6 @@
 package mocacong.server.domain;
 
 import mocacong.server.exception.badrequest.InvalidNicknameException;
-import mocacong.server.exception.badrequest.InvalidPhoneException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -17,7 +16,7 @@ class MemberTest {
     @DisplayName("모든 정보를 올바른 형식으로 입력하면 회원이 생성된다")
     void createMember() {
         assertDoesNotThrow(
-                () -> new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678")
+                () -> new Member("kth990303@naver.com", "a1b2c3d4", "케이")
         );
     }
 
@@ -60,7 +59,7 @@ class MemberTest {
     @ValueSource(strings = {"ㄱㅁㄴㄷㄹ", "ㅏㅣㅓㅜ", "가ㅏ누ㅟ"})
     void createMemberNicknameOnlyOnset(String nickname) {
         assertDoesNotThrow(
-                () -> new Member("kth990303@naver.com", "a1b2c3d4", nickname, "010-1234-5678")
+                () -> new Member("kth990303@naver.com", "a1b2c3d4", nickname)
         );
     }
 
@@ -68,7 +67,7 @@ class MemberTest {
     @DisplayName("닉네임이 2~6자가 아니면 예외를 반환한다")
     @ValueSource(strings = {"일", "일이삼사오육칠"})
     void nicknameLengthValidation(String nickname) {
-        assertThatThrownBy(() -> new Member("kth990303@naver.com", "a1b2c3d4", nickname, "010-1234-5678"))
+        assertThatThrownBy(() -> new Member("kth990303@naver.com", "a1b2c3d4", nickname))
                 .isInstanceOf(InvalidNicknameException.class);
     }
 
@@ -76,23 +75,15 @@ class MemberTest {
     @DisplayName("닉네임이 영어 또는 한글이 아니면 예외를 반환한다")
     @ValueSource(strings = {"123", "愛してるよ"})
     void nicknameConfigureValidation(String nickname) {
-        assertThatThrownBy(() -> new Member("kth990303@naver.com", "a1b2c3d4", nickname, "010-1234-5678"))
+        assertThatThrownBy(() -> new Member("kth990303@naver.com", "a1b2c3d4", nickname))
                 .isInstanceOf(InvalidNicknameException.class);
-    }
-
-    @ParameterizedTest
-    @DisplayName("전화번호가 01로 시작하지 않거나 하이픈 포함 10~14자가 아니면 예외를 반환한다")
-    @ValueSource(strings = {"030-1234-5678", "01-123-45", "010-12345-56789", "010123456", "012345678901234"})
-    void phoneValidation(String phone) {
-        assertThatThrownBy(() -> new Member("kth990303@naver.com", "a1b2c3d4", "케이", phone))
-                .isInstanceOf(InvalidPhoneException.class);
     }
 
     @Test
     @DisplayName("회원의 프로필 이미지가 존재하면 해당 이미지 url을 올바르게 반환한다")
     void getImgUrlWhenHasImage() {
         String expected = "test_img.jpg";
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678", new MemberProfileImage(expected));
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", new MemberProfileImage(expected));
 
         String actual = member.getImgUrl();
 
@@ -102,7 +93,7 @@ class MemberTest {
     @Test
     @DisplayName("회원의 프로필 이미지가 존재하지 않으면 해당 이미지 url 반환은 null을 반환한다")
     void getImgUrlWhenHasNotImage() {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
 
         String actual = member.getImgUrl();
 
@@ -114,7 +105,7 @@ class MemberTest {
     void updateProfileImgUrl() {
         String expected = "test_img.jpg";
         MemberProfileImage memberProfileImage = new MemberProfileImage("before.jpg");
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678",
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이",
                 memberProfileImage, Platform.MOCACONG, "1234");
 
         member.updateProfileImgUrl(new MemberProfileImage(expected));

--- a/src/test/java/mocacong/server/domain/ScoreTest.java
+++ b/src/test/java/mocacong/server/domain/ScoreTest.java
@@ -1,11 +1,10 @@
 package mocacong.server.domain;
 
 import mocacong.server.exception.badrequest.InvalidScoreException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ScoreTest {
 
@@ -13,7 +12,7 @@ class ScoreTest {
     @ValueSource(ints = {0, 6})
     @DisplayName("평점이 1점 이상 5점 이하가 아니면 예외를 반환한다")
     void invalidRangeScore(int score) {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
         Cafe cafe = new Cafe("1", "케이카페");
 
         assertThatThrownBy(() -> new Score(score, member, cafe))
@@ -24,7 +23,7 @@ class ScoreTest {
     @ValueSource(ints = {0, 6})
     @DisplayName("수정 시 평점이 1점 이상 5점 이하가 아니면 예외를 반환한다")
     void updateInvalidRangeScore(int score) {
-        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이");
         Cafe cafe = new Cafe("1", "케이카페");
         Score oldScore = new Score(3, member, cafe);
         assertThatThrownBy(() -> oldScore.updateScore(score))

--- a/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
@@ -36,7 +36,7 @@ class CafeRepositoryTest {
         Cafe savedCafe2 = cafeRepository.save(new Cafe(mapId2, "케이카페2"));
         Cafe savedCafe3 = cafeRepository.save(new Cafe(mapId3, "케이카페3"));
         Cafe savedCafe4 = cafeRepository.save(new Cafe(mapId4, "케이카페4"));
-        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
         favoriteRepository.save(new Favorite(member, savedCafe1));
         favoriteRepository.save(new Favorite(member, savedCafe2));
         favoriteRepository.save(new Favorite(member, savedCafe3));
@@ -59,7 +59,7 @@ class CafeRepositoryTest {
         Cafe savedCafe2 = cafeRepository.save(new Cafe("2", "케이카페2"));
         Cafe savedCafe3 = cafeRepository.save(new Cafe("3", "케이카페3"));
         Cafe savedCafe4 = cafeRepository.save(new Cafe("4", "케이카페4"));
-        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
         favoriteRepository.save(new Favorite(member, savedCafe1));
         favoriteRepository.save(new Favorite(member, savedCafe2));
         favoriteRepository.save(new Favorite(member, savedCafe3));
@@ -85,7 +85,7 @@ class CafeRepositoryTest {
         Cafe savedCafe4 = cafeRepository.save(new Cafe("4", "케이카페4"));
         CafeDetail cafeDetail = new CafeDetail(StudyType.BOTH, Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.NORMAL,
                 Power.NONE, Sound.LOUD);
-        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
         reviewRepository.save(new Review(member, savedCafe1, cafeDetail));
         reviewRepository.save(new Review(member, savedCafe2, cafeDetail));
         reviewRepository.save(new Review(member, savedCafe3, cafeDetail));

--- a/src/test/java/mocacong/server/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/FavoriteRepositoryTest.java
@@ -25,7 +25,7 @@ class FavoriteRepositoryTest {
     @DisplayName("카페 id, 멤버 id로 즐겨찾기 id를 조회한다")
     void findByCafeIdAndMemberId() {
         Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
-        Member savedMember = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Member savedMember = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
         Favorite favorite = new Favorite(savedMember, savedCafe);
         favoriteRepository.save(favorite);
 

--- a/src/test/java/mocacong/server/repository/MemberRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/MemberRepositoryTest.java
@@ -3,7 +3,6 @@ package mocacong.server.repository;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Platform;
 import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +21,6 @@ class MemberRepositoryTest {
                 "kth@apple.com",
                 "a1b2c3d4",
                 "케이",
-                "010-1234-1234",
                 null,
                 Platform.APPLE,
                 "1234321"

--- a/src/test/java/mocacong/server/repository/ReviewRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/ReviewRepositoryTest.java
@@ -6,7 +6,6 @@ import mocacong.server.domain.Member;
 import mocacong.server.domain.Review;
 import mocacong.server.domain.cafedetail.*;
 import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +24,7 @@ class ReviewRepositoryTest {
     @DisplayName("카페 id, 멤버 id로 해당 멤버가 특정 카페에 작성한 리뷰의 id를 조회한다")
     void findIdByCafeIdAndMemberId() {
         Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
-        Member savedMember = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Member savedMember = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
         CafeDetail cafeDetail = new CafeDetail(StudyType.SOLO, Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.COMFORTABLE, Power.MANY, Sound.LOUD);
         Review savedReview = reviewRepository.save(new Review(savedMember, savedCafe, cafeDetail));
 

--- a/src/test/java/mocacong/server/repository/ScoreRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/ScoreRepositoryTest.java
@@ -3,12 +3,10 @@ package mocacong.server.repository;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Score;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @RepositoryTest
 class ScoreRepositoryTest {
@@ -24,7 +22,7 @@ class ScoreRepositoryTest {
     @DisplayName("카페 id, 멤버 id로 해당 멤버가 특정 카페에 등록한 평점을 조회한다")
     void findScoreByCafeIdAndMemberId() {
         Cafe savedCafe = cafeRepository.save(new Cafe("1", "케이카페"));
-        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이", "010-1234-5678"));
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
         Score score = new Score(4, member, savedCafe);
         scoreRepository.save(score);
 

--- a/src/test/java/mocacong/server/service/AuthServiceTest.java
+++ b/src/test/java/mocacong/server/service/AuthServiceTest.java
@@ -10,16 +10,15 @@ import mocacong.server.exception.badrequest.PasswordMismatchException;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.when;
 
 @ServiceTest
 class AuthServiceTest {
@@ -40,7 +39,7 @@ class AuthServiceTest {
         String email = "kth990303@naver.com";
         String password = "a1b2c3d4";
         String encodedPassword = passwordEncoder.encode("a1b2c3d4");
-        Member member = new Member("kth990303@naver.com", encodedPassword, "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", encodedPassword, "케이");
         memberRepository.save(member);
         AuthLoginRequest loginRequest = new AuthLoginRequest(email, password);
 
@@ -55,7 +54,7 @@ class AuthServiceTest {
         String email = "kth990303@naver.com";
         String password = "a1b2c3d4";
         String encodedPassword = passwordEncoder.encode(password);
-        Member member = new Member(email, encodedPassword, "케이", "010-1234-5678");
+        Member member = new Member(email, encodedPassword, "케이");
         memberRepository.save(member);
 
         AuthLoginRequest loginRequest = new AuthLoginRequest(email, "wrongPassword");
@@ -91,7 +90,6 @@ class AuthServiceTest {
                 expected,
                 passwordEncoder.encode("a1b2c3d4"),
                 "케이",
-                "010-1234-1234",
                 null,
                 Platform.APPLE,
                 platformId
@@ -135,7 +133,7 @@ class AuthServiceTest {
     void loginOAuthWithMocacongEmail() {
         String email = "kth@apple.com";
         String encodedPassword = passwordEncoder.encode("a1b2c3d4");
-        Member member = new Member(email, encodedPassword, "케이", "010-1234-5678");
+        Member member = new Member(email, encodedPassword, "케이");
         memberRepository.save(member);
         String platformId = "1234321";
         when(appleOAuthUserProvider.getApplePlatformMember(anyString()))
@@ -161,7 +159,7 @@ class AuthServiceTest {
         OAuthTokenResponse response = authService.appleOAuthLogin(new AppleLoginRequest("token"));
         String encodedPassword = passwordEncoder.encode("a1b2c3d4");
 
-        Member member = new Member(email, encodedPassword, "케이", "010-1234-5678");
+        Member member = new Member(email, encodedPassword, "케이");
         memberRepository.save(member);
 
         assertAll(

--- a/src/test/java/mocacong/server/service/CafeConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeConcurrentServiceTest.java
@@ -1,5 +1,11 @@
 package mocacong.server.service;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Member;
 import mocacong.server.domain.Review;
@@ -10,26 +16,16 @@ import mocacong.server.exception.badrequest.DuplicateCafeException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.repository.ReviewRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ServiceTest
 public class CafeConcurrentServiceTest {
     @Autowired
     private CafeService cafeService;
-    @Autowired
-    private MemberService memberService;
     @Autowired
     private CafeRepository cafeRepository;
     @Autowired
@@ -67,7 +63,7 @@ public class CafeConcurrentServiceTest {
     @Test
     @DisplayName("회원이 한 카페에 동시에 여러 번 평점만 등록 시도해도 한 번만 등록된다")
     void saveScoreWithConcurrent() throws InterruptedException {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -99,7 +95,7 @@ public class CafeConcurrentServiceTest {
     @Test
     @DisplayName("회원이 한 카페에 동시에 여러 번 리뷰 등록 시도해도 한 번만 등록된다")
     void saveCafeReviewWithConcurrent() throws InterruptedException {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,5 +1,9 @@
 package mocacong.server.service;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
@@ -12,22 +16,16 @@ import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mock.web.MockMultipartFile;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 
 @ServiceTest
 class CafeServiceTest {
@@ -48,8 +46,6 @@ class CafeServiceTest {
     private FavoriteRepository favoriteRepository;
     @Autowired
     private CafeImageRepository cafeImageRepository;
-    @Autowired
-    private ReviewRepository reviewRepository;
 
     @MockBean
     private AwsS3Uploader awsS3Uploader;
@@ -83,7 +79,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("평점, 리뷰 및 코멘트가 존재하지 않는 카페를 조회한다")
     void findCafe() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -106,9 +102,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("평점이 존재하고 리뷰, 코멘트가 존재하지 않는 카페를 조회한다")
     void findCafeWithScore() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -134,9 +130,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("평점, 리뷰, 코멘트가 모두 존재하는 카페를 조회한다")
     void findCafeWithReviewsAndComments() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -172,7 +168,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("평점, 리뷰가 존재하지 않는 카페 정보를 미리보기한다")
     void previewCafe() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -190,9 +186,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("평점이 존재하고 리뷰가 존재하지 않는 카페 정보를 미리보기한다")
     void previewCafeWithScore() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -213,9 +209,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("평점과 리뷰가 모두 존재하는 카페 정보를 미리보기한다")
     void previewCafeWithScoreAndReview() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -240,7 +236,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("카페를 조회할 때 댓글은 3개까지만 보여준다")
     void findCafeAndShowLimitComments() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -264,9 +260,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("탈퇴한 회원이 작성한 리뷰와 코멘트가 존재하는 카페를 조회한다")
     void findCafeWithReviewsAndCommentsByDeleteMember() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -294,9 +290,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("평점, 리뷰, 코멘트가 존재하고 즐겨찾기가 등록된 카페를 조회한다")
     void findCafeWithAll() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -335,7 +331,7 @@ class CafeServiceTest {
     @DisplayName("카페를 조회할 때 이미지는 5개까지만 보여준다")
     void findCafeAndShowLimitImages() throws IOException {
         String expected = "test_img.jpg";
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -362,9 +358,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("회원이 즐겨찾기한 카페 목록들을 보여준다")
     void findMyFavoriteCafes() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -388,9 +384,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("회원이 리뷰를 남긴 카페 목록들을 보여준다")
     void findMyReviewCafes() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe1 = new Cafe("2143154352323", "케이카페");
         Cafe cafe2 = new Cafe("2154122541112", "메리카페");
@@ -421,9 +417,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("회원이 댓글을 작성한 카페 목록들을 보여준다")
     void findMyCommentCafes() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe1 = new Cafe("2143154352323", "케이카페");
         Cafe cafe2 = new Cafe("1212121212121", "메리카페");
@@ -448,9 +444,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("카페에 대한 리뷰를 작성하면 해당 카페 평점과 세부정보가 갱신된다")
     void saveCafeReview() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -479,9 +475,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("카페 리뷰 작성 후 studyType의 타입 개수가 동일하면 both를 반환한다")
     void saveCafeAndStudyTypesEquals() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -499,9 +495,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("특정 카페에 내가 작성한 리뷰를 볼 수 있다")
     void findMyCafeReview() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -529,7 +525,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("작성하지 않은 카페에 대한 리뷰를 조회하는 경우 null을 반환한다")
     void findNotRegisteredCafeReview() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -551,9 +547,9 @@ class CafeServiceTest {
     @Test
     @DisplayName("이미 리뷰를 작성했으면 수정만 가능하고 새로 작성은 불가능하다")
     void cannotSaveManyReviews() {
-        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -570,7 +566,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("등록한 카페 리뷰를 성공적으로 수정한다")
     public void updateCafeReview() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -598,7 +594,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("등록한 카페 리뷰를 수정할 때 세부정보를 모두 null 값으로 성공적으로 수정한다")
     public void updateCafeReviewWhenDetailsNull() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -626,7 +622,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("카페 리뷰를 등록한 적이 없다면 리뷰 수정은 불가능하다")
     public void updateCafeReviewNotFoundReview() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -640,8 +636,8 @@ class CafeServiceTest {
     @Test
     @DisplayName("studyTypeValue가 주어진 경우 해당 카페 목록을 필터링한다")
     void getCafesFilterStudyType() {
-        Member member1 = new Member("dlawotn3@naver.com", "encodePassword", "메리", "010-1234-5678");
-        Member member2 = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member("dlawotn3@naver.com", "encodePassword", "메리");
+        Member member2 = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member1);
         memberRepository.save(member2);
         Cafe cafe1 = new Cafe("2143154352323", "케이카페");
@@ -682,7 +678,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("studyTypeValue에 해당하는 카페가 없는 경우 빈 리스트를 반환한다")
     void getCafesFilterStudyTypeWhenNoMatch() {
-        Member member = new Member("dlawotn3@naver.com", "encodePassword", "메리", "010-1234-5678");
+        Member member = new Member("dlawotn3@naver.com", "encodePassword", "메리");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -699,7 +695,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("즐겨찾기가 등록된 카페가 있는 경우 해당 카페 목록을 필터링한다")
     void getCafesFilterFavorites() {
-        Member member = new Member("dlawotn3@naver.com", "encodePassword", "메리", "010-1234-5678");
+        Member member = new Member("dlawotn3@naver.com", "encodePassword", "메리");
         memberRepository.save(member);
         Cafe cafe1 = new Cafe("2143154352323", "케이카페");
         Cafe cafe2 = new Cafe("2143154311111", "메리카페");
@@ -724,7 +720,7 @@ class CafeServiceTest {
     @Test
     @DisplayName("즐겨찾기가 등록된 카페가 없는 경우 빈 리스트를 반환한다")
     void getCafesFilterFavoritesWhenNoMatch() {
-        Member member = new Member("dlawotn3@naver.com", "encodePassword", "메리", "010-1234-5678");
+        Member member = new Member("dlawotn3@naver.com", "encodePassword", "메리");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -742,7 +738,7 @@ class CafeServiceTest {
         String expected = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
@@ -763,7 +759,7 @@ class CafeServiceTest {
     void saveCafeImagesPerRequest() throws IOException {
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         MockMultipartFile mockMultipartFile1 =
@@ -785,7 +781,7 @@ class CafeServiceTest {
     void saveCafeImageWhenNoneCafeImage() throws IOException {
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         MockMultipartFile mockMultipartFile =
@@ -801,7 +797,7 @@ class CafeServiceTest {
     void saveCafeImagesManyPerRequest() throws IOException {
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         MockMultipartFile mockMultipartFile1 =
@@ -826,7 +822,7 @@ class CafeServiceTest {
         String expected = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
@@ -850,7 +846,7 @@ class CafeServiceTest {
         String expected = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
@@ -876,7 +872,7 @@ class CafeServiceTest {
         String expected = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
@@ -902,9 +898,9 @@ class CafeServiceTest {
         String expected = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member1 = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member1 = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member1);
-        Member member2 = new Member("kth990303@naver.com", "a1b2c3d4", "다른사람", "010-1111-2222", null);
+        Member member2 = new Member("kth990303@naver.com", "a1b2c3d4", "다른사람", null);
         memberRepository.save(member2);
         String mapId = cafe.getMapId();
         FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
@@ -934,7 +930,7 @@ class CafeServiceTest {
         String newImage = "test_img2.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         FileInputStream oldFileInputStream = new FileInputStream("src/test/resources/images/" + oldImage);
@@ -964,7 +960,7 @@ class CafeServiceTest {
         String newImage = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
         memberRepository.save(member);
         String mapId = cafe.getMapId();
         FileInputStream newFileInputStream = new FileInputStream("src/test/resources/images/" + newImage);
@@ -980,7 +976,7 @@ class CafeServiceTest {
     void updateCafeImageAndShowLimitImages() throws IOException {
         String oldImage = "test_img.jpg";
         String newImage = "test_img2.jpg";
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -1019,7 +1015,7 @@ class CafeServiceTest {
     @DisplayName("사용하지 않는 카페 이미지들을 삭제한다")
     void deleteNotUsedCafeImages() {
         List<String> notUsedImgUrls = List.of("test_img2.jpg", "test_img3.jpg");
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -12,14 +12,13 @@ import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @ServiceTest
 class CommentServiceTest {
@@ -40,7 +39,7 @@ class CommentServiceTest {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
         String expected = "공부하기 좋아요~🥰";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -57,7 +56,7 @@ class CommentServiceTest {
     void saveNotExistsCafe() {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
 
         assertThatThrownBy(() -> commentService.save(email, mapId, "공부하기 좋아요~🥰"))
@@ -69,7 +68,7 @@ class CommentServiceTest {
     void saveManyTimes() {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -84,7 +83,7 @@ class CommentServiceTest {
     void findComments() {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -109,8 +108,8 @@ class CommentServiceTest {
     void findOnlyMyComments() {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
-        Member member2 = new Member("mery@naver.com", "encodePassword", "메리", "010-1234-5679");
+        Member member = new Member(email, "encodePassword", "케이");
+        Member member2 = new Member("mery@naver.com", "encodePassword", "메리");
         memberRepository.save(member);
         memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "케이카페");
@@ -137,7 +136,7 @@ class CommentServiceTest {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
         String comment = "공부하기 좋아요~🥰";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -157,7 +156,7 @@ class CommentServiceTest {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
         String comment = "공부하기 좋아요~🥰";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -175,9 +174,9 @@ class CommentServiceTest {
         String email1 = "kth990303@naver.com";
         String email2 = "mery@naver.com";
         String mapId = "2143154352323";
-        Member member1 = new Member(email1, "encodePassword", "케이", "010-1234-5678");
+        Member member1 = new Member(email1, "encodePassword", "케이");
         memberRepository.save(member1);
-        Member member2 = new Member(email2, "encodePassword", "메리", "010-1234-5678");
+        Member member2 = new Member(email2, "encodePassword", "메리");
         memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -192,7 +191,7 @@ class CommentServiceTest {
     void delete() {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -209,7 +208,7 @@ class CommentServiceTest {
     void deleteNotExistsComment() {
         String email = "kth990303@naver.com";
         String mapId = "2143154352323";
-        Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member(email, "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
@@ -224,8 +223,8 @@ class CommentServiceTest {
         String email1 = "kth990303@naver.com";
         String email2 = "dlawotn3@naver.com";
         String mapId = "2143154352323";
-        Member member1 = new Member(email1, "encodePassword", "케이", "010-1234-5678");
-        Member member2 = new Member(email2, "encodePassword", "메리", "010-1234-5678");
+        Member member1 = new Member(email1, "encodePassword", "케이");
+        Member member2 = new Member(email2, "encodePassword", "메리");
         memberRepository.save(member1);
         memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "케이카페");

--- a/src/test/java/mocacong/server/service/FavoriteConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteConcurrentServiceTest.java
@@ -35,7 +35,7 @@ public class FavoriteConcurrentServiceTest {
     @Test
     @DisplayName("회원이 한 카페를 동시에 여러 번 즐겨찾기 등록 시도해도 한 번만 등록된다")
     void saveFavoriteWithConcurrent() throws InterruptedException {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -1,5 +1,6 @@
 package mocacong.server.service;
 
+import java.util.List;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
@@ -9,16 +10,13 @@ import mocacong.server.exception.notfound.NotFoundFavoriteException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.FavoriteRepository;
 import mocacong.server.repository.MemberRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @ServiceTest
 class FavoriteServiceTest {
@@ -35,7 +33,7 @@ class FavoriteServiceTest {
     @Test
     @DisplayName("회원이 카페를 즐겨찾기 등록한다")
     void save() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -52,7 +50,7 @@ class FavoriteServiceTest {
     @Test
     @DisplayName("이미 즐겨찾기 등록한 카페에 즐겨찾기를 등록하면 예외를 반환한다")
     void saveDuplicate() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -65,7 +63,7 @@ class FavoriteServiceTest {
     @Test
     @DisplayName("회원이 카페를 즐겨찾기 삭제한다")
     void delete() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
@@ -80,7 +78,7 @@ class FavoriteServiceTest {
     @Test
     @DisplayName("회원이 즐겨찾기를 안한 카페 즐겨찾기 삭제할 경우 예외를 던진다")
     void deleteWithException() {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
+        Member member = new Member("kth990303@naver.com", "encodePassword", "케이");
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);

--- a/src/test/java/mocacong/server/service/MemberConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberConcurrentServiceTest.java
@@ -28,7 +28,7 @@ public class MemberConcurrentServiceTest {
     @Test
     @DisplayName("회원이 동시에 여러 번 가입 시도해도 한 번만 가입된다")
     void signUpWithConcurrent() throws InterruptedException {
-        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
         ExecutorService executorService = Executors.newFixedThreadPool(3);
         CountDownLatch latch = new CountDownLatch(3);
         List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());

--- a/src/test/java/mocacong/server/service/MemberServiceTest.java
+++ b/src/test/java/mocacong/server/service/MemberServiceTest.java
@@ -53,7 +53,7 @@ class MemberServiceTest {
     @DisplayName("회원을 정상적으로 가입한다")
     void signUp() {
         String expected = "kth990303@naver.com";
-        MemberSignUpRequest request = new MemberSignUpRequest(expected, "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest(expected, "a1b2c3d4", "케이");
 
         memberService.signUp(request);
 
@@ -66,8 +66,8 @@ class MemberServiceTest {
     @DisplayName("이미 가입된 이메일이 존재하면 회원 가입 시에 예외를 반환한다")
     void signUpByDuplicateEmailMember() {
         String email = "kth990303@naver.com";
-        memberRepository.save(new Member(email, "1234", "케이", "010-1234-5678"));
-        MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
+        memberRepository.save(new Member(email, "1234", "케이"));
+        MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이");
 
         assertThatThrownBy(() -> memberService.signUp(request))
                 .isInstanceOf(DuplicateMemberException.class);
@@ -77,8 +77,8 @@ class MemberServiceTest {
     @DisplayName("이미 가입된 닉네임이 존재하면 회원 가입 시에 예외를 반환한다")
     void signUpByDuplicateNicknameMember() {
         String nickname = "케이";
-        memberRepository.save(new Member("kth2@naver.com", "1234", nickname, "010-1234-5678"));
-        MemberSignUpRequest request = new MemberSignUpRequest("kth@naver.com", "a1b2c3d4", nickname, "010-1234-5678");
+        memberRepository.save(new Member("kth2@naver.com", "1234", nickname));
+        MemberSignUpRequest request = new MemberSignUpRequest("kth@naver.com", "a1b2c3d4", nickname);
 
         assertThatThrownBy(() -> memberService.signUp(request))
                 .isInstanceOf(DuplicateNicknameException.class);
@@ -124,7 +124,7 @@ class MemberServiceTest {
     @DisplayName("비밀번호가 8~20자가 아니면 예외를 반환한다")
     @ValueSource(strings = {"abcdef7", "abcdefgabcdefgabcde21"})
     void passwordLengthValidation(String password) {
-        assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("kth990303@naver.com", password, "케이", "010-1234-5678")))
+        assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("kth990303@naver.com", password, "케이")))
                 .isInstanceOf(InvalidPasswordException.class);
     }
 
@@ -132,7 +132,7 @@ class MemberServiceTest {
     @DisplayName("비밀번호가 소문자, 숫자를 모두 포함하지 않으면 예외를 반환한다")
     @ValueSource(strings = {"abcdefgh", "12345678"})
     void passwordConfigureValidation(String password) {
-        assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("kth990303@naver.com", password, "케이", "010-1234-5678")))
+        assertThatThrownBy(() -> memberService.signUp(new MemberSignUpRequest("kth990303@naver.com", password, "케이")))
                 .isInstanceOf(InvalidPasswordException.class);
     }
 
@@ -216,7 +216,7 @@ class MemberServiceTest {
     @DisplayName("이미 존재하는 이메일인 경우 True를 반환한다")
     void isDuplicateEmailReturnTrue() {
         String email = "dlawotn3@naver.com";
-        MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이", "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4", "케이");
         memberService.signUp(request);
 
         IsDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
@@ -238,7 +238,7 @@ class MemberServiceTest {
     @DisplayName("이미 존재하는 닉네임인 경우 True를 반환한다")
     void isDuplicateNicknameReturnTrue() {
         String nickname = "메리";
-        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", nickname, "010-1234-5678");
+        MemberSignUpRequest request = new MemberSignUpRequest("dlawotn3@naver.com", "a1b2c3d4", nickname);
         memberService.signUp(request);
 
         IsDuplicateNicknameResponse response = memberService.isDuplicateNickname(nickname);
@@ -266,7 +266,7 @@ class MemberServiceTest {
     @Test
     @DisplayName("회원을 정상적으로 탈퇴한다")
     void delete() {
-        Member savedMember = memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678"));
+        Member savedMember = memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "메리"));
 
         memberService.delete(savedMember.getEmail());
 
@@ -284,8 +284,8 @@ class MemberServiceTest {
     @Test
     @DisplayName("회원을 전체 조회한다")
     void getAllMembers() {
-        memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678"));
-        memberRepository.save(new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", "010-1234-5678"));
+        memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이"));
+        memberRepository.save(new Member("dlawotn3@naver.com", "a1b2c3d4", "메리"));
 
         MemberGetAllResponse actual = memberService.getAllMembers();
 
@@ -298,11 +298,9 @@ class MemberServiceTest {
         String imgUrl = "test_img.jpg";
         String email = "kth990303@naver.com";
         String nickname = "케이";
-        String phone = "010-1234-5678";
         MemberProfileImage memberProfileImage = new MemberProfileImage(imgUrl);
         memberProfileImageRepository.save(memberProfileImage);
-        Member member = new Member(email, "a1b2c3d4", "케이", phone, memberProfileImage,
-                Platform.MOCACONG, "1234");
+        Member member = new Member(email, "a1b2c3d4", "케이", memberProfileImage, Platform.MOCACONG, "1234");
         memberRepository.save(member);
 
         MyPageResponse actual = memberService.findMyInfo(email);
@@ -310,7 +308,6 @@ class MemberServiceTest {
         assertAll(
                 () -> assertThat(actual.getEmail()).isEqualTo(email),
                 () -> assertThat(actual.getImgUrl()).isEqualTo(imgUrl),
-                () -> assertThat(actual.getPhone()).isEqualTo(phone),
                 () -> assertThat(actual.getNickname()).isEqualTo(nickname)
         );
     }
@@ -319,7 +316,7 @@ class MemberServiceTest {
     @DisplayName("회원의 프로필 이미지를 변경하면 s3 서버와 연동하여 이미지를 업로드한다")
     void updateProfileImg() throws IOException {
         String expected = "test_img.jpg";
-        Member member = memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678"));
+        Member member = memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "메리"));
         FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + expected);
         MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", expected, "jpg", fileInputStream);
 
@@ -341,8 +338,7 @@ class MemberServiceTest {
         MemberProfileImage memberProfileImage = new MemberProfileImage("test.me.jpg");
         memberProfileImageRepository.save(memberProfileImage);
         Member member = memberRepository.save(
-                new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678",
-                        memberProfileImage, Platform.MOCACONG, "1234")
+                new Member("kth990303@naver.com", "a1b2c3d4", "메리", memberProfileImage, Platform.MOCACONG, "1234")
         );
 
         memberService.updateProfileImage(member.getEmail(), null);
@@ -363,18 +359,15 @@ class MemberServiceTest {
         String password = "a1b2c3d4";
         String originalNickname = "mery";
         String newNickname = "케이";
-        String originalPhone = "010-1111-1111";
-        String newPhone = "010-1234-1234";
-        Member member = new Member(email, passwordEncoder.encode(password), originalNickname, originalPhone);
+        Member member = new Member(email, passwordEncoder.encode(password), originalNickname);
         memberRepository.save(member);
 
-        memberService.updateProfileInfo(email, new MemberProfileUpdateRequest(newNickname, newPhone));
+        memberService.updateProfileInfo(email, new MemberProfileUpdateRequest(newNickname));
         Member updatedMember = memberRepository.findByEmail(member.getEmail())
                 .orElseThrow();
 
         assertAll(
-                () -> assertThat(updatedMember.getNickname()).isEqualTo(newNickname),
-                () -> assertThat(updatedMember.getPhone()).isEqualTo(newPhone)
+                () -> assertThat(updatedMember.getNickname()).isEqualTo(newNickname)
         );
     }
 
@@ -385,31 +378,12 @@ class MemberServiceTest {
         String password = "jisu1234";
         String originalNickname = "mery";
         String newNickname = "케이123";
-        String originalPhone = "010-1111-1111";
-        String newPhone = "010-1234-1234";
-        Member member = new Member(email, passwordEncoder.encode(password), originalNickname, originalPhone);
+        Member member = new Member(email, passwordEncoder.encode(password), originalNickname);
         memberRepository.save(member);
 
-        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname, newPhone);
+        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname);
         assertThatThrownBy(() -> memberService.updateProfileInfo(member.getEmail(), request))
                 .isInstanceOf(InvalidNicknameException.class);
-    }
-
-    @Test
-    @DisplayName("회원이 잘못된 전화번호 형식으로 회원정보 수정을 시도하면 예외를 반환한다")
-    void updateBadPhoneWithValidateException() {
-        String email = "mery@naver.com";
-        String password = "jisu1234";
-        String originalNickname = "mery";
-        String newNickname = "케이";
-        String originalPhone = "010-1111-1111";
-        String newPhone = "010-0000";
-        Member member = new Member(email, passwordEncoder.encode(password), originalNickname, originalPhone);
-        memberRepository.save(member);
-
-        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname, newPhone);
-        assertThatThrownBy(() -> memberService.updateProfileInfo(member.getEmail(), request))
-                .isInstanceOf(InvalidPhoneException.class);
     }
 
     @Test
@@ -419,11 +393,10 @@ class MemberServiceTest {
         String password = "jisu0708";
         String originalNickname = "mery";
         String newNickname = "케이";
-        String phone = "010-1111-1111";
-        memberRepository.save(new Member(email, password, originalNickname, phone));
-        memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678"));
+        memberRepository.save(new Member(email, password, originalNickname));
+        memberRepository.save(new Member("kth990303@naver.com", "a1b2c3d4", "케이"));
 
-        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname, phone);
+        MemberProfileUpdateRequest request = new MemberProfileUpdateRequest(newNickname);
         assertThatThrownBy(() -> memberService.updateProfileInfo(email, request))
                 .isInstanceOf(DuplicateNicknameException.class);
     }
@@ -456,7 +429,7 @@ class MemberServiceTest {
         MemberProfileImage memberProfileImage = new MemberProfileImage("test_img.jpg");
         memberProfileImageRepository.save(memberProfileImage);
         Member member = memberRepository.save(
-                new Member("kth990303@naver.com", "a1b2c3d4", "케이", "010-1234-5678", memberProfileImage)
+                new Member("kth990303@naver.com", "a1b2c3d4", "케이", memberProfileImage)
         );
 
         memberService.delete(member.getEmail());
@@ -472,8 +445,7 @@ class MemberServiceTest {
         String email = "dlawotn3@naver.com";
         String password = "jisu1234";
         String nickname = "mery";
-        String phone = "010-1111-1111";
-        Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
+        Member member = new Member(email, passwordEncoder.encode(password), nickname);
         memberRepository.save(member);
         PasswordVerifyRequest request = new PasswordVerifyRequest("jisu1234");
 
@@ -488,8 +460,7 @@ class MemberServiceTest {
         String email = "dlawotn3@naver.com";
         String password = "jisu1234";
         String nickname = "mery";
-        String phone = "010-1111-1111";
-        Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
+        Member member = new Member(email, passwordEncoder.encode(password), nickname);
         memberRepository.save(member);
         PasswordVerifyRequest request = new PasswordVerifyRequest("wrongpwd123");
 
@@ -504,16 +475,14 @@ class MemberServiceTest {
         String email = "dlawotn3@naver.com";
         String password = "jisu1234";
         String nickname = "mery";
-        String phone = "010-1111-1111";
-        Member member = new Member(email, passwordEncoder.encode(password), nickname, phone);
+        Member member = new Member(email, passwordEncoder.encode(password), nickname);
         memberRepository.save(member);
 
         GetUpdateProfileInfoResponse actual = memberService.getUpdateProfileInfo(member.getEmail());
 
         assertAll(
                 () -> assertThat(actual.getEmail()).isEqualTo(email),
-                () -> assertThat(actual.getNickname()).isEqualTo(nickname),
-                () -> assertThat(actual.getPhone()).isEqualTo(phone)
+                () -> assertThat(actual.getNickname()).isEqualTo(nickname)
         );
     }
 }


### PR DESCRIPTION
## 개요
- 전화번호를 수집할 이유가 없습니다. 

## 작업사항
- 전화번호 컬럼을 삭제하고 관련 생성자 및 테스트를 변경했습니다.

## 주의사항
- 현재 프론트 측에서 전화번호 관련 UI를 삭제하지 않아 API 명세서는 수정하지 않았습니다. API 명세서는 추후 협의해야될 것 같아요.
- 전화번호 관련 로직이 남아있다면 리뷰 부탁드려요.
