### PR TITLE
feat: 카페 이미지 url 수정 시 동일 id 반환하도록 로직 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -42,11 +42,11 @@ public class CafeImage extends BaseTime {
         return this.member != null && this.member.equals(member);
     }
 
-    public void removeMember() {
-        this.member = null;
+    public void updateImgUrl(String imgUrl) {
+        this.imgUrl = imgUrl;
     }
 
-    public void setIsUsed(Boolean isUsed) {
-        this.isUsed = isUsed;
+    public void removeMember() {
+        this.member = null;
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,5 +1,9 @@
 package mocacong.server.service;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -27,11 +31,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.persistence.EntityManager;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -357,13 +356,15 @@ public class CafeService {
                 .orElseThrow(NotFoundCafeException::new);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
-        CafeImage notUsedImage = cafeImageRepository.findById(cafeImageId)
+        CafeImage cafeImage = cafeImageRepository.findById(cafeImageId)
                 .orElseThrow(NotFoundCafeImageException::new);
-        notUsedImage.setIsUsed(false);
+        String beforeImgUrl = cafeImage.getImgUrl();
 
         String newImgUrl = awsS3Uploader.uploadImage(cafeImg);
-        CafeImage cafeImage = new CafeImage(newImgUrl, true, cafe, member);
-        cafeImageRepository.save(cafeImage);
+        cafeImage.updateImgUrl(newImgUrl);
+
+        CafeImage notUseImage = new CafeImage(beforeImgUrl, false, cafe, member);
+        cafeImageRepository.save(notUseImage);
     }
 
     @EventListener

--- a/src/test/java/mocacong/server/domain/CafeImageTest.java
+++ b/src/test/java/mocacong/server/domain/CafeImageTest.java
@@ -50,4 +50,16 @@ class CafeImageTest {
 
         assertThat(cafeImage.getMember()).isNull();
     }
+
+    @Test
+    @DisplayName("특정 카페 이미지 url을 수정한다")
+    void updateCafeImageUrl() {
+        String expected = "test_update_url";
+        Cafe cafe = new Cafe("123454321", "케이카페");
+        CafeImage cafeImage = new CafeImage("test_url", true, cafe, member);
+
+        cafeImage.updateImgUrl(expected);
+
+        assertThat(cafeImage.getImgUrl()).isEqualTo(expected);
+    }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -999,10 +999,10 @@ class CafeServiceTest {
         String mapId = cafe.getMapId();
         FileInputStream oldFileInputStream = new FileInputStream("src/test/resources/images/" + oldImage);
         FileInputStream newFileInputStream = new FileInputStream("src/test/resources/images/" + newImage);
-        MockMultipartFile oldMockMultipartFile = new MockMultipartFile("test_img", oldImage, "jpg",
-                oldFileInputStream);
-        MockMultipartFile newMockMultipartFile = new MockMultipartFile("test_img2", newImage, "jpg",
-                newFileInputStream);
+        MockMultipartFile oldMockMultipartFile =
+                new MockMultipartFile("test_img", oldImage, "jpg", oldFileInputStream);
+        MockMultipartFile newMockMultipartFile =
+                new MockMultipartFile("test_img2", newImage, "jpg", newFileInputStream);
         when(awsS3Uploader.uploadImage(oldMockMultipartFile)).thenReturn("test_img.jpg");
         cafeService.saveCafeImage(member.getId(), mapId, List.of(oldMockMultipartFile));
         CafeImagesResponse oldFindImage = cafeService.findCafeImages(member.getId(), mapId, 0, 10);
@@ -1010,13 +1010,14 @@ class CafeServiceTest {
 
         cafeService.updateCafeImage(member.getId(), mapId, oldFindImage.getCafeImages().get(0).getId(),
                 newMockMultipartFile);
+
         CafeImagesResponse actual = cafeService.findCafeImages(member.getId(), mapId, 0, 10);
         List<CafeImageResponse> cafeImages = actual.getCafeImages();
-
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
+                // 수정 이미지의 url 자체만 변경되고 id는 동일할 것
                 () -> assertThat(actual.getCafeImages().get(0).getId())
-                        .isNotEqualTo(oldFindImage.getCafeImages().get(0).getId()),
+                        .isEqualTo(oldFindImage.getCafeImages().get(0).getId()),
                 () -> assertThat(cafeImages.get(0).getImageUrl()).endsWith("test_img2.jpg"),
                 () -> assertThat(cafeImages).hasSize(1)
         );
@@ -1052,10 +1053,10 @@ class CafeServiceTest {
         String mapId = cafe.getMapId();
         FileInputStream oldFileInputStream = new FileInputStream("src/test/resources/images/" + oldImage);
         FileInputStream newFileInputStream = new FileInputStream("src/test/resources/images/" + newImage);
-        MockMultipartFile oldMockMultipartFile = new MockMultipartFile("test_img", oldImage, "jpg",
-                oldFileInputStream);
-        MockMultipartFile newMockMultipartFile = new MockMultipartFile("test_img2", newImage, "jpg",
-                newFileInputStream);
+        MockMultipartFile oldMockMultipartFile =
+                new MockMultipartFile("test_img", oldImage, "jpg", oldFileInputStream);
+        MockMultipartFile newMockMultipartFile =
+                new MockMultipartFile("test_img2", newImage, "jpg", newFileInputStream);
         when(awsS3Uploader.uploadImage(oldMockMultipartFile)).thenReturn("test_img.jpg");
         cafeService.saveCafeImage(member.getId(), mapId, List.of(oldMockMultipartFile));
         cafeService.saveCafeImage(member.getId(), mapId, List.of(oldMockMultipartFile));
@@ -1065,8 +1066,9 @@ class CafeServiceTest {
         CafeImagesResponse oldFindImage = cafeService.findCafeImages(member.getId(), mapId, 0, 10);
         when(awsS3Uploader.uploadImage(newMockMultipartFile)).thenReturn("test_img2.jpg");
 
-        cafeService.updateCafeImage(member.getId(), mapId, oldFindImage.getCafeImages().get(0).getId(),
-                newMockMultipartFile);
+        cafeService.updateCafeImage(
+                member.getId(), mapId, oldFindImage.getCafeImages().get(0).getId(), newMockMultipartFile
+        );
         cafeService.saveCafeImage(member.getId(), mapId, List.of(oldMockMultipartFile));
         FindCafeResponse actual = cafeService.findCafeByMapId(member.getId(), mapId);
         CafeImagesResponse given = cafeService.findCafeImages(member.getId(), mapId, 0, 10);
@@ -1078,7 +1080,7 @@ class CafeServiceTest {
                 () -> assertThat(actual.getCafeImages().get(2).getIsMe()).isEqualTo(true),
                 () -> assertThat(actual.getCafeImages().get(3).getIsMe()).isEqualTo(true),
                 () -> assertThat(actual.getCafeImages().get(4).getIsMe()).isEqualTo(true),
-                () -> assertThat(actual.getCafeImages().get(4).getImageUrl()).endsWith("test_img2.jpg"),
+                () -> assertThat(actual.getCafeImages().get(0).getImageUrl()).endsWith("test_img2.jpg"),
                 () -> assertThat(given.getCafeImages()).hasSize(6)
         );
     }


### PR DESCRIPTION
## 개요
- 기존 로직에서는 카페 이미지 수정 시, id를 새로 반환해주었습니다. 프론트 측에서 매번 GET으로 새 id를 조회해야 합니다. (프론트 측에서는 카페 이미지 수정 로직에서 캐싱된 값을 꺼내는 듯함.)

## 작업사항
- 카페 이미지 변경 로직을 변경했습니다.
- 기존
  - 변경하는 이미지를 새로 save해주어 id가 바뀜. 그리고 변경 전 이미지의 `is_used`는 false로 설정해줬었음.
- 변경
  - 변경하는 이미지 url을 얻어와서 imgUrl 값을 update. 변경 전 이미지는 `is_used` false인 상태로 새로 save (S3 배치 삭제 대상에 포함되도록) 

## 주의사항
- swagger와 h2로 카페 이미지 변경 시 img_url 변경이 잘 되는지 여부, 기존 이미지가 `is_used=false`인 상태로 DB에 남아있는지 확인해주세요
