### PR TITLE
feat: 리뷰 수정 시 카페 미리보기 캐시 무효화

### DIFF
--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -238,6 +238,7 @@ public class CafeService {
         return CafeMyReviewResponse.of(score, review);
     }
 
+    @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
     public CafeReviewUpdateResponse updateCafeReview(String email, String mapId, CafeReviewUpdateRequest request) {
         Cafe cafe = cafeRepository.findByMapId(mapId)


### PR DESCRIPTION
## 개요
<img width="224" alt="image" src="https://github.com/mocacong/Mocacong-Backend/assets/57135043/e3f51997-9693-4e7a-baf4-7e81af23b291">

- 리뷰 수정으로 인한 평점이 수정됨에도 불구하고, 카페 미리보기 API와 카페 조회 API에서 반환하는 평점이 다릅니다.

## 작업사항
- 리뷰 수정 시 카페 미리보기 API 의 캐시를 무효화하도록 하였습니다.

## 주의사항
- Swagger로 아래 카페 리뷰 등록 후, 평점 수정 시에 미리보기 API, 조회 API가 서로 같은 평점을 반환하는지 확인해주세요.
