### PR TITLE
fix: 회원가입 시 이메일 확인 로직과 이메일 중복체크 로직 동일

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
-import mocacong.server.security.auth.LoginUserEmail;
+import mocacong.server.security.auth.LoginUserId;
 import mocacong.server.service.CafeService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,10 +35,10 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/{mapId}")
     public ResponseEntity<FindCafeResponse> findCafeByMapId(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId
     ) {
-        FindCafeResponse response = cafeService.findCafeByMapId(email, mapId);
+        FindCafeResponse response = cafeService.findCafeByMapId(memberId, mapId);
         return ResponseEntity.ok(response);
     }
 
@@ -46,10 +46,10 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/{mapId}/preview")
     public ResponseEntity<PreviewCafeResponse> previewCafeByMapId(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId
     ) {
-        PreviewCafeResponse response = cafeService.previewCafeByMapId(email, mapId);
+        PreviewCafeResponse response = cafeService.previewCafeByMapId(memberId, mapId);
         return ResponseEntity.ok(response);
     }
 
@@ -57,11 +57,11 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @PostMapping("/{mapId}")
     public ResponseEntity<CafeReviewResponse> saveCafeReview(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestBody @Valid CafeReviewRequest request
     ) {
-        CafeReviewResponse response = cafeService.saveCafeReview(email, mapId, request);
+        CafeReviewResponse response = cafeService.saveCafeReview(memberId, mapId, request);
         return ResponseEntity.ok(response);
     }
 
@@ -69,10 +69,10 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/{mapId}/me")
     public ResponseEntity<CafeMyReviewResponse> findMyCafeReview(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId
     ) {
-        CafeMyReviewResponse response = cafeService.findMyCafeReview(email, mapId);
+        CafeMyReviewResponse response = cafeService.findMyCafeReview(memberId, mapId);
         return ResponseEntity.ok(response);
     }
 
@@ -80,11 +80,11 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @PutMapping("/{mapId}")
     public ResponseEntity<CafeReviewUpdateResponse> updateCafeReview(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestBody @Valid CafeReviewUpdateRequest request
     ) {
-        CafeReviewUpdateResponse response = cafeService.updateCafeReview(email, mapId, request);
+        CafeReviewUpdateResponse response = cafeService.updateCafeReview(memberId, mapId, request);
         return ResponseEntity.ok(response);
     }
 
@@ -103,10 +103,10 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @PostMapping("/favorites")
     public ResponseEntity<CafeFilterFavoritesResponse> getCafesByFavorites(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestBody CafeFilterFavoritesRequest request
     ) {
-        CafeFilterFavoritesResponse responseBody = cafeService.filterCafesByFavorites(email, request);
+        CafeFilterFavoritesResponse responseBody = cafeService.filterCafesByFavorites(memberId, request);
         return ResponseEntity.ok(responseBody);
     }
 
@@ -114,11 +114,11 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = "/{mapId}/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> saveCafeImage(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestParam(value = "files") List<MultipartFile> multipartFiles
     ) {
-        cafeService.saveCafeImage(email, mapId, multipartFiles);
+        cafeService.saveCafeImage(memberId, mapId, multipartFiles);
         return ResponseEntity.ok().build();
     }
 
@@ -126,12 +126,12 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/{mapId}/img")
     public ResponseEntity<CafeImagesResponse> getCafeImages(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count
     ) {
-        CafeImagesResponse response = cafeService.findCafeImages(email, mapId, page, count);
+        CafeImagesResponse response = cafeService.findCafeImages(memberId, mapId, page, count);
         return ResponseEntity.ok(response);
     }
 
