### PR TITLE
fix: 카페 이미지 조회 정렬 로직 ASC로 수정

### DIFF
--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -12,8 +12,8 @@ public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
 
     @Query("SELECT ci FROM CafeImage ci WHERE ci.cafe.id = :cafeId AND ci.isUsed = true " +
             "ORDER BY CASE WHEN ci.member.id = :memberId THEN 0 ELSE 1 END, " +
-            "CASE WHEN ci.member.id = :memberId THEN ci.id END DESC, ci.id DESC")
-    Slice<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(Long cafeId, Long memberId, Pageable pageable);
+            "CASE WHEN ci.member.id = :memberId THEN ci.id END, ci.id")
+    Slice<CafeImage> findAllByCafeIdAndIsUsedOrderByCafeImageId(Long cafeId, Long memberId, Pageable pageable);
 
     List<CafeImage> findAllByMemberId(Long memberId);
 

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -17,8 +13,8 @@ import mocacong.server.exception.notfound.NotFoundCafeImageException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
-import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.service.event.DeleteMemberEvent;
+import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -31,6 +27,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -129,7 +130,7 @@ public class CafeService {
     private List<CafeImageResponse> findCafeImageResponses(Cafe cafe, Member member) {
         Pageable pageable = PageRequest.of(0, 5);
         Slice<CafeImage> cafeImages = cafeImageRepository.
-                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), member.getId(), pageable);
+                findAllByCafeIdAndIsUsedOrderByCafeImageId(cafe.getId(), member.getId(), pageable);
 
         return cafeImages
                 .getContent()
@@ -343,7 +344,7 @@ public class CafeService {
                 .orElseThrow(NotFoundMemberException::new);
         Pageable pageable = PageRequest.of(page, count);
         Slice<CafeImage> cafeImages = cafeImageRepository.
-                findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(), member.getId(), pageable);
+                findAllByCafeIdAndIsUsedOrderByCafeImageId(cafe.getId(), member.getId(), pageable);
 
         List<CafeImageResponse> responses = cafeImages
                 .getContent()

