### PR TITLE
feat: 로그 마스킹 처리에 이메일 제외

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -28,11 +28,9 @@
             <file>${LOG_PATH}/mocacong-${BY_DATE}.log</file>
             <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                 <layout class="mocacong.server.support.logging.MaskingPatternLayout">
-                    <maskPattern>email\s*=\s*([^,)\s]+)</maskPattern> <!-- Email Arg pattern -->
                     <maskPattern>password\s*=\s*([^,)\s]+)</maskPattern> <!-- Password Arg pattern -->
                     <maskPattern>nonce\s*=\s*([^,)\s]+)</maskPattern> <!-- Nonce Arg pattern -->
                     <maskPattern>(\d+\.\d+\.\d+\.\d+)</maskPattern> <!-- Ip address IPv4 pattern -->
-                    <maskPattern>(\w+@\w+\.\w+)</maskPattern> <!-- Email pattern -->
                     <pattern>${LOG_PATTERN}</pattern>
                 </layout>
             </encoder>
@@ -59,11 +57,9 @@
             </filter>
             <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                 <layout class="mocacong.server.support.logging.MaskingPatternLayout">
-                    <maskPattern>email\s*=\s*([^,)\s]+)</maskPattern> <!-- Email Arg pattern -->
                     <maskPattern>password\s*=\s*([^,)\s]+)</maskPattern> <!-- Password Arg pattern -->
                     <maskPattern>nonce\s*=\s*([^,)\s]+)</maskPattern> <!-- Nonce Arg pattern -->
                     <maskPattern>(\d+\.\d+\.\d+\.\d+)</maskPattern> <!-- Ip address IPv4 pattern -->
-                    <maskPattern>(\w+@\w+\.\w+)</maskPattern> <!-- Email pattern -->
                     <pattern>${LOG_PATTERN}</pattern>
                 </layout>
             </encoder>


### PR DESCRIPTION
## 개요
- 모카콩 로그에서 마스킹 (`***` 처리) 되는 컬럼에 이메일이 포함돼있습니다. 하지만 이메일이 마스킹처리되면 유저를 식별하기 어렵다는 점, 이메일 자체만으로 크래킹에 악용될 여지는 적다는 점이 존재합니다.

## 작업사항
- 개발 환경, 운영 환경에서 이메일 마스킹 처리를 제외했습니다.

## 주의사항
- logback 설정 관련해서 추가로 리뷰남기고 싶은 사항이 있으면 편하게 남겨주세요.
- 이메일 마스킹 처리가 필요하다 싶으면 리뷰남겨주세요. 확인 후에 pr merge 또는 closed 하겠습니다.