@@ -139,12 +139,12 @@ public class CafeController {
     @SecurityRequirement(name = "JWT")
     @PutMapping(value = "/{mapId}/img/{cafeImageId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> updateCafeImage(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @PathVariable Long cafeImageId,
             @RequestParam(value = "file") MultipartFile multipartFile
     ) {
-        cafeService.updateCafeImage(email, mapId, cafeImageId, multipartFile);
+        cafeService.updateCafeImage(memberId, mapId, cafeImageId, multipartFile);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/mocacong/server/controller/CommentController.java
+++ b/src/main/java/mocacong/server/controller/CommentController.java
@@ -3,16 +3,17 @@ package mocacong.server.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.CommentSaveRequest;
 import mocacong.server.dto.request.CommentUpdateRequest;
 import mocacong.server.dto.response.CommentSaveResponse;
 import mocacong.server.dto.response.CommentsResponse;
-import mocacong.server.security.auth.LoginUserEmail;
+import mocacong.server.security.auth.LoginUserId;
 import mocacong.server.service.CommentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @Tag(name = "Comments", description = "댓글")
 @RestController
@@ -26,11 +27,11 @@ public class CommentController {
     @SecurityRequirement(name = "JWT")
     @PostMapping
     public ResponseEntity<CommentSaveResponse> saveComment(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestBody @Valid CommentSaveRequest request
     ) {
-        CommentSaveResponse response = commentService.save(email, mapId, request.getContent());
+        CommentSaveResponse response = commentService.save(memberId, mapId, request.getContent());
         return ResponseEntity.ok(response);
     }
 
@@ -38,12 +39,12 @@ public class CommentController {
     @SecurityRequirement(name = "JWT")
     @GetMapping
     public ResponseEntity<CommentsResponse> findComments(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count
     ) {
-        CommentsResponse response = commentService.findAll(email, mapId, page, count);
+        CommentsResponse response = commentService.findAll(memberId, mapId, page, count);
         return ResponseEntity.ok(response);
     }
 
@@ -51,12 +52,12 @@ public class CommentController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/me")
     public ResponseEntity<CommentsResponse> findCommentsByMe(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count
     ) {
-        CommentsResponse response = commentService.findCafeCommentsOnlyMyComments(email, mapId, page, count);
+        CommentsResponse response = commentService.findCafeCommentsOnlyMyComments(memberId, mapId, page, count);
         return ResponseEntity.ok(response);
     }
 
@@ -64,12 +65,12 @@ public class CommentController {
     @SecurityRequirement(name = "JWT")
     @PutMapping("/{commentId}")
     public ResponseEntity<Void> updateComment(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @PathVariable Long commentId,
             @RequestBody @Valid CommentUpdateRequest request
     ) {
-        commentService.update(email, mapId, request.getContent(), commentId);
+        commentService.update(memberId, mapId, request.getContent(), commentId);
         return ResponseEntity.ok().build();
     }
 
@@ -77,11 +78,11 @@ public class CommentController {
     @SecurityRequirement(name = "JWT")
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId,
             @PathVariable Long commentId
     ) {
-        commentService.delete(email, mapId, commentId);
+        commentService.delete(memberId, mapId, commentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/mocacong/server/controller/FavoriteController.java
+++ b/src/main/java/mocacong/server/controller/FavoriteController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.response.FavoriteSaveResponse;
-import mocacong.server.security.auth.LoginUserEmail;
+import mocacong.server.security.auth.LoginUserId;
 import mocacong.server.service.FavoriteService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,10 +22,10 @@ public class FavoriteController {
     @SecurityRequirement(name = "JWT")
     @PostMapping
     public ResponseEntity<FavoriteSaveResponse> saveFavoriteCafe(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId
     ) {
-        FavoriteSaveResponse response = favoriteService.save(email, mapId);
+        FavoriteSaveResponse response = favoriteService.save(memberId, mapId);
         return ResponseEntity.ok(response);
     }
 
@@ -33,10 +33,10 @@ public class FavoriteController {
     @SecurityRequirement(name = "JWT")
     @DeleteMapping
     public ResponseEntity<Void> deleteFavoriteCafe(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @PathVariable String mapId
     ) {
-        favoriteService.delete(email, mapId);
+        favoriteService.delete(memberId, mapId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/mocacong/server/controller/MemberController.java
+++ b/src/main/java/mocacong/server/controller/MemberController.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
-import mocacong.server.security.auth.LoginUserEmail;
+import mocacong.server.security.auth.LoginUserId;
 import mocacong.server.service.CafeService;
 import mocacong.server.service.MemberService;
 import org.springframework.http.MediaType;
@@ -63,8 +63,8 @@ public class MemberController {
     @Operation(summary = "마이페이지 조회")
     @SecurityRequirement(name = "JWT")
     @GetMapping("/mypage")
-    public ResponseEntity<MyPageResponse> findMyInfo(@LoginUserEmail String email) {
-        MyPageResponse response = memberService.findMyInfo(email);
+    public ResponseEntity<MyPageResponse> findMyInfo(@LoginUserId Long memberId) {
+        MyPageResponse response = memberService.findMyInfo(memberId);
         return ResponseEntity.ok(response);
     }
 
@@ -72,11 +72,11 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/mypage/stars")
     public ResponseEntity<MyFavoriteCafesResponse> findMyFavoriteCafes(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count
     ) {
-        MyFavoriteCafesResponse response = cafeService.findMyFavoriteCafes(email, page, count);
+        MyFavoriteCafesResponse response = cafeService.findMyFavoriteCafes(memberId, page, count);
         return ResponseEntity.ok(response);
     }
 
@@ -84,11 +84,11 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/mypage/reviews")
     public ResponseEntity<MyReviewCafesResponse> findMyReviewCafes(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count
     ) {
-        MyReviewCafesResponse response = cafeService.findMyReviewCafes(email, page, count);
+        MyReviewCafesResponse response = cafeService.findMyReviewCafes(memberId, page, count);
         return ResponseEntity.ok(response);
     }
 
@@ -96,11 +96,11 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @GetMapping("/mypage/comments")
     public ResponseEntity<MyCommentCafesResponse> findMyComments(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestParam("page") final Integer page,
             @RequestParam("count") final int count
     ) {
-        MyCommentCafesResponse response = cafeService.findMyCommentCafes(email, page, count);
+        MyCommentCafesResponse response = cafeService.findMyCommentCafes(memberId, page, count);
         return ResponseEntity.ok(response);
     }
 
@@ -108,10 +108,10 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @PutMapping(value = "/mypage/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> updateProfileImage(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestParam(value = "file", required = false) MultipartFile multipartFile
     ) {
-        memberService.updateProfileImage(email, multipartFile);
+        memberService.updateProfileImage(memberId, multipartFile);
         return ResponseEntity.ok().build();
     }
 
@@ -119,10 +119,10 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @PutMapping(value = "/info")
     public ResponseEntity<Void> updateProfileInfo(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestBody @Valid MemberProfileUpdateRequest request
     ) {
-        memberService.updateProfileInfo(email, request);
+        memberService.updateProfileInfo(memberId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -130,9 +130,9 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @GetMapping(value = "/info")
     public ResponseEntity<GetUpdateProfileInfoResponse> getUpdateProfileInfo(
-            @LoginUserEmail String email
+            @LoginUserId Long memberId
     ) {
-        GetUpdateProfileInfoResponse response = memberService.getUpdateProfileInfo(email);
+        GetUpdateProfileInfoResponse response = memberService.getUpdateProfileInfo(memberId);
         return ResponseEntity.ok(response);
     }
 
@@ -140,10 +140,10 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @PostMapping("/info/password")
     public ResponseEntity<PasswordVerifyResponse> passwordVerify(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestBody @Valid PasswordVerifyRequest request
     ) {
-        PasswordVerifyResponse response = memberService.verifyPassword(email, request);
+        PasswordVerifyResponse response = memberService.verifyPassword(memberId, request);
         return ResponseEntity.ok(response);
     }
 
@@ -151,18 +151,18 @@ public class MemberController {
     @SecurityRequirement(name = "JWT")
     @PutMapping("/info/reset-password")
     public ResponseEntity<Void> findAndResetPassword(
-            @LoginUserEmail String email,
+            @LoginUserId Long memberId,
             @RequestBody @Valid ResetPasswordRequest request
     ) {
-        memberService.resetPassword(email, request);
+        memberService.resetPassword(memberId, request);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "회원탈퇴")
     @SecurityRequirement(name = "JWT")
     @DeleteMapping
-    public ResponseEntity<Void> delete(@LoginUserEmail String email) {
-        memberService.delete(email);
+    public ResponseEntity<Void> delete(@LoginUserId Long memberId) {
+        memberService.delete(memberId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -1,15 +1,16 @@
 package mocacong.server.domain;
 
-import java.util.regex.Pattern;
-import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mocacong.server.exception.badrequest.InvalidNicknameException;
 
+import javax.persistence.*;
+import java.util.regex.Pattern;
+
 @Entity
 @Table(name = "member", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"platform", "email"})
+        @UniqueConstraint(columnNames = {"email", "platform"})
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -18,18 +18,18 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
 
     @Query("select c.mapId from Favorite f " +
             "join f.cafe c join f.member m " +
-            "where c.mapId in :mapIds and m.email = :email")
-    List<String> findNearCafeMapIdsByMyFavoriteCafes(String email, List<String> mapIds);
+            "where c.mapId in :mapIds and m.id = :id")
+    List<String> findNearCafeMapIdsByMyFavoriteCafes(Long id, List<String> mapIds);
 
     @Query("select c from Favorite f " +
             "join f.cafe c " +
             "join f.member m " +
-            "where m.email = :email")
-    Slice<Cafe> findByMyFavoriteCafes(String email, Pageable pageRequest);
+            "where m.id = :id")
+    Slice<Cafe> findByMyFavoriteCafes(Long id, Pageable pageRequest);
 
     @Query("select c from Review r " +
             "join r.cafe c " +
             "join r.member m " +
-            "where m.email = :email")
-    Slice<Cafe> findByMyReviewCafes(String email, Pageable pageRequest);
+            "where m.id = :id")
+    Slice<Cafe> findByMyReviewCafes(Long id, Pageable pageRequest);
 }

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
 
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 

--- a/src/main/java/mocacong/server/repository/MemberRepository.java
+++ b/src/main/java/mocacong/server/repository/MemberRepository.java
@@ -12,6 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 
+    Optional<Member> findByEmailAndPlatform(String email, Platform platform);
+
     Boolean existsByEmailAndPlatform(String email, Platform platform);
 
     Boolean existsByNickname(String nickname);

--- a/src/main/java/mocacong/server/security/auth/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/mocacong/server/security/auth/AuthenticationPrincipalArgumentResolver.java
@@ -1,12 +1,13 @@
 package mocacong.server.security.auth;
 
-import javax.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
 
 @Component
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
@@ -27,6 +28,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String token = AuthorizationExtractor.extractAccessToken(request);
-        return jwtTokenProvider.getPayload(token);
+        String payload = jwtTokenProvider.getPayload(token);
+        return Long.parseLong(payload);
     }
 }

--- a/src/main/java/mocacong/server/security/auth/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/mocacong/server/security/auth/AuthenticationPrincipalArgumentResolver.java
@@ -20,7 +20,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(LoginUserEmail.class);
+        return parameter.hasParameterAnnotation(LoginUserId.class);
     }
 
     @Override

--- a/src/main/java/mocacong/server/security/auth/JwtTokenProvider.java
+++ b/src/main/java/mocacong/server/security/auth/JwtTokenProvider.java
@@ -21,12 +21,12 @@ public class JwtTokenProvider {
         this.jwtParser = Jwts.parser().setSigningKey(secretKey);
     }
 
-    public String createToken(String payload) {
+    public String createToken(Long memberId) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
 
         return Jwts.builder()
-                .setSubject(payload)
+                .setSubject(String.valueOf(memberId))
                 .setIssuedAt(now)
                 .setExpiration(validity)
                 .signWith(SignatureAlgorithm.HS256, secretKey)

--- a/src/main/java/mocacong/server/security/auth/LoginUserId.java
+++ b/src/main/java/mocacong/server/security/auth/LoginUserId.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 @Hidden
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface LoginUserEmail {
+public @interface LoginUserId {
 }
 

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -78,9 +78,7 @@ public class AuthService {
     }
 
     private String issueToken(final Member findMember) {
-        String email = findMember.getEmail();
-
-        return jwtTokenProvider.createToken(email);
+        return jwtTokenProvider.createToken(findMember.getId());
     }
 
     private void validatePassword(final Member findMember, final String password) {

--- a/src/main/java/mocacong/server/service/AuthService.java
+++ b/src/main/java/mocacong/server/service/AuthService.java
@@ -29,7 +29,7 @@ public class AuthService {
     private final KakaoOAuthUserProvider kakaoOAuthUserProvider;
 
     public TokenResponse login(AuthLoginRequest request) {
-        Member findMember = memberRepository.findByEmail(request.getEmail())
+        Member findMember = memberRepository.findByEmailAndPlatform(request.getEmail(), Platform.MOCACONG)
                 .orElseThrow(NotFoundMemberException::new);
         validatePassword(findMember, request.getPassword());
 

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,9 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -17,8 +13,8 @@ import mocacong.server.exception.notfound.NotFoundCafeImageException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
-import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.service.event.DeleteMemberEvent;
+import mocacong.server.service.event.DeleteNotUsedImagesEvent;
 import mocacong.server.support.AwsS3Uploader;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -31,6 +27,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -61,11 +62,11 @@ public class CafeService {
     }
 
     @Transactional(readOnly = true)
-    public FindCafeResponse findCafeByMapId(String email, String mapId) {
+    public FindCafeResponse findCafeByMapId(Long memberId, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
         CafeDetail cafeDetail = cafe.getCafeDetail();
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Score scoreByLoginUser = scoreRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
@@ -94,11 +95,11 @@ public class CafeService {
 
     @Cacheable(key = "#mapId", value = "cafePreviewCache", cacheManager = "cafeCacheManager")
     @Transactional(readOnly = true)
-    public PreviewCafeResponse previewCafeByMapId(String email, String mapId) {
+    public PreviewCafeResponse previewCafeByMapId(Long memberId, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
         CafeDetail cafeDetail = cafe.getCafeDetail();
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElse(null);
@@ -142,8 +143,8 @@ public class CafeService {
     }
 
     @Transactional(readOnly = true)
-    public MyFavoriteCafesResponse findMyFavoriteCafes(String email, Integer page, int count) {
-        Slice<Cafe> myFavoriteCafes = cafeRepository.findByMyFavoriteCafes(email, PageRequest.of(page, count));
+    public MyFavoriteCafesResponse findMyFavoriteCafes(Long memberId, Integer page, int count) {
+        Slice<Cafe> myFavoriteCafes = cafeRepository.findByMyFavoriteCafes(memberId, PageRequest.of(page, count));
         List<MyFavoriteCafeResponse> responses = myFavoriteCafes
                 .getContent()
                 .stream()
@@ -153,10 +154,10 @@ public class CafeService {
     }
 
     @Transactional(readOnly = true)
-    public MyReviewCafesResponse findMyReviewCafes(String email, Integer page, int count) {
-        Member member = memberRepository.findByEmail(email)
+    public MyReviewCafesResponse findMyReviewCafes(Long memberId, Integer page, int count) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
-        Slice<Cafe> myReviewCafes = cafeRepository.findByMyReviewCafes(email, PageRequest.of(page, count));
+        Slice<Cafe> myReviewCafes = cafeRepository.findByMyReviewCafes(memberId, PageRequest.of(page, count));
         List<MyReviewCafeResponse> responses = myReviewCafes
                 .getContent()
                 .stream()
@@ -169,8 +170,8 @@ public class CafeService {
     }
 
     @Transactional(readOnly = true)
-    public MyCommentCafesResponse findMyCommentCafes(String email, int page, int count) {
-        Member member = memberRepository.findByEmail(email)
+    public MyCommentCafesResponse findMyCommentCafes(Long memberId, int page, int count) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Comment> comments = commentRepository.findByMemberId(member.getId(), PageRequest.of(page, count));
 
@@ -186,10 +187,10 @@ public class CafeService {
 
     @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
-    public CafeReviewResponse saveCafeReview(String email, String mapId, CafeReviewRequest request) {
+    public CafeReviewResponse saveCafeReview(Long memberId, String mapId, CafeReviewRequest request) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         checkAlreadySaveCafeReview(cafe, member);
 
@@ -228,10 +229,10 @@ public class CafeService {
     }
 
     @Transactional(readOnly = true)
-    public CafeMyReviewResponse findMyCafeReview(String email, String mapId) {
+    public CafeMyReviewResponse findMyCafeReview(Long memberId, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
         Review review = reviewRepository.findByCafeIdAndMemberId(cafe.getId(), member.getId())
@@ -243,10 +244,10 @@ public class CafeService {
 
     @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
-    public CafeReviewUpdateResponse updateCafeReview(String email, String mapId, CafeReviewUpdateRequest request) {
+    public CafeReviewUpdateResponse updateCafeReview(Long memberId, String mapId, CafeReviewUpdateRequest request) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
         updateCafeReviewDetails(request, cafe, member);
@@ -299,19 +300,19 @@ public class CafeService {
         return new CafeFilterStudyTypeResponse(filteredIds);
     }
 
-    public CafeFilterFavoritesResponse filterCafesByFavorites(String email, CafeFilterFavoritesRequest request) {
+    public CafeFilterFavoritesResponse filterCafesByFavorites(Long memberId, CafeFilterFavoritesRequest request) {
         List<String> mapIds = request.getMapIds();
-        List<String> filteredIds = cafeRepository.findNearCafeMapIdsByMyFavoriteCafes(email, mapIds);
+        List<String> filteredIds = cafeRepository.findNearCafeMapIdsByMyFavoriteCafes(memberId, mapIds);
 
         return new CafeFilterFavoritesResponse(filteredIds);
     }
 
     @Transactional
-    public void saveCafeImage(String email, String mapId, List<MultipartFile> cafeImages) {
+    public void saveCafeImage(Long memberId, String mapId, List<MultipartFile> cafeImages) {
         validateCafeImagesCounts(cafeImages);
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
         for (MultipartFile cafeImage : cafeImages) {
@@ -336,10 +337,10 @@ public class CafeService {
     }
 
     @Transactional(readOnly = true)
-    public CafeImagesResponse findCafeImages(String email, String mapId, Integer page, int count) {
+    public CafeImagesResponse findCafeImages(Long memberId, String mapId, Integer page, int count) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Pageable pageable = PageRequest.of(page, count);
         Slice<CafeImage> cafeImages = cafeImageRepository.
@@ -358,10 +359,10 @@ public class CafeService {
     }
 
     @Transactional
-    public void updateCafeImage(String email, String mapId, Long cafeImageId, MultipartFile cafeImg) {
+    public void updateCafeImage(Long memberId, String mapId, Long cafeImageId, MultipartFile cafeImg) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         CafeImage notUsedImage = cafeImageRepository.findById(cafeImageId)
                 .orElseThrow(NotFoundCafeImageException::new);

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -1,7 +1,5 @@
 package mocacong.server.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
@@ -24,6 +22,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -33,10 +34,10 @@ public class CommentService {
     private final CafeRepository cafeRepository;
     private final CommentRepository commentRepository;
 
-    public CommentSaveResponse save(String email, String mapId, String content) {
+    public CommentSaveResponse save(Long memberId, String mapId, String content) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Comment comment = new Comment(cafe, member, content);
 
@@ -44,10 +45,10 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public CommentsResponse findAll(String email, String mapId, Integer page, int count) {
+    public CommentsResponse findAll(Long memberId, String mapId, Integer page, int count) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Comment> comments = commentRepository.findAllByCafeId(cafe.getId(), PageRequest.of(page, count));
         List<CommentResponse> responses = findCommentResponses(member, comments);
@@ -55,10 +56,10 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public CommentsResponse findCafeCommentsOnlyMyComments(String email, String mapId, Integer page, int count) {
+    public CommentsResponse findCafeCommentsOnlyMyComments(Long memberId, String mapId, Integer page, int count) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Comment> comments =
                 commentRepository.findAllByCafeIdAndMemberId(cafe.getId(), member.getId(), PageRequest.of(page, count));
@@ -79,10 +80,10 @@ public class CommentService {
     }
 
     @Transactional
-    public void update(String email, String mapId, String content, Long commentId) {
+    public void update(Long memberId, String mapId, String content, Long commentId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Comment comment = cafe.getComments().stream()
                 .filter(c -> c.getId().equals(commentId))
@@ -96,10 +97,10 @@ public class CommentService {
     }
 
     @Transactional
-    public void delete(String email, String mapId, Long commentId) {
+    public void delete(Long memberId, String mapId, Long commentId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Comment comment = cafe.getComments().stream()
                 .filter(c -> c.getId().equals(commentId))

--- a/src/main/java/mocacong/server/service/FavoriteService.java
+++ b/src/main/java/mocacong/server/service/FavoriteService.java
@@ -32,10 +32,10 @@ public class FavoriteService {
 
     @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
-    public FavoriteSaveResponse save(String email, String mapId) {
+    public FavoriteSaveResponse save(Long memberId, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         validateDuplicateFavorite(cafe.getId(), member.getId());
 
@@ -55,9 +55,9 @@ public class FavoriteService {
 
     @CacheEvict(key = "#mapId", value = "cafePreviewCache")
     @Transactional
-    public void delete(String email, String mapId) {
+    public void delete(Long memberId, String mapId) {
         Cafe cafe = cafeRepository.findByMapId(mapId).orElseThrow(NotFoundCafeException::new);
-        Member member = memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
         Long favoriteId = favoriteRepository.findFavoriteIdByCafeIdAndMemberId(cafe.getId(), member.getId())
                 .orElseThrow(NotFoundFavoriteException::new);
 

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -115,13 +115,13 @@ public class MemberService {
     public EmailVerifyCodeResponse sendEmailVerifyCode(EmailVerifyCodeRequest request) {
         validateNonce(request.getNonce());
         String requestEmail = request.getEmail();
-        memberRepository.findByEmailAndPlatform(requestEmail, Platform.MOCACONG)
+        Member member = memberRepository.findByEmailAndPlatform(requestEmail, Platform.MOCACONG)
                 .orElseThrow(NotFoundMemberException::new);
         Random random = new Random();
         int randomNumber = random.nextInt(EMAIL_VERIFY_CODE_MAXIMUM_NUMBER + 1);
         String code = String.format("%04d", randomNumber);
         awsSESSender.sendToVerifyEmail(requestEmail, code);
-        String token = jwtTokenProvider.createToken(requestEmail);
+        String token = jwtTokenProvider.createToken(member.getId());
         return new EmailVerifyCodeResponse(token, code);
     }
 

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -115,7 +115,7 @@ public class MemberService {
     public EmailVerifyCodeResponse sendEmailVerifyCode(EmailVerifyCodeRequest request) {
         validateNonce(request.getNonce());
         String requestEmail = request.getEmail();
-        memberRepository.findByEmail(requestEmail)
+        memberRepository.findByEmailAndPlatform(requestEmail, Platform.MOCACONG)
                 .orElseThrow(NotFoundMemberException::new);
         Random random = new Random();
         int randomNumber = random.nextInt(EMAIL_VERIFY_CODE_MAXIMUM_NUMBER + 1);

--- a/src/main/java/mocacong/server/service/MemberService.java
+++ b/src/main/java/mocacong/server/service/MemberService.java
@@ -81,8 +81,8 @@ public class MemberService {
     }
 
     @Transactional
-    public void delete(String email) {
-        Member findMember = memberRepository.findByEmail(email)
+    public void delete(Long memberId) {
+        Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         findMember.updateProfileImgUrl(null);
         applicationEventPublisher.publishEvent(new DeleteMemberEvent(findMember));
@@ -102,7 +102,7 @@ public class MemberService {
     public IsDuplicateEmailResponse isDuplicateEmail(String email) {
         validateEmail(email);
 
-        Optional<Member> findMember = memberRepository.findByEmail(email);
+        Optional<Member> findMember = memberRepository.findByEmailAndPlatform(email, Platform.MOCACONG);
         return new IsDuplicateEmailResponse(findMember.isPresent());
     }
 
@@ -126,9 +126,9 @@ public class MemberService {
     }
 
     @Transactional
-    public void resetPassword(String email, ResetPasswordRequest request) {
+    public void resetPassword(Long memberId, ResetPasswordRequest request) {
         validateNonce(request.getNonce());
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         String updatePassword = request.getPassword();
         validatePassword(updatePassword);
@@ -161,15 +161,15 @@ public class MemberService {
         }
     }
 
-    public MyPageResponse findMyInfo(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public MyPageResponse findMyInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         return new MyPageResponse(member.getEmail(), member.getNickname(), member.getPhone(), member.getImgUrl());
     }
 
     @Transactional
-    public void updateProfileImage(String email, MultipartFile profileImg) {
-        Member member = memberRepository.findByEmail(email)
+    public void updateProfileImage(Long memberId, MultipartFile profileImg) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         if (profileImg == null) {
             member.updateProfileImgUrl(null);
@@ -182,10 +182,10 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateProfileInfo(String email, MemberProfileUpdateRequest request) {
+    public void updateProfileInfo(Long memberId, MemberProfileUpdateRequest request) {
         String updateNickname = request.getNickname();
         String updatePhone = request.getPhone();
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         validateDuplicateNickname(updateNickname);
         member.updateProfileInfo(updateNickname, updatePhone);
@@ -205,8 +205,8 @@ public class MemberService {
         memberProfileImageRepository.deleteAllByIdInBatch(ids);
     }
 
-    public PasswordVerifyResponse verifyPassword(String email, PasswordVerifyRequest request) {
-        Member member = memberRepository.findByEmail(email)
+    public PasswordVerifyResponse verifyPassword(Long memberId, PasswordVerifyRequest request) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         String storedPassword = member.getPassword();
         String encodedPassword = passwordEncoder.encode(request.getPassword());
@@ -215,8 +215,8 @@ public class MemberService {
         return new PasswordVerifyResponse(isSuccess);
     }
 
-    public GetUpdateProfileInfoResponse getUpdateProfileInfo(String email) {
-        Member member = memberRepository.findByEmail(email)
+    public GetUpdateProfileInfoResponse getUpdateProfileInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
         return new GetUpdateProfileInfoResponse(member.getEmail(), member.getNickname(), member.getPhone());

--- a/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
@@ -42,7 +42,7 @@ class CafeRepositoryTest {
         favoriteRepository.save(new Favorite(member, savedCafe3));
         List<String> mapIds = List.of(mapId1, mapId2, mapId3, mapId4);
 
-        List<String> actual = cafeRepository.findNearCafeMapIdsByMyFavoriteCafes(member.getEmail(), mapIds);
+        List<String> actual = cafeRepository.findNearCafeMapIdsByMyFavoriteCafes(member.getId(), mapIds);
 
         assertAll(
                 () -> assertThat(actual).hasSize(3),
@@ -64,7 +64,7 @@ class CafeRepositoryTest {
         favoriteRepository.save(new Favorite(member, savedCafe2));
         favoriteRepository.save(new Favorite(member, savedCafe3));
 
-        Slice<Cafe> actual = cafeRepository.findByMyFavoriteCafes(member.getEmail(), PageRequest.of(1, 2));
+        Slice<Cafe> actual = cafeRepository.findByMyFavoriteCafes(member.getId(), PageRequest.of(1, 2));
 
         assertAll(
                 () -> assertThat(actual).hasSize(1),
@@ -90,7 +90,7 @@ class CafeRepositoryTest {
         reviewRepository.save(new Review(member, savedCafe2, cafeDetail));
         reviewRepository.save(new Review(member, savedCafe3, cafeDetail));
 
-        Slice<Cafe> actual = cafeRepository.findByMyReviewCafes(member.getEmail(), PageRequest.of(1, 2));
+        Slice<Cafe> actual = cafeRepository.findByMyReviewCafes(member.getId(), PageRequest.of(1, 2));
 
         assertAll(
                 () -> assertThat(actual).hasSize(1),

--- a/src/test/java/mocacong/server/security/auth/JwtTokenProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/JwtTokenProviderTest.java
@@ -2,12 +2,13 @@ package mocacong.server.security.auth;
 
 import mocacong.server.exception.unauthorized.InvalidTokenException;
 import mocacong.server.exception.unauthorized.TokenExpiredException;
-import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 class JwtTokenProviderTest {

--- a/src/test/java/mocacong/server/security/auth/JwtTokenProviderTest.java
+++ b/src/test/java/mocacong/server/security/auth/JwtTokenProviderTest.java
@@ -19,7 +19,7 @@ class JwtTokenProviderTest {
     @DisplayName("payload 정보를 통해 유효한 JWT 토큰을 생성한다")
     @Test
     public void createToken() {
-        String payload = "dlawotn3@naver.com";
+        Long payload = 1L;
 
         String token = jwtTokenProvider.createToken(payload);
 
@@ -30,7 +30,7 @@ class JwtTokenProviderTest {
     @DisplayName("올바른 토큰 정보로 payload를 조회한다")
     @Test
     void getPayload() {
-        token = jwtTokenProvider.createToken("dlawotn3@naver.com");
+        token = jwtTokenProvider.createToken(1L);
 
         String payload = jwtTokenProvider.getPayload(token);
 
@@ -51,7 +51,7 @@ class JwtTokenProviderTest {
     void getPayloadByExpiredToken() {
         long expirationMillis = 1L;
         JwtTokenProvider jwtTokenProvider = new JwtTokenProvider("secret-key", expirationMillis);
-        String expiredPayload = "expired-payload";
+        Long expiredPayload = 1L;
 
         String expiredToken = jwtTokenProvider.createToken(expiredPayload);
         try {
@@ -67,7 +67,7 @@ class JwtTokenProviderTest {
     @DisplayName("시크릿 키가 틀린 토큰 정보로 payload를 조회할 경우 예외를 발생시킨다")
     @Test
     void getPayloadByWrongSecretKeyToken() {
-        String payload = "dlawotn3@naver.com";
+        Long payload = 1L;
         String correctSecretKey = "correct-secret-key";
         String wrongSecretKey = "wrong-secret-key";
 

--- a/src/test/java/mocacong/server/service/CafeConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeConcurrentServiceTest.java
@@ -80,7 +80,7 @@ public class CafeConcurrentServiceTest {
         for (int i = 0; i < 3; i++) {
             executorService.execute(() -> {
                 try {
-                    cafeService.saveCafeReview(member.getEmail(), cafe.getMapId(), request);
+                    cafeService.saveCafeReview(member.getId(), cafe.getMapId(), request);
                 } catch (AlreadyExistsCafeReview e) {
                     exceptions.add(e); // 중복 예외를 리스트에 추가
                 }
@@ -99,8 +99,8 @@ public class CafeConcurrentServiceTest {
     @Test
     @DisplayName("회원이 한 카페에 동시에 여러 번 리뷰 등록 시도해도 한 번만 등록된다")
     void saveCafeReviewWithConcurrent() throws InterruptedException {
-        Member member = new Member("kth990303@naver.com", "encodePassword", "케이", "010-1234-5678");
-        memberRepository.save(member);
+        Member member = memberRepository.save(new Member("kth990303@naver.com", "encodePassword",
+                "케이", "010-1234-5678"));
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
         ExecutorService executorService = Executors.newFixedThreadPool(3);
@@ -112,7 +112,7 @@ public class CafeConcurrentServiceTest {
         for (int i = 0; i < 3; i++) {
             executorService.execute(() -> {
                 try {
-                    cafeService.saveCafeReview(member.getEmail(), cafe.getMapId(), request);
+                    cafeService.saveCafeReview(member.getId(), cafe.getMapId(), request);
                 } catch (AlreadyExistsCafeReview e) {
                     exceptions.add(e); // 중복 예외를 리스트에 추가
                 }

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -45,7 +45,7 @@ class CommentServiceTest {
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
 
-        CommentSaveResponse savedComment = commentService.save(email, mapId, expected);
+        CommentSaveResponse savedComment = commentService.save(member.getId(), mapId, expected);
 
         Comment actual = commentRepository.findById(savedComment.getId())
                 .orElseThrow(NotFoundCommentException::new);
@@ -60,7 +60,7 @@ class CommentServiceTest {
         Member member = new Member(email, "encodePassword", "케이", "010-1234-5678");
         memberRepository.save(member);
 
-        assertThatThrownBy(() -> commentService.save(email, mapId, "공부하기 좋아요~🥰"))
+        assertThatThrownBy(() -> commentService.save(member.getId(), mapId, "공부하기 좋아요~🥰"))
                 .isInstanceOf(NotFoundCafeException.class);
     }
 
@@ -74,9 +74,9 @@ class CommentServiceTest {
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
 
-        commentService.save(email, mapId, "공부하기 좋아요~🥰");
+        commentService.save(member.getId(), mapId, "공부하기 좋아요~🥰");
 
-        assertDoesNotThrow(() -> commentService.save(email, mapId, "공부하기 좋아요~🥰"));
+        assertDoesNotThrow(() -> commentService.save(member.getId(), mapId, "공부하기 좋아요~🥰"));
     }
 
     @Test
@@ -93,7 +93,7 @@ class CommentServiceTest {
         commentRepository.save(new Comment(cafe, member, "댓글3"));
         commentRepository.save(new Comment(cafe, member, "댓글4"));
 
-        CommentsResponse actual = commentService.findAll(email, mapId, 0, 3);
+        CommentsResponse actual = commentService.findAll(member.getId(), mapId, 0, 3);
 
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isFalse(),
@@ -120,7 +120,7 @@ class CommentServiceTest {
         commentRepository.save(new Comment(cafe, member, "댓글3"));
         commentRepository.save(new Comment(cafe, member2, "댓글4"));
 
-        CommentsResponse actual = commentService.findCafeCommentsOnlyMyComments(email, mapId, 0, 3);
+        CommentsResponse actual = commentService.findCafeCommentsOnlyMyComments(member.getId(), mapId, 0, 3);
 
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
@@ -141,10 +141,10 @@ class CommentServiceTest {
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
-        CommentSaveResponse savedComment = commentService.save(email, mapId, comment);
+        CommentSaveResponse savedComment = commentService.save(member.getId(), mapId, comment);
         String expected = "조용하고 좋네요";
 
-        commentService.update(email, mapId, expected, savedComment.getId());
+        commentService.update(member.getId(), mapId, expected, savedComment.getId());
 
         Comment updatedComment = commentRepository.findById(savedComment.getId())
                 .orElseThrow(NotFoundCommentException::new);
@@ -161,12 +161,12 @@ class CommentServiceTest {
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
-        CommentSaveResponse savedComment = commentService.save(email, mapId, comment);
+        CommentSaveResponse savedComment = commentService.save(member.getId(), mapId, comment);
         String expected = "조용하고 좋네요";
 
-        commentService.update(email, mapId, expected, savedComment.getId());
+        commentService.update(member.getId(), mapId, expected, savedComment.getId());
 
-        assertDoesNotThrow(() -> commentService.update(email, mapId, expected, savedComment.getId()));
+        assertDoesNotThrow(() -> commentService.update(member.getId(), mapId, expected, savedComment.getId()));
     }
 
     @Test
@@ -181,9 +181,9 @@ class CommentServiceTest {
         memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
-        CommentSaveResponse savedComment = commentService.save(email1, mapId, "조용하고 좋네요");
+        CommentSaveResponse savedComment = commentService.save(member1.getId(), mapId, "조용하고 좋네요");
 
-        assertThatThrownBy(() -> commentService.update(email2, mapId, "몰래 이 코멘트를 바꿔", savedComment.getId()))
+        assertThatThrownBy(() -> commentService.update(member2.getId(), mapId, "몰래 이 코멘트를 바꿔", savedComment.getId()))
                 .isInstanceOf(InvalidCommentUpdateException.class);
     }
 
@@ -196,10 +196,10 @@ class CommentServiceTest {
         memberRepository.save(member);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
-        CommentSaveResponse response = commentService.save(email, mapId, "공부하기 좋아요~🥰");
+        CommentSaveResponse response = commentService.save(member.getId(), mapId, "공부하기 좋아요~🥰");
 
-        commentService.delete(email, mapId, response.getId());
-        CommentsResponse actual = commentService.findAll(email, mapId, 0, 3);
+        commentService.delete(member.getId(), mapId, response.getId());
+        CommentsResponse actual = commentService.findAll(member.getId(), mapId, 0, 3);
 
         assertThat(actual.getComments()).hasSize(0);
     }
@@ -214,7 +214,7 @@ class CommentServiceTest {
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
 
-        assertThatThrownBy(() -> commentService.delete(email, mapId, 9999L))
+        assertThatThrownBy(() -> commentService.delete(member.getId(), mapId, 9999L))
                 .isInstanceOf(NotFoundCommentException.class);
     }
 
@@ -230,9 +230,9 @@ class CommentServiceTest {
         memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "케이카페");
         cafeRepository.save(cafe);
-        CommentSaveResponse response = commentService.save(email1, mapId, "공부하기 좋아요~🥰");
+        CommentSaveResponse response = commentService.save(member1.getId(), mapId, "공부하기 좋아요~🥰");
 
-        assertThatThrownBy(() -> commentService.delete(email2, mapId, response.getId()))
+        assertThatThrownBy(() -> commentService.delete(member2.getId(), mapId, response.getId()))
                 .isInstanceOf(InvalidCommentDeleteException.class);
     }
 }

--- a/src/test/java/mocacong/server/service/FavoriteConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteConcurrentServiceTest.java
@@ -46,7 +46,7 @@ public class FavoriteConcurrentServiceTest {
         for (int i = 0; i < 3; i++) {
             executorService.execute(() -> {
                 try {
-                    favoriteService.save(member.getEmail(), cafe.getMapId());
+                    favoriteService.save(member.getId(), cafe.getMapId());
                 } catch (AlreadyExistsFavorite e) {
                     exceptions.add(e); // 중복 예외를 리스트에 추가
                 }

--- a/src/test/java/mocacong/server/service/FavoriteServiceTest.java
+++ b/src/test/java/mocacong/server/service/FavoriteServiceTest.java
@@ -40,7 +40,7 @@ class FavoriteServiceTest {
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
 
-        FavoriteSaveResponse actual = favoriteService.save(member.getEmail(), cafe.getMapId());
+        FavoriteSaveResponse actual = favoriteService.save(member.getId(), cafe.getMapId());
 
         List<Favorite> favorites = favoriteRepository.findAll();
         assertAll(
@@ -56,9 +56,9 @@ class FavoriteServiceTest {
         memberRepository.save(member);
         Cafe cafe = new Cafe("2143154352323", "케이카페");
         cafeRepository.save(cafe);
-        favoriteService.save(member.getEmail(), cafe.getMapId());
+        favoriteService.save(member.getId(), cafe.getMapId());
 
-        assertThatThrownBy(() -> favoriteService.save(member.getEmail(), cafe.getMapId()))
+        assertThatThrownBy(() -> favoriteService.save(member.getId(), cafe.getMapId()))
                 .isInstanceOf(AlreadyExistsFavorite.class);
     }
 
@@ -72,7 +72,7 @@ class FavoriteServiceTest {
         Favorite favorite = new Favorite(member, cafe);
         favoriteRepository.save(favorite);
 
-        favoriteService.delete(member.getEmail(), cafe.getMapId());
+        favoriteService.delete(member.getId(), cafe.getMapId());
 
         assertThat(favoriteRepository.findById(favorite.getId())).isEmpty();
     }
@@ -86,6 +86,6 @@ class FavoriteServiceTest {
         cafeRepository.save(cafe);
 
         assertThrows(NotFoundFavoriteException.class,
-                () -> favoriteService.delete(member.getEmail(), cafe.getMapId()));
+                () -> favoriteService.delete(member.getId(), cafe.getMapId()));
     }
 }


### PR DESCRIPTION
## 개요
- 기존 로직에서는 회원 체크를 할 때 findByEmail을 이용해서 했기 때문에 Platform 상관없이 `email`이 같으면 중복된 회원으로 인식했습니다. 이 문제를 해결하고자 회원 체크를 `email` 과 `Platform` 두가지를 이용해 확인하거나 `memberRepository`의 `findById` 를 통해 확인하도록 로직을 변경했습니다.

## 작업사항
- token payload를 `email` 에서 `memberId` 로 변경
  - 그에 따라 코드 내에서  `findByEmail` 대신 `findById` 를 사용하도록 코드를 변경했습니다
  - `@LoginUserEmail` 에서 `@LoginUserId` 로 이름 변경했습니다
  - `memberRepository`에서 `findByEmail` 메서드를 삭제했습니다
- `validateDuplicateMember` 와 `isDuplicateEmail` 메서드 로직에서 `email` 과 `Platform` 모두 체크하도록 변경
- 해당 변경 사항에 따른 테스트 코드 수정

## 주의사항
- 놓친 수정 사항이 있는지 확인해주세요
- 오타가 있는지 확인해주세요
- 테스트 코드 파일 변경사항은 `member.getEmail()`에서 `member.getId()` 로 변경한 것 뿐이므로 테스트 코드 파일 외의 파일들을 집중적으로 확인해주시면 됩니다
