### PR TITLE
feat: cafeImage 즉시로딩에서 지연로딩으로 변경

### DIFF
--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -35,7 +35,7 @@ public class Cafe extends BaseTime {
     @Embedded
     private CafeDetail cafeDetail;
 
-    @OneToMany(mappedBy = "cafe", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY)
     private List<CafeImage> cafeImages;
 
     @OneToMany(mappedBy = "cafe", fetch = FetchType.LAZY)


### PR DESCRIPTION
## 개요
- cafeImage가 비즈니스 로직에 따라 여러 조건이 붙어 더 이상 즉시 로딩으로 cafeImage를 가져올 필요가 없어졌습니다.
- 이에 따라 cafeImage를 지연로딩으로 변경하였습니다.

## 작업사항
- cafe의 cafeImage 지연로딩으로 수정하였습니다.
- 이에 따라 변경이 필요해진 테스트 코드를 함께 수정하였습니다.

## 주의사항
- 더 나은 로직 혹은 방법이 있다면 말씀해주세요.
