### PR TITLE
feat: 내가 리뷰를 작성한 카페 조회 시 작성한 리뷰의 studyType이 반환되게끔 기능 수정

### DIFF
--- a/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
@@ -1,6 +1,7 @@
 package mocacong.server.dto.response;
 
 import lombok.*;
+import mocacong.server.domain.cafedetail.StudyType;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -10,6 +11,6 @@ public class MyReviewCafeResponse {
 
     private String mapId;
     private String name;
-    private String studyType;
+    private StudyType studyType;
     private int myScore;
 }

--- a/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyReviewCafeResponse.java
@@ -5,12 +5,18 @@ import mocacong.server.domain.cafedetail.StudyType;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @ToString
 public class MyReviewCafeResponse {
 
     private String mapId;
     private String name;
-    private StudyType studyType;
+    private String studyType;
     private int myScore;
+
+    public MyReviewCafeResponse(String mapId, String name, StudyType studyType, int myScore) {
+        this.mapId = mapId;
+        this.name = name;
+        this.studyType = studyType.getValue();
+        this.myScore = myScore;
+    }
 }

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -28,12 +28,6 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
             "where m.id = :id")
     Slice<Cafe> findByMyFavoriteCafes(Long id, Pageable pageRequest);
 
-    @Query("select c from Review r " +
-            "join r.cafe c " +
-            "join r.member m " +
-            "where m.id = :id")
-    Slice<Cafe> findByMyReviewCafes(Long id, Pageable pageRequest);
-
     @Query("select new mocacong.server.dto.response.MyReviewCafeResponse(c.mapId,c.name,r.cafeDetail.studyType,s.score) from Review r " +
             "join r.cafe c " +
             "join r.member m " +

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -2,6 +2,7 @@ package mocacong.server.repository;
 
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.cafedetail.StudyType;
+import mocacong.server.dto.response.MyReviewCafeResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,9 +34,10 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
             "where m.id = :id")
     Slice<Cafe> findByMyReviewCafes(Long id, Pageable pageRequest);
 
-    @Query("select r.cafeDetail.studyType from Review r " +
+    @Query("select new mocacong.server.dto.response.MyReviewCafeResponse(c.mapId,c.name,r.cafeDetail.studyType,s.score) from Review r " +
             "join r.cafe c " +
             "join r.member m " +
-            "where c.id = :cafeId and m.id = :memberId")
-    String findStudyTypeByCafeIdAndMemberId(Long cafeId, Long memberId);
+            "join c.score s "+
+            "where m.id = :id and s.member.id = :id")
+    Slice<MyReviewCafeResponse> findMyReviewCafesById(Long id, Pageable pageRequest);
 }

--- a/src/main/java/mocacong/server/repository/CafeRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeRepository.java
@@ -32,4 +32,10 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
             "join r.member m " +
             "where m.id = :id")
     Slice<Cafe> findByMyReviewCafes(Long id, Pageable pageRequest);
