### PR TITLE
feat: 파일 손상 및 요청 에러 예외 핸들링

### DIFF
--- a/src/main/java/mocacong/server/controller/ControllerAdvice.java
+++ b/src/main/java/mocacong/server/controller/ControllerAdvice.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import mocacong.server.dto.response.ErrorResponse;
 import mocacong.server.exception.MocacongException;
 import mocacong.server.support.SlackAlarmGenerator;
+import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -86,6 +87,14 @@ public class ControllerAdvice {
 
         return ResponseEntity.badRequest()
                 .body(new ErrorResponse(9005, "요청 MultipartFile param 이름이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(FileUploadException.class)
+    public ResponseEntity<ErrorResponse> handleMissingMultiPartParamException(FileUploadException e) {
+        log.warn("File Upload Exception! Please check request. ErrMessage={}\n", e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9006, "요청 파일이 올바르지 않습니다. 파일 손상 여부나 요청 형식을 확인해주세요."));
     }
 
     @ExceptionHandler(MocacongException.class)

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidFileEmptyException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidFileEmptyException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class InvalidFileEmptyException extends BadRequestException {
+
+    public InvalidFileEmptyException() {
+        super("빈 파일은 업로드할 수 없습니다.", 9007);
+    }
+}

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -17,8 +17,8 @@ import mocacong.server.exception.notfound.NotFoundCafeImageException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
-import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.service.event.DeleteMemberEvent;
+import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -315,10 +315,6 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
 
         for (MultipartFile cafeImage : cafeImages) {
-            if (checkInvalidUploadFile(cafeImage)) {
-                continue;
-            }
-
             String imgUrl = awsS3Uploader.uploadImage(cafeImage);
             CafeImage uploadedCafeImage = new CafeImage(imgUrl, true, cafe, member);
             cafeImageRepository.save(uploadedCafeImage);
@@ -329,10 +325,6 @@ public class CafeService {
         if (cafeImages.size() > CAFE_IMAGES_PER_REQUEST_LIMIT_COUNTS) {
             throw new ExceedCafeImagesCountsException();
         }
-    }
-
-    private boolean checkInvalidUploadFile(MultipartFile multipartFile) {
-        return multipartFile.getSize() == 0;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/mocacong/server/support/AwsS3Uploader.java
+++ b/src/main/java/mocacong/server/support/AwsS3Uploader.java
@@ -2,20 +2,20 @@ package mocacong.server.support;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mocacong.server.exception.badrequest.InvalidFileEmptyException;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @Component
@@ -30,6 +30,8 @@ public class AwsS3Uploader {
     private String bucket;
 
     public String uploadImage(MultipartFile multipartFile) {
+        checkInvalidUploadFile(multipartFile);
+
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentType(multipartFile.getContentType());
         objectMetadata.setContentLength(multipartFile.getSize());
@@ -44,6 +46,12 @@ public class AwsS3Uploader {
             throw new IllegalStateException("S3 파일 업로드에 실패했습니다.");
         }
         return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void checkInvalidUploadFile(MultipartFile multipartFile) {
+        if (multipartFile.isEmpty() || multipartFile.getSize() == 0) {
+            throw new InvalidFileEmptyException();
+        }
     }
 
     @Async

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -2,7 +2,6 @@ package mocacong.server.service;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.*;
@@ -22,7 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
@@ -774,22 +774,6 @@ class CafeServiceTest {
         Cafe actual = cafeRepository.findByMapId(mapId)
                 .orElseThrow();
         assertThat(actual.getCafeImages()).hasSize(2);
-    }
-
-    @Test
-    @DisplayName("빈 카페 이미지를 포함하는 경우, 해당 이미지는 S3 호출을 하지 않는다")
-    void saveCafeImageWhenNoneCafeImage() throws IOException {
-        Cafe cafe = new Cafe("2143154352323", "케이카페");
-        cafeRepository.save(cafe);
-        Member member = new Member("kth990303@naver.com", "a1b2c3d4", "메리", "010-1234-5678", null);
-        memberRepository.save(member);
-        String mapId = cafe.getMapId();
-        MockMultipartFile mockMultipartFile =
-                new MockMultipartFile("empty", "empty.jpg", null, (InputStream) null);
-
-        cafeService.saveCafeImage(member.getEmail(), mapId, List.of(mockMultipartFile));
-
-        verify(awsS3Uploader, times(0)).uploadImage(mockMultipartFile);
     }
 
     @Test


### PR DESCRIPTION
## 개요
- 손상된 파일로 요청이 오는 경우 500번대 에러가 발생합니다.
```java
nested exception is java.io.IOException: org.apache.tomcat.util.http.fileupload.impl.IOFileUploadException: 
Processing of multipart/form-data request failed. java.io.EOFException
```

- 카페 이미지를 수정할 때, 없는 파일은 업로드할 수 없습니다. 하지만 파일 자체는 존재하나 사이즈가 0인 경우는 그대로 업로드됩니다.

## 작업사항
- 손상된 파일 요청을 9006번 예외 발생하도록 핸들링했습니다.
- 빈 파일 체크 여부를 CafeService, MemberService 에서 AwsS3Uploader 객체에게 위임했습니다.
  - 카페 이미지 여러 개 업로드 시, 2개 빈 파일이고 1개 정상적 이미지 파일일 경우  1개만 잘 올라가는 것을 확인했습니다.
- 사이즈가 0인 빈 파일 업로드 시 9007번 예외 발생하도록 핸들링했습니다. 

## 주의사항
- **9007번 예외 발생 프로세스 로직은 프론트 측과 최종 협의가 되지 않았습니다. 프론트가 동의하면 그대로 유지, 동의하지 않으면 `e6845a2 (feat: 빈 파일 업로드 시 예외 발생 구현)` 커밋은 롤백 예정입니다.**
- 회원 프로필 이미지 등록, 수정, 카페 이미지 업로드, 여러 개 업로드, 수정 기능이 잘 동작하는지 확인해주세요.
- 빈 파일 업로드 시 예외를 발생시키는지 확인해주세요.
  - 카페 이미지 여러 개 업로드 시, 하나라도 비어있는 파일이 아닐 경우 예외 발생 안시키게 했습니다. 그리고 S3에는 비어있지 않은 파일만 오브젝트로 올라갑니다. 이 점도 한번 확인 부탁드려요 
