### PR TITLE
feat: 댓글 좋아요 등록 기능 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CommentLikeController.java
+++ b/src/main/java/mocacong/server/controller/CommentLikeController.java
@@ -1,0 +1,33 @@
+package mocacong.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import mocacong.server.dto.response.CommentLikeSaveResponse;
+import mocacong.server.security.auth.LoginUserId;
+import mocacong.server.service.CommentLikeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "CommentsLike", description = "댓글 좋아요")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comments/{commentId}/like")
+public class CommentLikeController {
+    private final CommentLikeService commentLikeService;
+
+    @Operation(summary = "댓글 좋아요 등록")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping
+    public ResponseEntity<CommentLikeSaveResponse> saveCommentLike(
+            @LoginUserId Long memberId,
+            @PathVariable Long commentId
+    ) {
+        CommentLikeSaveResponse response = commentLikeService.save(memberId, commentId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/mocacong/server/controller/CommentLikeController.java
+++ b/src/main/java/mocacong/server/controller/CommentLikeController.java
@@ -8,10 +8,7 @@ import mocacong.server.dto.response.CommentLikeSaveResponse;
 import mocacong.server.security.auth.LoginUserId;
 import mocacong.server.service.CommentLikeService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "CommentsLike", description = "댓글 좋아요")
 @RestController
@@ -29,5 +26,16 @@ public class CommentLikeController {
     ) {
         CommentLikeSaveResponse response = commentLikeService.save(memberId, commentId);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "댓글 좋아요 삭제")
+    @SecurityRequirement(name = "JWT")
+    @DeleteMapping
+    public ResponseEntity<Void> deleteCommentLike(
+            @LoginUserId Long memberId,
+            @PathVariable Long commentId
+    ) {
+        commentLikeService.delete(memberId, commentId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/mocacong/server/domain/CommentLike.java
+++ b/src/main/java/mocacong/server/domain/CommentLike.java
@@ -31,4 +31,8 @@ public class CommentLike {
         this.member = member;
         this.comment = comment;
     }
+
+    public void removeMember() {
+        this.member = null;
+    }
 }

--- a/src/main/java/mocacong/server/domain/CommentLike.java
+++ b/src/main/java/mocacong/server/domain/CommentLike.java
@@ -1,0 +1,34 @@
+package mocacong.server.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "comment_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "member_id", "comment_id" })
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike {
+
+    @Id
+    @Column(name = "comment_like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    public CommentLike(Member member, Comment comment) {
+        this.member = member;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/mocacong/server/domain/CommentLike.java
+++ b/src/main/java/mocacong/server/domain/CommentLike.java
@@ -35,4 +35,8 @@ public class CommentLike {
     public void removeMember() {
         this.member = null;
     }
+
+    public void removeComment() {
+        this.comment = null;
+    }
 }

--- a/src/main/java/mocacong/server/dto/response/CommentLikeSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentLikeSaveResponse.java
@@ -1,0 +1,12 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class CommentLikeSaveResponse {
+    private Long commentLikeId;
+}
+

--- a/src/main/java/mocacong/server/dto/response/CommentLikeSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentLikeSaveResponse.java
@@ -9,4 +9,3 @@ import lombok.*;
 public class CommentLikeSaveResponse {
     private Long commentLikeId;
 }
-

--- a/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsCommentLike.java
+++ b/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsCommentLike.java
@@ -3,6 +3,6 @@ package mocacong.server.exception.badrequest;
 public class AlreadyExistsCommentLike extends BadRequestException {
 
     public AlreadyExistsCommentLike() {
-        super("이미 좋아요한 댓글입니다.", 6002);
+        super("이미 좋아요한 댓글입니다.", 6001);
     }
 }

--- a/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsCommentLike.java
+++ b/src/main/java/mocacong/server/exception/badrequest/AlreadyExistsCommentLike.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class AlreadyExistsCommentLike extends BadRequestException {
+
+    public AlreadyExistsCommentLike() {
+        super("이미 좋아요한 댓글입니다.", 6002);
+    }
+}

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidCommentLikeException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidCommentLikeException.java
@@ -1,0 +1,7 @@
+package mocacong.server.exception.badrequest;
+
+public class InvalidCommentLikeException extends BadRequestException {
+    public InvalidCommentLikeException() {
+        super("자신의 댓글에 좋아요할 수 없습니다.", 6002);;
+    }
+}

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidCommentLikeException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidCommentLikeException.java
@@ -2,6 +2,6 @@ package mocacong.server.exception.badrequest;
 
 public class InvalidCommentLikeException extends BadRequestException {
     public InvalidCommentLikeException() {
-        super("자신의 댓글에 좋아요할 수 없습니다.", 6002);;
+        super("자신의 댓글에 좋아요할 수 없습니다.", 6002);
     }
 }

--- a/src/main/java/mocacong/server/exception/notfound/NotFoundCommentLikeException.java
+++ b/src/main/java/mocacong/server/exception/notfound/NotFoundCommentLikeException.java
@@ -3,6 +3,6 @@ package mocacong.server.exception.notfound;
 public class NotFoundCommentLikeException extends NotFoundException {
 
     public NotFoundCommentLikeException() {
-        super("존재하지 않는 댓글 좋아요입니다.", 6001);
+        super("존재하지 않는 댓글 좋아요입니다.", 6000);
     }
 }

--- a/src/main/java/mocacong/server/exception/notfound/NotFoundCommentLikeException.java
+++ b/src/main/java/mocacong/server/exception/notfound/NotFoundCommentLikeException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.notfound;
+
+public class NotFoundCommentLikeException extends NotFoundException {
+
+    public NotFoundCommentLikeException() {
+        super("존재하지 않는 댓글 좋아요입니다.", 6001);
+    }
+}

--- a/src/main/java/mocacong/server/repository/CommentLikeRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentLikeRepository.java
@@ -2,6 +2,18 @@ package mocacong.server.repository;
 
 import mocacong.server.domain.CommentLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike,Long> {
+    @Query("select cl.id " +
+            "from CommentLike cl " +
+            "join cl.comment c " +
+            "join cl.member m " +
+            "where c.id = :commentId and m.id = :memberId")
+    Optional<Long> findCommentLikeIdByCommentIdAndMemberId(Long memberId, Long commentId);
+
+    List<CommentLike> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/mocacong/server/repository/CommentLikeRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentLikeRepository.java
@@ -1,0 +1,7 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike,Long> {
+}

--- a/src/main/java/mocacong/server/repository/CommentLikeRepository.java
+++ b/src/main/java/mocacong/server/repository/CommentLikeRepository.java
@@ -2,6 +2,7 @@ package mocacong.server.repository;
 
 import mocacong.server.domain.CommentLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -16,4 +17,10 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike,Long> {
     Optional<Long> findCommentLikeIdByCommentIdAndMemberId(Long memberId, Long commentId);
 
     List<CommentLike> findAllByMemberId(Long memberId);
+
+    List<CommentLike> findAllByCommentId(Long commentId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from CommentLike cl where cl.comment.id IS null")
+    void deleteAllByCommentIdIsNull();
 }

--- a/src/main/java/mocacong/server/service/CommentLikeService.java
+++ b/src/main/java/mocacong/server/service/CommentLikeService.java
@@ -30,17 +30,11 @@ public class CommentLikeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
-        validateDuplicateFavorite(member.getId(), comment.getId());
-
         try {
             CommentLike commentLike = new CommentLike(member, comment);
             return new CommentLikeSaveResponse(commentLikeRepository.save(commentLike).getId());
         } catch (DataIntegrityViolationException e) {
             throw new AlreadyExistsCommentLike();
         }
-    }
-
-    private void validateDuplicateFavorite(Long memberId, Long commentId) {
-
     }
 }

--- a/src/main/java/mocacong/server/service/CommentLikeService.java
+++ b/src/main/java/mocacong/server/service/CommentLikeService.java
@@ -76,13 +76,13 @@ public class CommentLikeService {
     }
 
     @EventListener
-    public void deleteAllWhenMemberDelete(DeleteMemberEvent event) {
+    public void deleteAllWhenMemberDeleted(DeleteMemberEvent event) {
         Member member = event.getMember();
         commentLikeRepository.findAllByMemberId(member.getId()).forEach(CommentLike::removeMember);
     }
 
     @EventListener
-    public void deleteAllWhenCommentDelete(DeleteCommentEvent event) {
+    public void deleteAllWhenCommentDeleted(DeleteCommentEvent event) {
         Comment comment = event.getComment();
         commentLikeRepository.findAllByCommentId(comment.getId()).forEach(CommentLike::removeComment);
     }
@@ -90,7 +90,7 @@ public class CommentLikeService {
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener
-    public void deleteFavoritesWhenMemberDeleted(DeleteCommentEvent event) {
+    public void deleteCommentsWhenCommentDeleted(DeleteCommentEvent event) {
         commentLikeRepository.deleteAllByCommentIdIsNull();
     }
 }

--- a/src/main/java/mocacong/server/service/CommentLikeService.java
+++ b/src/main/java/mocacong/server/service/CommentLikeService.java
@@ -3,14 +3,18 @@ package mocacong.server.service;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.Comment;
 import mocacong.server.domain.CommentLike;
+import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentLikeSaveResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsCommentLike;
 import mocacong.server.exception.notfound.NotFoundCommentException;
+import mocacong.server.exception.notfound.NotFoundCommentLikeException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CommentLikeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
+import mocacong.server.service.event.DeleteMemberEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,5 +40,25 @@ public class CommentLikeService {
         } catch (DataIntegrityViolationException e) {
             throw new AlreadyExistsCommentLike();
         }
+    }
+
+    @Transactional
+    public void delete(Long memberId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(NotFoundCommentException::new);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        Long commentLikeId = commentLikeRepository
+                .findCommentLikeIdByCommentIdAndMemberId(member.getId(), comment.getId())
+                .orElseThrow(NotFoundCommentLikeException::new);
+
+        commentLikeRepository.deleteById(commentLikeId);
+    }
+
+    @EventListener
+    public void deleteAllWhenMemberDelete(DeleteMemberEvent event) {
+        Member member = event.getMember();
+        commentLikeRepository.findAllByMemberId(member.getId()).forEach(CommentLike::removeMember);
     }
 }

--- a/src/main/java/mocacong/server/service/CommentLikeService.java
+++ b/src/main/java/mocacong/server/service/CommentLikeService.java
@@ -1,4 +1,46 @@
 package mocacong.server.service;
 
+import lombok.RequiredArgsConstructor;
+import mocacong.server.domain.Comment;
+import mocacong.server.domain.CommentLike;
+import mocacong.server.domain.Member;
+import mocacong.server.dto.response.CommentLikeSaveResponse;
+import mocacong.server.exception.badrequest.AlreadyExistsCommentLike;
+import mocacong.server.exception.notfound.NotFoundCommentException;
+import mocacong.server.exception.notfound.NotFoundMemberException;
+import mocacong.server.repository.CommentLikeRepository;
+import mocacong.server.repository.CommentRepository;
+import mocacong.server.repository.MemberRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class CommentLikeService {
+
+    private final CommentLikeRepository commentLikeRepository;
+    private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CommentLikeSaveResponse save(Long memberId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(NotFoundCommentException::new);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        validateDuplicateFavorite(member.getId(), comment.getId());
+
+        try {
+            CommentLike commentLike = new CommentLike(member, comment);
+            return new CommentLikeSaveResponse(commentLikeRepository.save(commentLike).getId());
+        } catch (DataIntegrityViolationException e) {
+            throw new AlreadyExistsCommentLike();
+        }
+    }
+
+    private void validateDuplicateFavorite(Long memberId, Long commentId) {
+
+    }
 }

--- a/src/main/java/mocacong/server/service/CommentLikeService.java
+++ b/src/main/java/mocacong/server/service/CommentLikeService.java
@@ -90,7 +90,7 @@ public class CommentLikeService {
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener
-    public void deleteCommentsWhenCommentDeleted(DeleteCommentEvent event) {
+    public void deleteCommentLikesWhenCommentDeleted(DeleteCommentEvent event) {
         commentLikeRepository.deleteAllByCommentIdIsNull();
     }
 }

--- a/src/main/java/mocacong/server/service/CommentLikeService.java
+++ b/src/main/java/mocacong/server/service/CommentLikeService.java
@@ -7,6 +7,7 @@ import mocacong.server.domain.Favorite;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentLikeSaveResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsCommentLike;
+import mocacong.server.exception.badrequest.InvalidCommentLikeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.exception.notfound.NotFoundCommentLikeException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
@@ -37,6 +38,10 @@ public class CommentLikeService {
                 .orElseThrow(NotFoundCommentException::new);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
+
+        if (comment.isWrittenByMember(member)) {
+            throw new InvalidCommentLikeException();
+        }
 
         try {
             CommentLike commentLike = new CommentLike(member, comment);

--- a/src/main/java/mocacong/server/service/CommentLikeService.java
+++ b/src/main/java/mocacong/server/service/CommentLikeService.java
@@ -1,0 +1,4 @@
+package mocacong.server.service;
+
+public class CommentLikeService {
+}

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -15,7 +15,9 @@ import mocacong.server.exception.notfound.NotFoundMemberException;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
+import mocacong.server.service.event.DeleteCommentEvent;
 import mocacong.server.service.event.DeleteMemberEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -33,6 +35,7 @@ public class CommentService {
     private final MemberRepository memberRepository;
     private final CafeRepository cafeRepository;
     private final CommentRepository commentRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public CommentSaveResponse save(Long memberId, String mapId, String content) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
@@ -115,6 +118,7 @@ public class CommentService {
         if (!comment.isWrittenByMember(member)) {
             throw new InvalidCommentDeleteException();
         }
+        applicationEventPublisher.publishEvent(new DeleteCommentEvent(comment));
         commentRepository.delete(comment);
     }
 

--- a/src/main/java/mocacong/server/service/event/DeleteCommentEvent.java
+++ b/src/main/java/mocacong/server/service/event/DeleteCommentEvent.java
@@ -1,0 +1,11 @@
+package mocacong.server.service.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import mocacong.server.domain.Comment;
+
+@Getter
+@RequiredArgsConstructor
+public class DeleteCommentEvent {
+    private final Comment comment;
+}

--- a/src/test/java/mocacong/server/acceptance/CommentLikeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentLikeAcceptanceTest.java
@@ -1,0 +1,35 @@
+package mocacong.server.acceptance;
+
+import io.restassured.RestAssured;
+import mocacong.server.dto.request.CafeRegisterRequest;
+import mocacong.server.dto.request.CommentSaveRequest;
+import mocacong.server.dto.request.MemberSignUpRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
+
+public class CommentLikeAcceptanceTest extends AcceptanceTest{
+    @Test
+    @DisplayName("회원이 댓글을 좋아요 한다.")
+    void saveCommentLike() {
+        String mapId = "12332312";
+        String comment = "코딩하고 싶어지는 카페에요.";
+        카페_등록(new CafeRegisterRequest(mapId, "정우네 카페"));
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
+        회원_가입(signUpRequest);
+        CommentSaveRequest commentRequest = new CommentSaveRequest(comment);
+
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        long commentId = 카페_코멘트_작성(token, mapId, commentRequest).body().jsonPath().getLong("id");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().post("/comments/" + commentId + "/like")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/mocacong/server/acceptance/CommentLikeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentLikeAcceptanceTest.java
@@ -18,16 +18,21 @@ public class CommentLikeAcceptanceTest extends AcceptanceTest{
         String mapId = "12332312";
         String comment = "코딩하고 싶어지는 카페에요.";
         카페_등록(new CafeRegisterRequest(mapId, "정우네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
-        회원_가입(signUpRequest);
+
+        MemberSignUpRequest signUpRequest1 = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
+        회원_가입(signUpRequest1);
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
+        회원_가입(signUpRequest2);
+
         CommentSaveRequest commentRequest = new CommentSaveRequest(comment);
 
-        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
-        long commentId = 카페_코멘트_작성(token, mapId, commentRequest).body().jsonPath().getLong("id");
+        String token1 = 로그인_토큰_발급(signUpRequest1.getEmail(), signUpRequest1.getPassword());
+        String token2 = 로그인_토큰_발급(signUpRequest2.getEmail(), signUpRequest2.getPassword());
+        long commentId = 카페_코멘트_작성(token1, mapId, commentRequest).body().jsonPath().getLong("id");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().oauth2(token)
+                .auth().oauth2(token2)
                 .when().post("/comments/" + commentId + "/like")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
@@ -39,23 +44,28 @@ public class CommentLikeAcceptanceTest extends AcceptanceTest{
         String mapId = "12332312";
         String comment = "코딩하고 싶어지는 카페에요.";
         카페_등록(new CafeRegisterRequest(mapId, "정우네 카페"));
-        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
-        회원_가입(signUpRequest);
+
+        MemberSignUpRequest signUpRequest1 = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
+        회원_가입(signUpRequest1);
+        MemberSignUpRequest signUpRequest2 = new MemberSignUpRequest("kth990303@naver.com", "a1b2c3d4", "케이");
+        회원_가입(signUpRequest2);
+
         CommentSaveRequest commentRequest = new CommentSaveRequest(comment);
 
-        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
-        long commentId = 카페_코멘트_작성(token, mapId, commentRequest).body().jsonPath().getLong("id");
+        String token1 = 로그인_토큰_발급(signUpRequest1.getEmail(), signUpRequest1.getPassword());
+        String token2 = 로그인_토큰_발급(signUpRequest2.getEmail(), signUpRequest2.getPassword());
+        long commentId = 카페_코멘트_작성(token1, mapId, commentRequest).body().jsonPath().getLong("id");
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().oauth2(token)
+                .auth().oauth2(token2)
                 .when().post("/comments/" + commentId + "/like")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
 
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().oauth2(token)
+                .auth().oauth2(token2)
                 .when().delete("/comments/" + commentId + "/like")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());

--- a/src/test/java/mocacong/server/acceptance/CommentLikeAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/CommentLikeAcceptanceTest.java
@@ -32,4 +32,32 @@ public class CommentLikeAcceptanceTest extends AcceptanceTest{
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
+
+    @Test
+    @DisplayName("회원이 댓글 좋아요를 취소한다.")
+    void deleteCommentLike() {
+        String mapId = "12332312";
+        String comment = "코딩하고 싶어지는 카페에요.";
+        카페_등록(new CafeRegisterRequest(mapId, "정우네 카페"));
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest("rlawjddn103@naver.com", "a1b2c3d4", "베어");
+        회원_가입(signUpRequest);
+        CommentSaveRequest commentRequest = new CommentSaveRequest(comment);
+
+        String token = 로그인_토큰_발급(signUpRequest.getEmail(), signUpRequest.getPassword());
+        long commentId = 카페_코멘트_작성(token, mapId, commentRequest).body().jsonPath().getLong("id");
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().post("/comments/" + commentId + "/like")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().oauth2(token)
+                .when().delete("/comments/" + commentId + "/like")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
 }

--- a/src/test/java/mocacong/server/repository/CommentLikeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CommentLikeRepositoryTest.java
@@ -1,0 +1,53 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RepositoryTest
+class CommentLikeRepositoryTest {
+
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("comment id, 멤버 id로 댓글 좋아요 id를 조회한다")
+    void findByCafeIdAndMemberId() {
+        Cafe savedCafe = cafeRepository.save(new Cafe("1", "베어카페"));
+        Member savedMember = memberRepository.save(new Member("rlawjddn103@naver.com", "abcd1234", "베어"));
+        Comment savedComment = commentRepository.save(new Comment(savedCafe, savedMember, "코딩하기 좋은 카페네요."));
+        CommentLike savedCommentLike = commentLikeRepository.save(new CommentLike(savedMember, savedComment));
+
+        Long actual = commentLikeRepository.findCommentLikeIdByCommentIdAndMemberId(savedMember.getId(), savedComment.getId())
+                .orElse(null);
+
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual).isEqualTo(savedCommentLike.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("comment id가 null인 즐겨찾기들을 모두 삭제한다")
+    void deleteAllByMemberIdIsNull() {
+        Member savedMember = memberRepository.save(new Member("rlawjddn103@naver.com", "abcd1234", "베어"));
+        CommentLike savedCommentLike = commentLikeRepository.save(new CommentLike(savedMember, null));
+
+        commentLikeRepository.deleteAllByCommentIdIsNull();
+
+        List<CommentLike> actual = commentLikeRepository.findAll();
+        assertThat(actual).isEmpty();
+    }
+}

--- a/src/test/java/mocacong/server/repository/CommentLikeRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CommentLikeRepositoryTest.java
@@ -24,7 +24,7 @@ class CommentLikeRepositoryTest {
 
     @Test
     @DisplayName("comment id, 멤버 id로 댓글 좋아요 id를 조회한다")
-    void findByCafeIdAndMemberId() {
+    void findByCommentIdAndMemberId() {
         Cafe savedCafe = cafeRepository.save(new Cafe("1", "베어카페"));
         Member savedMember = memberRepository.save(new Member("rlawjddn103@naver.com", "abcd1234", "베어"));
         Comment savedComment = commentRepository.save(new Comment(savedCafe, savedMember, "코딩하기 좋은 카페네요."));
@@ -41,9 +41,9 @@ class CommentLikeRepositoryTest {
 
     @Test
     @DisplayName("comment id가 null인 즐겨찾기들을 모두 삭제한다")
-    void deleteAllByMemberIdIsNull() {
+    void deleteAllByCommentIdIsNull() {
         Member savedMember = memberRepository.save(new Member("rlawjddn103@naver.com", "abcd1234", "베어"));
-        CommentLike savedCommentLike = commentLikeRepository.save(new CommentLike(savedMember, null));
+        commentLikeRepository.save(new CommentLike(savedMember, null));
 
         commentLikeRepository.deleteAllByCommentIdIsNull();
 

--- a/src/test/java/mocacong/server/repository/CommentRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/CommentRepositoryTest.java
@@ -1,0 +1,45 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RepositoryTest
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("코멘트 id, 멤버 id로 댓글 좋아요 id를 조회한다")
+    void findByCommentIdAndMemberId() {
+        Cafe savedCafe = cafeRepository
+                .save(new Cafe("1", "베어카페"));
+        Member savedMember = memberRepository
+                .save(new Member("rlawjddn103@naver.com", "abcd1234", "베어"));
+        Comment savedComment = commentRepository
+                .save(new Comment(savedCafe, savedMember, "코딩하고 싶어지네요."));
+        CommentLike commentLike = new CommentLike(savedMember, savedComment);
+        commentLikeRepository.save(commentLike);
+
+        Long actual = commentLikeRepository.findCommentLikeIdByCommentIdAndMemberId(savedMember.getId(), savedComment.getId())
+                .orElse(null);
+
+        assertAll(
+                () -> assertThat(actual).isNotNull(),
+                () -> assertThat(actual).isEqualTo(commentLike.getId())
+        );
+    }
+}

--- a/src/test/java/mocacong/server/service/CommentLikeConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeConcurrentServiceTest.java
@@ -1,0 +1,72 @@
+package mocacong.server.service;
+
+import mocacong.server.domain.*;
+import mocacong.server.exception.badrequest.AlreadyExistsCommentLike;
+import mocacong.server.exception.badrequest.AlreadyExistsFavorite;
+import mocacong.server.repository.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@ServiceTest
+public class CommentLikeConcurrentServiceTest {
+
+    @Autowired
+    private CommentLikeService commentLikeService;
+
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원이 한 댓글을 동시에 여러 번 좋아요 등록 시도해도 한 번만 등록된다")
+    void saveFavoriteWithConcurrent() throws InterruptedException {
+        String email = "rlawjddn103@naver.com";
+        String mapId = "2143154352323";
+        String commentContent = "코딩하고 싶어지는 카페에요.";
+        Member member = new Member(email, "encodePassword", "베어");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "베어카페");
+        cafeRepository.save(cafe);
+        Comment comment = new Comment(cafe, member, commentContent);
+        commentRepository.save(comment);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        CountDownLatch latch = new CountDownLatch(3);
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < 3; i++) {
+            executorService.execute(() -> {
+                try {
+                    commentLikeService.save(member.getId(), comment.getId());
+                } catch (AlreadyExistsCommentLike e) {
+                    exceptions.add(e); // 중복 예외를 리스트에 추가
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        List<CommentLike> commentLikes = commentLikeRepository.findAll();
+        assertAll(
+                () -> assertThat(exceptions).hasSize(2),
+                () -> assertThat(commentLikes).hasSize(1)
+        );
+    }
+}

--- a/src/test/java/mocacong/server/service/CommentLikeConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeConcurrentServiceTest.java
@@ -36,7 +36,7 @@ public class CommentLikeConcurrentServiceTest {
 
     @Test
     @DisplayName("회원이 한 댓글을 동시에 여러 번 좋아요 등록 시도해도 한 번만 등록된다")
-    void saveFavoriteWithConcurrent() throws InterruptedException {
+    void saveCommentLikeWithConcurrent() throws InterruptedException {
         String mapId = "2143154352323";
         String commentContent = "코딩하고 싶어지는 카페에요.";
         Member member1 = new Member("rlawjddn103@naver.com", "encodePassword", "베어");

--- a/src/test/java/mocacong/server/service/CommentLikeConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeConcurrentServiceTest.java
@@ -37,14 +37,15 @@ public class CommentLikeConcurrentServiceTest {
     @Test
     @DisplayName("회원이 한 댓글을 동시에 여러 번 좋아요 등록 시도해도 한 번만 등록된다")
     void saveFavoriteWithConcurrent() throws InterruptedException {
-        String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";
         String commentContent = "코딩하고 싶어지는 카페에요.";
-        Member member = new Member(email, "encodePassword", "베어");
-        memberRepository.save(member);
+        Member member1 = new Member("rlawjddn103@naver.com", "encodePassword", "베어");
+        memberRepository.save(member1);
+        Member member2 = new Member("kth990303@naver.com", "encodePassword", "케이");
+        memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "베어카페");
         cafeRepository.save(cafe);
-        Comment comment = new Comment(cafe, member, commentContent);
+        Comment comment = new Comment(cafe, member2, commentContent);
         commentRepository.save(comment);
 
         ExecutorService executorService = Executors.newFixedThreadPool(3);
@@ -54,7 +55,7 @@ public class CommentLikeConcurrentServiceTest {
         for (int i = 0; i < 3; i++) {
             executorService.execute(() -> {
                 try {
-                    commentLikeService.save(member.getId(), comment.getId());
+                    commentLikeService.save(member1.getId(), comment.getId());
                 } catch (AlreadyExistsCommentLike e) {
                     exceptions.add(e); // 중복 예외를 리스트에 추가
                 }

--- a/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
@@ -1,9 +1,6 @@
 package mocacong.server.service;
 
-import mocacong.server.domain.Cafe;
-import mocacong.server.domain.Comment;
-import mocacong.server.domain.CommentLike;
-import mocacong.server.domain.Member;
+import mocacong.server.domain.*;
 import mocacong.server.dto.response.CommentLikeSaveResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsCommentLike;
 import mocacong.server.exception.notfound.NotFoundCommentException;
@@ -58,7 +55,7 @@ class CommentLikeServiceTest {
     }
 
     @Test
-    @DisplayName("이미 좋아요한 댓글에 좋아요를 또 할 수 없다.")
+    @DisplayName("이미 좋아요한 댓글에 좋아요를 또 하면 예외를 반환한다.")
     void saveDuplicateCommentLike() {
         String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";
@@ -73,6 +70,46 @@ class CommentLikeServiceTest {
         commentLikeService.save(member.getId(), comment.getId());
 
         assertThrows(AlreadyExistsCommentLike.class,() -> commentLikeService.save(member.getId(), comment.getId()));
+    }
+
+    @Test
+    @DisplayName("회원이 댓글 좋아요를 삭제한다")
+    void delete() {
+        String email = "rlawjddn103@naver.com";
+        String mapId = "2143154352323";
+        String commentContent = "코딩하고 싶어지는 카페에요.";
+        Member member = new Member(email, "encodePassword", "베어");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "베어카페");
+        cafeRepository.save(cafe);
+        Comment comment = new Comment(cafe, member, commentContent);
+        commentRepository.save(comment);
+        CommentLike commentLike = new CommentLike(member, comment);
+        commentLikeRepository.save(commentLike);
+
+        commentLikeService.delete(member.getId(), comment.getId());
+
+        assertThat(commentLikeRepository.findById(commentLike.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원이 존재하지 않는 댓글을 삭제할 시 오류를 반환한다.")
+    void deleteNotExistCommentLike() {
+        String email = "rlawjddn103@naver.com";
+        String mapId = "2143154352323";
+        String commentContent = "코딩하고 싶어지는 카페에요.";
+        Member member = new Member(email, "encodePassword", "베어");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "베어카페");
+        cafeRepository.save(cafe);
+        Comment comment = new Comment(cafe, member, commentContent);
+        commentRepository.save(comment);
+        CommentLike commentLike = new CommentLike(member, comment);
+        commentLikeRepository.save(commentLike);
+
+        commentLikeService.delete(member.getId(), comment.getId());
+
+        assertThrows(NotFoundCommentLikeException.class,() -> commentLikeService.delete(member.getId(), comment.getId()));
     }
 }
 

--- a/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
@@ -3,6 +3,7 @@ package mocacong.server.service;
 import mocacong.server.domain.*;
 import mocacong.server.dto.response.CommentLikeSaveResponse;
 import mocacong.server.exception.badrequest.AlreadyExistsCommentLike;
+import mocacong.server.exception.badrequest.InvalidCommentLikeException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.exception.notfound.NotFoundCommentLikeException;
 import mocacong.server.repository.CafeRepository;
@@ -35,46 +36,48 @@ class CommentLikeServiceTest {
     @Test
     @DisplayName("특정 댓글에 좋아요를 할 수 있다.")
     void save() {
-        String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";
         String commentContent = "코딩하고 싶어지는 카페에요.";
-        Member member = new Member(email, "encodePassword", "베어");
-        memberRepository.save(member);
+        Member member1 = new Member("rlawjddn103@naver.com", "encodePassword", "베어");
+        memberRepository.save(member1);
+        Member member2 = new Member("kth990303@naver.com", "encodePassword", "케이");
+        memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "베어카페");
         cafeRepository.save(cafe);
-        Comment comment = new Comment(cafe, member, commentContent);
+        Comment comment = new Comment(cafe, member2, commentContent);
         commentRepository.save(comment);
 
-        CommentLikeSaveResponse savedCommentLike = commentLikeService.save(member.getId(), comment.getId());
+        CommentLikeSaveResponse savedCommentLike = commentLikeService.save(member1.getId(), comment.getId());
 
         CommentLike actual = commentLikeRepository.findById(savedCommentLike.getCommentLikeId()).orElseThrow(NotFoundCommentLikeException::new);
 
         assertEquals(savedCommentLike.getCommentLikeId(), actual.getId());
         assertEquals(comment.getId(), actual.getComment().getId());
-        assertEquals(member.getId(), actual.getMember().getId());
+        assertEquals(member1.getId(), actual.getMember().getId());
     }
 
     @Test
     @DisplayName("이미 좋아요한 댓글에 좋아요를 또 하면 예외를 반환한다.")
     void saveDuplicateCommentLike() {
-        String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";
         String commentContent = "코딩하고 싶어지는 카페에요.";
-        Member member = new Member(email, "encodePassword", "베어");
-        memberRepository.save(member);
+        Member member1 = new Member("rlawjddn103@naver.com", "encodePassword", "베어");
+        memberRepository.save(member1);
+        Member member2 = new Member("kth990303@naver.com", "encodePassword", "케이");
+        memberRepository.save(member2);
         Cafe cafe = new Cafe(mapId, "베어카페");
         cafeRepository.save(cafe);
-        Comment comment = new Comment(cafe, member, commentContent);
+        Comment comment = new Comment(cafe, member2, commentContent);
         commentRepository.save(comment);
 
-        commentLikeService.save(member.getId(), comment.getId());
+        commentLikeService.save(member1.getId(), comment.getId());
 
-        assertThrows(AlreadyExistsCommentLike.class,() -> commentLikeService.save(member.getId(), comment.getId()));
+        assertThrows(AlreadyExistsCommentLike.class,() -> commentLikeService.save(member1.getId(), comment.getId()));
     }
 
     @Test
-    @DisplayName("회원이 댓글 좋아요를 삭제한다")
-    void delete() {
+    @DisplayName("자신의 댓글에 좋아요를 하면 예외를 반환한다.")
+    void saveInvalidCommentLike() {
         String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";
         String commentContent = "코딩하고 싶어지는 카페에요.";
@@ -84,10 +87,27 @@ class CommentLikeServiceTest {
         cafeRepository.save(cafe);
         Comment comment = new Comment(cafe, member, commentContent);
         commentRepository.save(comment);
-        CommentLike commentLike = new CommentLike(member, comment);
+
+        assertThrows(InvalidCommentLikeException.class,() -> commentLikeService.save(member.getId(), comment.getId()));
+    }
+
+    @Test
+    @DisplayName("회원이 댓글 좋아요를 삭제한다.")
+    void delete() {
+        String mapId = "2143154352323";
+        String commentContent = "코딩하고 싶어지는 카페에요.";
+        Member member1 = new Member("rlawjddn103@naver.com", "encodePassword", "베어");
+        memberRepository.save(member1);
+        Member member2 = new Member("kth990303@naver.com", "encodePassword", "케이");
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "베어카페");
+        cafeRepository.save(cafe);
+        Comment comment = new Comment(cafe, member2, commentContent);
+        commentRepository.save(comment);
+        CommentLike commentLike = new CommentLike(member1, comment);
         commentLikeRepository.save(commentLike);
 
-        commentLikeService.delete(member.getId(), comment.getId());
+        commentLikeService.delete(member1.getId(), comment.getId());
 
         assertThat(commentLikeRepository.findById(commentLike.getId())).isEmpty();
     }

--- a/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
@@ -1,0 +1,59 @@
+package mocacong.server.service;
+
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Comment;
+import mocacong.server.domain.CommentLike;
+import mocacong.server.domain.Member;
+import mocacong.server.dto.response.CommentLikeSaveResponse;
+import mocacong.server.exception.notfound.NotFoundCommentException;
+import mocacong.server.exception.notfound.NotFoundCommentLikeException;
+import mocacong.server.repository.CafeRepository;
+import mocacong.server.repository.CommentLikeRepository;
+import mocacong.server.repository.CommentRepository;
+import mocacong.server.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ServiceTest
+class CommentLikeServiceTest {
+
+    @Autowired
+    private CommentLikeService commentLikeService;
+
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CafeRepository cafeRepository;
+
+    @Test
+    @DisplayName("특정 댓글에 좋아요를 할 수 있다.")
+    void save() {
+        String email = "rlawjddn103@naver.com";
+        String mapId = "2143154352323";
+        String commentContent = "코딩하고 싶어지는 카페에요.";
+        Member member = new Member(email, "encodePassword", "베어");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "베어카페");
+        cafeRepository.save(cafe);
+        Comment comment = new Comment(cafe, member, commentContent);
+        commentRepository.save(comment);
+
+        CommentLikeSaveResponse savedCommentLike = commentLikeService.save(member.getId(), comment.getId());
+
+        CommentLike actual = commentLikeRepository.findById(savedCommentLike.getCommentLikeId()).orElseThrow(NotFoundCommentLikeException::new);
+
+        assertEquals(savedCommentLike.getCommentLikeId(), actual.getId());
+        assertEquals(comment.getId(), actual.getComment().getId());
+        assertEquals(member.getId(), actual.getMember().getId());
+    }
+}
+

--- a/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
@@ -5,6 +5,7 @@ import mocacong.server.domain.Comment;
 import mocacong.server.domain.CommentLike;
 import mocacong.server.domain.Member;
 import mocacong.server.dto.response.CommentLikeSaveResponse;
+import mocacong.server.exception.badrequest.AlreadyExistsCommentLike;
 import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.exception.notfound.NotFoundCommentLikeException;
 import mocacong.server.repository.CafeRepository;
@@ -54,6 +55,24 @@ class CommentLikeServiceTest {
         assertEquals(savedCommentLike.getCommentLikeId(), actual.getId());
         assertEquals(comment.getId(), actual.getComment().getId());
         assertEquals(member.getId(), actual.getMember().getId());
+    }
+
+    @Test
+    @DisplayName("이미 좋아요한 댓글에 좋아요를 또 할 수 없다.")
+    void saveDuplicateCommentLike() {
+        String email = "rlawjddn103@naver.com";
+        String mapId = "2143154352323";
+        String commentContent = "코딩하고 싶어지는 카페에요.";
+        Member member = new Member(email, "encodePassword", "베어");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "베어카페");
+        cafeRepository.save(cafe);
+        Comment comment = new Comment(cafe, member, commentContent);
+        commentRepository.save(comment);
+
+        commentLikeService.save(member.getId(), comment.getId());
+
+        assertThrows(AlreadyExistsCommentLike.class,() -> commentLikeService.save(member.getId(), comment.getId()));
     }
 }
 

--- a/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentLikeServiceTest.java
@@ -93,7 +93,7 @@ class CommentLikeServiceTest {
     }
 
     @Test
-    @DisplayName("회원이 존재하지 않는 댓글을 삭제할 시 오류를 반환한다.")
+    @DisplayName("회원이 존재하지 않는 댓글 좋아요를 삭제할 시 오류를 반환한다.")
     void deleteNotExistCommentLike() {
         String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";

--- a/src/test/java/mocacong/server/service/CommentServiceTest.java
+++ b/src/test/java/mocacong/server/service/CommentServiceTest.java
@@ -270,7 +270,7 @@ class CommentServiceTest {
 
     @Test
     @DisplayName("댓글 좋아요가 있는 댓글을 삭제할 수 있다.")
-    void deleteNotExistCommentLike() {
+    void deleteExistCommentLike() {
         String email = "rlawjddn103@naver.com";
         String mapId = "2143154352323";
         String commentContent = "코딩하고 싶어지는 카페에요.";


### PR DESCRIPTION
## 개요
- 댓글 좋아요 등록 기능이 추가되었습니다.
- 댓글 좋아요 취소 기능이 추가되었습니다.

## 작업사항

### 댓글 좋아요 등록
- 댓글과 댓글에 좋아요한 유저의 정보를 담기위한 CommentLike 테이블을 새롭게 생성하였습니다.
- 한 유저가 한 댓글에 여러번 좋아요할 수 없도록 데이터베이스 unique 무결성 제약을 걸어 동시성을 고려하였습니다.
- 추가로 동시성 테스트도 구현하였습니다.
- 스웨거로 정상 동작하는지 확인하였습니다.

### 댓글 좋아요 취소
- 댓글 좋아요 취소 기능을 구현했습니다.
- 댓글 좋아요 취소 시 inner join과 id 값만을 받아와 커버링 인덱스를 타도록 구현했습니다.
- 유저가 삭제되었을 때 FK 무결성 제약조건을 해결하기 위해, EventListner를 이용해 유저가 삭제되었을 때 연결 관계를 끊어주었습니다.
- 유저가 삭제된다고 댓글 좋아요 기록은 사라지지 않기 때문에 이를 반영하여 CommentLike를 삭제하진 않았습니다.

## 주의사항
- 댓글 좋아요에 cafes의 mapId가 필요없어 path가 바뀌게 되었는데, 혹시 더 좋은 방법이 있다면 말씀해주세요.
- 동시성 테스트에 더 좋은 방법이 있다면 추천해주세요.