+
+    @Query("select r.cafeDetail.studyType from Review r " +
+            "join r.cafe c " +
+            "join r.member m " +
+            "where c.id = :cafeId and m.id = :memberId")
+    String findStudyTypeByCafeIdAndMemberId(Long cafeId, Long memberId);
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -157,7 +157,8 @@ public class CafeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
-        Slice<MyReviewCafeResponse> myReviewCafes = cafeRepository.findMyReviewCafesById(member.getId(), PageRequest.of(page, count));
+        Slice<MyReviewCafeResponse> myReviewCafes =
+                cafeRepository.findMyReviewCafesById(member.getId(), PageRequest.of(page, count));
         List<MyReviewCafeResponse> responses = myReviewCafes.getContent();
         return new MyReviewCafesResponse(myReviewCafes.isLast(), responses);
     }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -156,20 +156,9 @@ public class CafeService {
     public MyReviewCafesResponse findMyReviewCafes(Long memberId, Integer page, int count) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
-        Slice<Cafe> myReviewCafes = cafeRepository.findByMyReviewCafes(memberId, PageRequest.of(page, count));
 
-        // TODO : cafe.getStudyType에서 myStudyType으로 변
-        // 리뷰가 작성된 카페의 studyType을 가져와야함
-
-        List<MyReviewCafeResponse> responses = myReviewCafes
-                .getContent()
-                .stream()
-                .map(cafe -> {
-                    int score = scoreRepository.findScoreByCafeIdAndMemberId(cafe.getId(), member.getId());
-                    String studyType = cafeRepository.findStudyTypeByCafeIdAndMemberId(cafe.getId(), member.getId());
-                    return new MyReviewCafeResponse(cafe.getMapId(), cafe.getName(), studyType, score);
-                })
-                .collect(Collectors.toList());
+        Slice<MyReviewCafeResponse> myReviewCafes = cafeRepository.findMyReviewCafesById(member.getId(), PageRequest.of(page, count));
+        List<MyReviewCafeResponse> responses = myReviewCafes.getContent();
         return new MyReviewCafesResponse(myReviewCafes.isLast(), responses);
     }
 

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -157,13 +157,17 @@ public class CafeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Cafe> myReviewCafes = cafeRepository.findByMyReviewCafes(memberId, PageRequest.of(page, count));
-        // TODO : cafe.getStudyType에서 myStudyType으로 변경
+
+        // TODO : cafe.getStudyType에서 myStudyType으로 변
+        // 리뷰가 작성된 카페의 studyType을 가져와야함
+
         List<MyReviewCafeResponse> responses = myReviewCafes
                 .getContent()
                 .stream()
                 .map(cafe -> {
                     int score = scoreRepository.findScoreByCafeIdAndMemberId(cafe.getId(), member.getId());
-                    return new MyReviewCafeResponse(cafe.getMapId(), cafe.getName(), cafe.getStudyType(), score);
+                    String studyType = cafeRepository.findStudyTypeByCafeIdAndMemberId(cafe.getId(), member.getId());
+                    return new MyReviewCafeResponse(cafe.getMapId(), cafe.getName(), studyType, score);
                 })
                 .collect(Collectors.toList());
         return new MyReviewCafesResponse(myReviewCafes.isLast(), responses);

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -157,6 +157,7 @@ public class CafeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Cafe> myReviewCafes = cafeRepository.findByMyReviewCafes(memberId, PageRequest.of(page, count));
+        // TODO : cafe.getStudyType에서 myStudyType으로 변경
         List<MyReviewCafeResponse> responses = myReviewCafes
                 .getContent()
                 .stream()

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -3,6 +3,7 @@ package mocacong.server.acceptance;
 import io.restassured.RestAssured;
 import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import mocacong.server.domain.Platform;
+import mocacong.server.domain.cafedetail.StudyType;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
@@ -362,9 +363,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(4),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("메리네 카페"),
-                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("SOLO"),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo(StudyType.SOLO),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(2),
-                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("GROUP"),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo(StudyType.GROUP),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("케이네 카페")
         );
     }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -362,9 +362,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(4),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("메리네 카페"),
-                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("solo"),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("SOLO"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(2),
-                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("group"),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("GROUP"),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("케이네 카페")
         );
     }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -342,7 +342,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String token2 = 로그인_토큰_발급(signUpRequest2.getEmail(), signUpRequest2.getPassword());
         CafeReviewRequest request1 = new CafeReviewRequest(4, "solo", "빵빵해요", "여유로워요",
                 "깨끗해요", "충분해요", "조용해요", "편해요");
-        CafeReviewRequest request2 = new CafeReviewRequest(2, "solo", "빵빵해요", "여유로워요",
+        CafeReviewRequest request2 = new CafeReviewRequest(2, "group", "빵빵해요", "여유로워요",
                 "깨끗해요", "충분해요", "조용해요", "편해요");
         CafeReviewRequest request3 = new CafeReviewRequest(1, "group", "빵빵해요", "여유로워요",
                 "깨끗해요", "충분해요", "조용해요", "편해요");
@@ -362,7 +362,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(4),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("메리네 카페"),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("solo"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(2),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("group"),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("케이네 카페")
         );
     }

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -363,9 +363,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(4),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("메리네 카페"),
-                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo(StudyType.SOLO),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("solo"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(2),
-                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo(StudyType.GROUP),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("group"),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("케이네 카페")
         );
     }