--- a/src/test/java/mocacong/server/repository/CafeImageRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeImageRepositoryTest.java
@@ -27,7 +27,7 @@ public class CafeImageRepositoryTest {
     private MemberRepository memberRepository;
 
     @Test
-    @DisplayName("내가 올린 카페 이미지부터 조회한다")
+    @DisplayName("내가 올린 카페 이미지부터 등록 순으로 조회한다")
     void findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc() throws IOException {
         Pageable pageable = PageRequest.of(0, 5);
         Cafe cafe = cafeRepository.save(new Cafe("1", "케이카페"));

--- a/src/test/java/mocacong/server/repository/CafeImageRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeImageRepositoryTest.java
@@ -27,7 +27,7 @@ public class CafeImageRepositoryTest {
     private MemberRepository memberRepository;
 
     @Test
-    @DisplayName("내가 올린 카페 이미지부터 최신순으로 조회한다")
+    @DisplayName("내가 올린 카페 이미지부터 조회한다")
     void findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc() throws IOException {
         Pageable pageable = PageRequest.of(0, 5);
         Cafe cafe = cafeRepository.save(new Cafe("1", "케이카페"));
@@ -48,17 +48,17 @@ public class CafeImageRepositoryTest {
         cafeImageRepository.save(cafeImage5);
         cafeImageRepository.save(cafeImage6);
 
-        Slice<CafeImage> actual = cafeImageRepository.findAllByCafeIdAndIsUsedOrderByCafeImageIdDesc(cafe.getId(),
+        Slice<CafeImage> actual = cafeImageRepository.findAllByCafeIdAndIsUsedOrderByCafeImageId(cafe.getId(),
                 member1.getId(), pageable); // member1로 카페 이미지 조회
         List<CafeImage> cafeImages = actual.getContent();
 
         assertAll(
                 () -> assertThat(cafeImages).hasSize(5),
-                () -> assertThat(cafeImages.get(0)).isEqualTo(cafeImage5),
-                () -> assertThat(cafeImages.get(1)).isEqualTo(cafeImage4),
-                () -> assertThat(cafeImages.get(2)).isEqualTo(cafeImage2),
-                () -> assertThat(cafeImages.get(3)).isEqualTo(cafeImage1),
-                () -> assertThat(cafeImages.get(4)).isEqualTo(cafeImage6)
+                () -> assertThat(cafeImages.get(0)).isEqualTo(cafeImage1),
+                () -> assertThat(cafeImages.get(1)).isEqualTo(cafeImage2),
+                () -> assertThat(cafeImages.get(2)).isEqualTo(cafeImage4),
+                () -> assertThat(cafeImages.get(3)).isEqualTo(cafeImage5),
+                () -> assertThat(cafeImages.get(4)).isEqualTo(cafeImage3)
         );
     }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
 import mocacong.server.domain.*;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
@@ -16,16 +12,22 @@ import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
 import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mock.web.MockMultipartFile;
 
 @ServiceTest
 class CafeServiceTest {
@@ -924,7 +926,7 @@ class CafeServiceTest {
     }
 
     @Test
-    @DisplayName("자신이 등록한 이미지부터 최신 순으로 이미지를 조회한다")
+    @DisplayName("자신이 등록한 이미지부터 등록 순으로 이미지를 조회한다")
     void findCafeImagesReturnOrderedImages() throws IOException {
         String expected = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
@@ -949,18 +951,18 @@ class CafeServiceTest {
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(cafeImages).hasSize(4),
-                // 최신 순으로 정렬되었는지 검증
-                () -> assertThat(cafeImages.get(0).getId()).isEqualTo(4),
-                () -> assertThat(cafeImages.get(1).getId()).isEqualTo(3),
-                () -> assertThat(cafeImages.get(2).getId()).isEqualTo(2),
-                () -> assertThat(cafeImages.get(3).getId()).isEqualTo(1),
+                // 등록 순으로 정렬되었는지 검증
+                () -> assertThat(cafeImages.get(0).getId()).isEqualTo(3),
+                () -> assertThat(cafeImages.get(1).getId()).isEqualTo(4),
+                () -> assertThat(cafeImages.get(2).getId()).isEqualTo(1),
+                () -> assertThat(cafeImages.get(3).getId()).isEqualTo(2),
                 () -> assertThat(cafeImages.get(0).getIsMe()).isTrue(),
                 () -> assertThat(cafeImages.get(2).getIsMe()).isFalse()
         );
     }
 
     @Test
-    @DisplayName("타인이 나중에 이미지를 등록해도 자신이 등록한 이미지부터 최신 순으로 조회한다")
+    @DisplayName("타인이 나중에 이미지를 등록해도 자신이 등록한 이미지부터 등록 순으로 조회한다")
     void findCafeImagesReturnOrderedMyImages() throws IOException {
         String expected = "test_img.jpg";
         Cafe cafe = new Cafe("2143154352323", "케이카페");
@@ -988,10 +990,10 @@ class CafeServiceTest {
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(cafeImages).hasSize(4),
                 // 자신이 올린 사진부터 최신 순으로 정렬되었는지 검증
-                () -> assertThat(cafeImages.get(0).getId()).isEqualTo(3),
-                () -> assertThat(cafeImages.get(1).getId()).isEqualTo(1),
-                () -> assertThat(cafeImages.get(2).getId()).isEqualTo(4),
-                () -> assertThat(cafeImages.get(3).getId()).isEqualTo(2),
+                () -> assertThat(cafeImages.get(0).getId()).isEqualTo(1),
+                () -> assertThat(cafeImages.get(1).getId()).isEqualTo(3),
+                () -> assertThat(cafeImages.get(2).getId()).isEqualTo(2),
+                () -> assertThat(cafeImages.get(3).getId()).isEqualTo(4),
                 () -> assertThat(cafeImages.get(0).getIsMe()).isTrue(),
                 () -> assertThat(cafeImages.get(2).getIsMe()).isFalse()
         );
@@ -1080,7 +1082,7 @@ class CafeServiceTest {
                 () -> assertThat(actual.getCafeImages().get(2).getIsMe()).isEqualTo(true),
                 () -> assertThat(actual.getCafeImages().get(3).getIsMe()).isEqualTo(true),
                 () -> assertThat(actual.getCafeImages().get(4).getIsMe()).isEqualTo(true),
-                () -> assertThat(actual.getCafeImages().get(4).getImageUrl()).endsWith("test_img.jpg"),
+                () -> assertThat(actual.getCafeImages().get(4).getImageUrl()).endsWith("test_img2.jpg"),
                 () -> assertThat(given.getCafeImages()).hasSize(6)
         );
     }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -989,7 +989,7 @@ class CafeServiceTest {
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(cafeImages).hasSize(4),
-                // 자신이 올린 사진부터 최신 순으로 정렬되었는지 검증
+                // 자신이 올린 사진부터 등록 순으로 정렬되었는지 검증
                 () -> assertThat(cafeImages.get(0).getId()).isEqualTo(1),
                 () -> assertThat(cafeImages.get(1).getId()).isEqualTo(3),
                 () -> assertThat(cafeImages.get(2).getId()).isEqualTo(2),


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 카페 이미지를 최신순(DESC) 정렬에서 등록순(ASC) 정렬로 수정하였습니다.

## 작업사항
- 정렬 Repository 메서드 쿼리문 수정
- 정렬 수정으로 인한 테스트 코드 수정

## 주의사항
- 프론트의 요청사항에 맞게 수정되었는지 포스트맨이나 스웨거로 확인해주세요
- 추가적으로 필요한 테스트 코드가 있는지 확인해주세요
