### PR TITLE
feat: 코멘트 첫페이지 조회 시 전체 코멘트 개수 반환 기능 구현

### DIFF
--- a/src/main/java/mocacong/server/dto/response/CommentsResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentsResponse.java
@@ -12,9 +12,9 @@ import lombok.*;
 public class CommentsResponse {
 
     private Boolean isEnd;
-    private List<CommentResponse> comments;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Long count;
+    private List<CommentResponse> comments;
 
     public CommentsResponse(Boolean isEnd, List<CommentResponse> comments) {
         this.isEnd = isEnd;

--- a/src/main/java/mocacong/server/dto/response/CommentsResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentsResponse.java
@@ -1,6 +1,8 @@
 package mocacong.server.dto.response;
 
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
 @Getter
@@ -11,4 +13,11 @@ public class CommentsResponse {
 
     private Boolean isEnd;
     private List<CommentResponse> comments;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long count;
+
+    public CommentsResponse(Boolean isEnd, List<CommentResponse> comments) {
+        this.isEnd = isEnd;
+        this.comments = comments;
+    }
 }

--- a/src/main/java/mocacong/server/repository/CommentRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentRepository.java
@@ -15,5 +15,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Slice<Comment> findAllByCafeId(Long cafeId, Pageable pageRequest);
 
+    Long countAllByCafeId(Long cafeId);
+
     Slice<Comment> findAllByCafeIdAndMemberId(Long cafeId, Long memberId, Pageable pageRequest);
 }

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -17,13 +17,11 @@ import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.DeleteMemberEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -54,6 +52,11 @@ public class CommentService {
                 .orElseThrow(NotFoundMemberException::new);
         Slice<Comment> comments = commentRepository.findAllByCafeId(cafe.getId(), PageRequest.of(page, count));
         List<CommentResponse> responses = findCommentResponses(member, comments);
+
+        if (page == 0) {
+            Long totalCounts = commentRepository.countAllByCafeId(cafe.getId());
+            return new CommentsResponse(comments.isLast(), responses, totalCounts);
+        }
         return new CommentsResponse(comments.isLast(), responses);
     }
 

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -55,7 +55,7 @@ public class CommentService {
 
         if (page == 0) {
             Long totalCounts = commentRepository.countAllByCafeId(cafe.getId());
-            return new CommentsResponse(comments.isLast(), responses, totalCounts);
+            return new CommentsResponse(comments.isLast(), totalCounts, responses);
         }
         return new CommentsResponse(comments.isLast(), responses);
     }

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -17,11 +17,13 @@ import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.service.event.DeleteMemberEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentAcceptanceTest.java
@@ -72,6 +72,52 @@ public class CommentAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("카페 코멘트 첫번째 목록을 조회한다")
+    void findCommentsFirstPage() {
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "베어네 카페"));
+
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        카페_코멘트_작성(token, mapId, new CommentSaveRequest("댓글"));
+
+        CommentsResponse response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().get("/cafes/" + mapId + "/comments?page=0&count=20")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(CommentsResponse.class);
+
+        assertThat(response.getCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("카페 코멘트 첫번째 목록을 제외한 페이지를 조회한다")
+    void findCommentsNotFirstPage() {
+        String mapId = "12332312";
+        카페_등록(new CafeRegisterRequest(mapId, "베어네 카페"));
+
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
+        회원_가입(signUpRequest);
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        카페_코멘트_작성(token, mapId, new CommentSaveRequest("댓글"));
+
+        CommentsResponse response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().get("/cafes/" + mapId + "/comments?page=1&count=20")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(CommentsResponse.class);
+
+        assertThat(response.getCount()).isEqualTo(null);
+    }
+
+    @Test
     @DisplayName("카페 코멘트 목록 중 내가 작성한 코멘트만을 조회한다")
     void findOnlyMyComments() {
         String mapId = "12332312";

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -104,7 +104,7 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("특정 카페에 달린 댓글 목록의 첫 페이지를 조회할 시에 총 댓글 개수를 함께 반환한다.")
+    @DisplayName("특정 카페에 달린 댓글 목록의 첫 페이지를 조회할 시에만 총 댓글 개수를 함께 반환한다.")
     void findCommentsWithCount() {
         String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -104,6 +104,34 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("특정 카페에 달린 댓글 목록의 첫 페이지를 조회할 시에 총 댓글 개수를 함께 반환한다.")
+    void findCommentsWithCount() {
+        String email = "rlawjddn103@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "베어");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "베어카페");
+        cafeRepository.save(cafe);
+        commentRepository.save(new Comment(cafe, member, "댓글1"));
+        commentRepository.save(new Comment(cafe, member, "댓글2"));
+        commentRepository.save(new Comment(cafe, member, "댓글3"));
+        commentRepository.save(new Comment(cafe, member, "댓글4"));
+
+        CommentsResponse actualPageOne = commentService.findAll(member.getId(), mapId, 0, 3);
+        CommentsResponse actualPageTwo = commentService.findAll(member.getId(), mapId, 1, 3);
+
+        assertAll(
+                () -> assertThat(actualPageOne.getIsEnd()).isFalse(),
+                () -> assertThat(actualPageOne.getComments()).hasSize(3),
+                () -> assertThat(actualPageOne.getComments())
+                        .extracting("content")
+                        .containsExactly("댓글1", "댓글2", "댓글3"),
+                () -> assertThat(actualPageOne.getCount()).isEqualTo(4),
+                () -> assertThat(actualPageTwo.getCount()).isEqualTo(null)
+        );
+    }
+
+    @Test
     @DisplayName("특정 카페에 달린 댓글 목록 중 내가 작성한 댓글만을 조회한다")
     void findOnlyMyComments() {
         String email = "kth990303@naver.com";


### PR DESCRIPTION
## 개요
- 코멘트 첫페이지 조회 시 전체 코멘트 개수가 필요해짐에 따라 해당 기능을 구현했습니다.

## 작업사항
- 페이지가 0일 때만 count 쿼리를 통해 전체 댓글 개수를 함께 반환하도록 하였습니다.

## 주의사항
- 반환 json이 count가 필요한지 아닌지에 따라 동적으로 변할 필요가 있어 dto의 count 필드 값에 Null 값이 들어와있을 때 json으로 변환되지 않도록 로직을 만들었는데, 혹시 더 좋은 방법이 있다면 추천해주세요.