--- a/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CafeRepositoryTest.java
@@ -2,6 +2,7 @@ package mocacong.server.repository;
 
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
+import mocacong.server.dto.response.MyReviewCafeResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,8 @@ class CafeRepositoryTest {
     private FavoriteRepository favoriteRepository;
     @Autowired
     private ReviewRepository reviewRepository;
+    @Autowired
+    private ScoreRepository scoreRepository;
 
     @Test
     @DisplayName("내가 즐겨찾기에 등록한 카페 mapId 목록을 조회한다.")
@@ -78,27 +81,43 @@ class CafeRepositoryTest {
 
     @Test
     @DisplayName("내가 리뷰를 등록한 카페 목록을 조회한다")
-    void findByMyReviewCafes() {
+    void findByMyReviewCafesById() {
+        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
+
         Cafe savedCafe1 = cafeRepository.save(new Cafe("1", "케이카페1"));
         Cafe savedCafe2 = cafeRepository.save(new Cafe("2", "케이카페2"));
         Cafe savedCafe3 = cafeRepository.save(new Cafe("3", "케이카페3"));
-        Cafe savedCafe4 = cafeRepository.save(new Cafe("4", "케이카페4"));
+
+        Score score1 = new Score(1, member, savedCafe1);
+        Score score2 = new Score(1, member, savedCafe2);
+        Score score3 = new Score(1, member, savedCafe3);
+
         CafeDetail cafeDetail = new CafeDetail(StudyType.BOTH, Wifi.FAST, Parking.COMFORTABLE, Toilet.CLEAN, Desk.NORMAL,
                 Power.NONE, Sound.LOUD);
-        Member member = memberRepository.save(new Member("kth@naver.com", "abcd1234", "케이"));
+
         reviewRepository.save(new Review(member, savedCafe1, cafeDetail));
         reviewRepository.save(new Review(member, savedCafe2, cafeDetail));
         reviewRepository.save(new Review(member, savedCafe3, cafeDetail));
 
-        Slice<Cafe> actual = cafeRepository.findByMyReviewCafes(member.getId(), PageRequest.of(1, 2));
+        scoreRepository.save(score1);
+        scoreRepository.save(score2);
+        scoreRepository.save(score3);
+
+        Slice<MyReviewCafeResponse> actual = cafeRepository.findMyReviewCafesById(member.getId(), PageRequest.of(1, 2));
 
         assertAll(
                 () -> assertThat(actual).hasSize(1),
                 () -> assertThat(actual.getNumber()).isEqualTo(1),
                 () -> assertThat(actual.isLast()).isTrue(),
                 () -> assertThat(actual)
+                        .extracting("studyType")
+                        .containsExactly("both"),
+                () -> assertThat(actual)
                         .extracting("name")
-                        .containsExactly("케이카페3")
+                        .containsExactly("케이카페3"),
+                () -> assertThat(actual)
+                        .extracting("myScore")
+                        .containsExactly(1)
         );
     }
 }

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -4,6 +4,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
 import mocacong.server.domain.*;
+import mocacong.server.domain.cafedetail.StudyType;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
@@ -405,16 +406,15 @@ class CafeServiceTest {
                 new CafeReviewRequest(2, "group", "느려요", "없어요",
                         "깨끗해요", "없어요", null, "보통이에요"));
 
-        System.out.println("---------------------------------------------------------------------------------");
         MyReviewCafesResponse actual = cafeService.findMyReviewCafes(member1.getId(), 0, 3);
 
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1),
-                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("SOLO"),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo(StudyType.SOLO),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("케이카페"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(5),
-                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("GROUP"),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo(StudyType.GROUP),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("메리카페"),
                 () -> assertThat(actual.getCafes()).hasSize(2)
         );

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -396,7 +396,7 @@ class CafeServiceTest {
         cafeRepository.save(cafe1);
         cafeRepository.save(cafe2);
         cafeService.saveCafeReview(member1.getId(), cafe1.getMapId(),
-                new CafeReviewRequest(1, "group", "느려요", "없어요",
+                new CafeReviewRequest(1, "solo", "느려요", "없어요",
                         "불편해요", "없어요", "북적북적해요", "불편해요"));
         cafeService.saveCafeReview(member1.getId(), cafe2.getMapId(),
                 new CafeReviewRequest(5, "group", "느려요", "없어요",
@@ -410,8 +410,10 @@ class CafeServiceTest {
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("solo"),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("케이카페"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(5),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("group"),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("메리카페"),
                 () -> assertThat(actual.getCafes()).hasSize(2)
         );

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -411,10 +411,10 @@ class CafeServiceTest {
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1),
-                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo(StudyType.SOLO),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("solo"),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("케이카페"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(5),
-                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo(StudyType.GROUP),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("group"),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("메리카페"),
                 () -> assertThat(actual.getCafes()).hasSize(2)
         );

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -405,15 +405,16 @@ class CafeServiceTest {
                 new CafeReviewRequest(2, "group", "느려요", "없어요",
                         "깨끗해요", "없어요", null, "보통이에요"));
 
+        System.out.println("---------------------------------------------------------------------------------");
         MyReviewCafesResponse actual = cafeService.findMyReviewCafes(member1.getId(), 0, 3);
 
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 () -> assertThat(actual.getCafes().get(0).getMyScore()).isEqualTo(1),
-                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("solo"),
+                () -> assertThat(actual.getCafes().get(0).getStudyType()).isEqualTo("SOLO"),
                 () -> assertThat(actual.getCafes().get(0).getName()).isEqualTo("케이카페"),
                 () -> assertThat(actual.getCafes().get(1).getMyScore()).isEqualTo(5),
-                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("group"),
+                () -> assertThat(actual.getCafes().get(1).getStudyType()).isEqualTo("GROUP"),
                 () -> assertThat(actual.getCafes().get(1).getName()).isEqualTo("메리카페"),
                 () -> assertThat(actual.getCafes()).hasSize(2)
         );


### PR DESCRIPTION
## 개요
원래 내가 리뷰를 작성한 카페 조회 시 내가 작성한 리뷰의 studyType이 아닌 카페의 studyType이 그대로 반환됨.
이를 **내가 작성한 리뷰의 studyType이 반환되게끔 변경**

## 작업사항
### 원래 구현 로직
1. 내가 리뷰를 작성한 카페를 DB에서 조회 (1번)
2. 카페 반복문을 돌며 DB에서 내가 작성한 리뷰의 score와 studyType 조회 (2N번)
결과적으로 쿼리가 2N+1번 나가던 상황.

### 변경 구현 로직
Repository에서 **DTO 조회**를 통해 쿼리 한번으로 카페 mapId, 카페 mapId, name, score, studyType이 조회되게끔 수정. 
그 결과 member 조회 쿼리 1, dto 조회 쿼리 1 총 2번의 쿼리문으로 모든 기능 구현. 

 
## 주의사항

### 인덱스
특정 데이터만 db에서 조회하는 것이기 때문에 커버링 인덱스를 활용가능하다.
그러나 해당 마이페이지 카페 조회 api가 자주 불리는가, 해당 api가 좋은 성능을 요구하는가 등에 대한 파악이 아직 필요하여 **db 인덱스를 만들어주지 않았음**

### 추가 고려해야할 사항
dto를 repository layer에서 까지 알게하는 것은 api spec이 변경되었을 때 repository의 변경을 야기할 수 있다.
즉, 유연하지 않은 설계라고 볼 수 있는데 이를 위한 화면 최적화한 repository 와 service (e.g. queryService)로 분리하는 과정이 필요할 수 있다.