### PR TITLE
feat: 공백 값에 대한 토큰 공백 커스텀 예외 처리 추가

### DIFF
--- a/src/main/java/mocacong/server/exception/badrequest/BlankTokenException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/BlankTokenException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class BlankTokenException extends BadRequestException {
+
+    public BlankTokenException() {
+        super("토큰은 공백일 수 없습니다.", 1018);
+    }
+}

--- a/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
+++ b/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
@@ -12,23 +12,23 @@ public class AuthorizationExtractor {
 
     private static final String AUTHENTICATION_TYPE = "Bearer";
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
-    private static final int TOKEN_INDEX = 1;
+    private static final int START_TOKEN_INDEX = 6;
 
     public static String extractAccessToken(HttpServletRequest request) {
         Enumeration<String> headers = request.getHeaders(AUTHORIZATION_HEADER_KEY);
         while (headers.hasMoreElements()) {
             String value = headers.nextElement();
             if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
-                String[] parts = value.split(" ");
-                validateParts(parts);
-                return parts[TOKEN_INDEX];
+                String extractToken = value.trim().substring(START_TOKEN_INDEX);
+                validateExtractToken(extractToken);
+                return extractToken;
             }
         }
         throw new InvalidBearerException();
     }
 
-    private static void validateParts(String[] parts) {
-        if (parts.length <= 1) {
+    private static void validateExtractToken(String extractToken) {
+        if (extractToken.isBlank()) {
             throw new BlankTokenException();
         }
     }

--- a/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
+++ b/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
@@ -19,7 +19,7 @@ public class AuthorizationExtractor {
         while (headers.hasMoreElements()) {
             String value = headers.nextElement();
             if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
-                String parts[] = value.split(" ");
+                String[] parts = value.split(" ");
                 if (parts.length > 1) {
                     return value.split(" ")[TOKEN_INDEX];
                 } else {

--- a/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
+++ b/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
@@ -20,13 +20,15 @@ public class AuthorizationExtractor {
             String value = headers.nextElement();
             if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
                 String[] parts = value.split(" ");
-                if (parts.length > 1) {
-                    return value.split(" ")[TOKEN_INDEX];
-                } else {
-                    throw new BlankTokenException();
-                }
+                validateParts(parts);
             }
         }
         throw new InvalidBearerException();
+    }
+
+    private static void validateParts(String[] parts) {
+        if (parts.length <= 1) {
+            throw new BlankTokenException();
+        }
     }
 }

--- a/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
+++ b/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
@@ -21,6 +21,7 @@ public class AuthorizationExtractor {
             if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
                 String[] parts = value.split(" ");
                 validateParts(parts);
+                return parts[TOKEN_INDEX];
             }
         }
         throw new InvalidBearerException();

--- a/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
+++ b/src/main/java/mocacong/server/security/auth/AuthorizationExtractor.java
@@ -1,6 +1,7 @@
 package mocacong.server.security.auth;
 
 import lombok.NoArgsConstructor;
+import mocacong.server.exception.badrequest.BlankTokenException;
 import mocacong.server.exception.unauthorized.InvalidBearerException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,7 +19,12 @@ public class AuthorizationExtractor {
         while (headers.hasMoreElements()) {
             String value = headers.nextElement();
             if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
-                return value.split(" ")[TOKEN_INDEX];
+                String parts[] = value.split(" ");
+                if (parts.length > 1) {
+                    return value.split(" ")[TOKEN_INDEX];
+                } else {
+                    throw new BlankTokenException();
+                }
             }
         }
         throw new InvalidBearerException();

--- a/src/test/java/mocacong/server/security/auth/AuthorizationExtractorTest.java
+++ b/src/test/java/mocacong/server/security/auth/AuthorizationExtractorTest.java
@@ -1,0 +1,25 @@
+package mocacong.server.security.auth;
+
+import mocacong.server.exception.badrequest.BlankTokenException;
+import mocacong.server.exception.unauthorized.TokenExpiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthorizationExtractorTest {
+
+    @DisplayName("공백 값으로 access token 추출을 시도하면 예외를 반환한다")
+    @Test
+    void extractAccessTokenByBlankToken() {
+        String token = "Bearer ";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", token);
+
+        assertThatThrownBy(() -> AuthorizationExtractor.extractAccessToken(request))
+                .isInstanceOf(BlankTokenException.class);
+    }
+}

--- a/src/test/java/mocacong/server/security/auth/AuthorizationExtractorTest.java
+++ b/src/test/java/mocacong/server/security/auth/AuthorizationExtractorTest.java
@@ -1,6 +1,6 @@
 package mocacong.server.security.auth;
 
-import mocacong.server.exception.unauthorized.InvalidBearerException;
+import mocacong.server.exception.badrequest.BlankTokenException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -17,6 +17,6 @@ class AuthorizationExtractorTest {
         request.addHeader("Authorization", token);
 
         assertThatThrownBy(() -> AuthorizationExtractor.extractAccessToken(request))
-                .isInstanceOf(InvalidBearerException.class);
+                .isInstanceOf(BlankTokenException.class);
     }
 }

--- a/src/test/java/mocacong/server/security/auth/AuthorizationExtractorTest.java
+++ b/src/test/java/mocacong/server/security/auth/AuthorizationExtractorTest.java
@@ -1,14 +1,11 @@
 package mocacong.server.security.auth;
 
-import mocacong.server.exception.badrequest.BlankTokenException;
-import mocacong.server.exception.unauthorized.TokenExpiredException;
+import mocacong.server.exception.unauthorized.InvalidBearerException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 class AuthorizationExtractorTest {
 
@@ -20,6 +17,6 @@ class AuthorizationExtractorTest {
         request.addHeader("Authorization", token);
 
         assertThatThrownBy(() -> AuthorizationExtractor.extractAccessToken(request))
-                .isInstanceOf(BlankTokenException.class);
+                .isInstanceOf(InvalidBearerException.class);
     }
 }


### PR DESCRIPTION
## 개요
- 기존 `extractAccessToken` 는 `request` 로 들어온 토큰 값이 공백이 아닌지에 대한 검증 로직을 포함하지 않았습니다. `extractAccessToken` 로직에서 분할된 헤더 값이 두 개 이상(인증 유형 + 토큰)인지 확인하여 헤더 값이 하나인 경우(공백 토큰) `BlankTokenException` 예외를 반환하도록 했습니다.

## 작업사항
- `BlankTokenException` 커스텀 예외 추가
- `extractAccessToken` 로직에서 공백 값에 대한 토큰 공백 커스텀 예외 처리 추가
- `BlankTokenException` 예외 반환 테스트 코드 추가

## 주의사항
- 포스트맨으로 해당 예외가 잘 반환되는지 확인해주세요
- 더 좋은 로직이 있다면 추천해주세요
