### PR TITLE
feat: 마이페이지 카페 조회 시, 스터디타입을 함께 반환하도록 구현

### DIFF
--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -89,6 +89,10 @@ public class Cafe extends BaseTime {
         else return StudyType.GROUP;
     }
 
+    public String getStudyType() {
+        return cafeDetail.getStudyTypeValue();
+    }
+
     public double findAverageScore() {
         return score.stream()
                 .mapToDouble(Score::getScore)

--- a/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
@@ -10,5 +10,6 @@ public class MyCommentCafeResponse {
 
     private String mapId;
     private String name;
+    private String studyType;
     private String comment;
 }

--- a/src/main/java/mocacong/server/dto/response/MyFavoriteCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyFavoriteCafeResponse.java
@@ -10,5 +10,6 @@ public class MyFavoriteCafeResponse {
 
     private String mapId;
     private String name;
+    private String studyType;
     private double score;
 }

--- a/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
@@ -10,5 +10,6 @@ public class MyReviewCafeResponse {
 
     private String mapId;
     private String name;
+    private String studyType;
     private int myScore;
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,5 +1,9 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -27,11 +31,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.persistence.EntityManager;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -148,7 +147,7 @@ public class CafeService {
         List<MyFavoriteCafeResponse> responses = myFavoriteCafes
                 .getContent()
                 .stream()
-                .map(cafe -> new MyFavoriteCafeResponse(cafe.getMapId(), cafe.getName(), cafe.findAverageScore()))
+                .map(cafe -> new MyFavoriteCafeResponse(cafe.getMapId(), cafe.getName(), cafe.getStudyType(), cafe.findAverageScore()))
                 .collect(Collectors.toList());
         return new MyFavoriteCafesResponse(myFavoriteCafes.isLast(), responses);
     }
@@ -163,7 +162,7 @@ public class CafeService {
                 .stream()
                 .map(cafe -> {
                     int score = scoreRepository.findScoreByCafeIdAndMemberId(cafe.getId(), member.getId());
-                    return new MyReviewCafeResponse(cafe.getMapId(), cafe.getName(), score);
+                    return new MyReviewCafeResponse(cafe.getMapId(), cafe.getName(), cafe.getStudyType(), score);
                 })
                 .collect(Collectors.toList());
         return new MyReviewCafesResponse(myReviewCafes.isLast(), responses);
@@ -179,6 +178,7 @@ public class CafeService {
                 .map(comment -> new MyCommentCafeResponse(
                         comment.getCafe().getMapId(),
                         comment.getCafe().getName(),
+                        comment.getCafe().getStudyType(),
                         comment.getContent()
                 ))
                 .collect(Collectors.toList());

--- a/src/test/java/mocacong/server/domain/CafeTest.java
+++ b/src/test/java/mocacong/server/domain/CafeTest.java
@@ -151,4 +151,24 @@ class CafeTest {
         );
     }
 
+    @Test
+    @DisplayName("카페의 스터디 타입을 반환한다")
+    void getStudyType() {
+        Member member = new Member("kth@naver.com", "a1b2c3d4", "케이", "010-1234-5678");
+        Cafe cafe = new Cafe("1", "케이카페");
+        CafeDetail cafeDetail = new CafeDetail(StudyType.SOLO, Wifi.FAST, null, Toilet.CLEAN, null, Power.MANY, Sound.LOUD);
+        Review review = new Review(member, cafe, cafeDetail);
+        cafe.addReview(review);
+        cafe.updateCafeDetails();
+
+        assertThat(cafe.getStudyType()).isEqualTo("solo");
+    }
+
+    @Test
+    @DisplayName("리뷰가 없는 카페의 스터디 타입은 null 을 반환한다")
+    void getStudyTypeWhenNotHasReviews() {
+        Cafe cafe = new Cafe("1", "케이카페");
+
+        assertThat(cafe.getStudyType()).isNull();
+    }
 }


### PR DESCRIPTION
## 개요
- 마이페이지에서 카페 조회 시, 스터디 타입까지 반환해달라는 기획 요청 존재

## 작업사항
- 마이페이지에서 즐겨찾기 목록 조회, 리뷰 남긴 카페 목록 조회, 코멘트 목록 조회 시에 API를 수정했습니다.
  - 해당 카페의 studyType이 같이 뜨도록 변경
  - 리뷰가 하나도 없는 카페의 studyType 조회 시에 에러가 뜨지 않고 null이 안전하게 뜨도록 구현했습니다.
- 해당 도메인 메서드의 테스트 코드를 작성했으며, 단순 DTO 변경 부분은 테스트 코드 미작성했습니다. 

## 주의사항
- NPE나 에러가 날만한 부분이 있는지 확인해주세요