### PR TITLE
feat: CafeImage 등록시 등록된 id 함께 반환 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/CafeController.java
+++ b/src/main/java/mocacong/server/controller/CafeController.java
@@ -113,13 +113,13 @@ public class CafeController {
     @Operation(summary = "카페 이미지 업로드")
     @SecurityRequirement(name = "JWT")
     @PostMapping(value = "/{mapId}/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> saveCafeImage(
+    public ResponseEntity<CafeImagesSaveResponse> saveCafeImage(
             @LoginUserId Long memberId,
             @PathVariable String mapId,
             @RequestParam(value = "files") List<MultipartFile> multipartFiles
     ) {
-        cafeService.saveCafeImage(memberId, mapId, multipartFiles);
-        return ResponseEntity.ok().build();
+        CafeImagesSaveResponse response = cafeService.saveCafeImage(memberId, mapId, multipartFiles);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "카페 이미지 조회")

--- a/src/main/java/mocacong/server/dto/response/CafeImageSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeImageSaveResponse.java
@@ -1,0 +1,11 @@
+package mocacong.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class CafeImageSaveResponse {
+    private Long id;
+}

--- a/src/main/java/mocacong/server/dto/response/CafeImagesSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeImagesSaveResponse.java
@@ -1,0 +1,15 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CafeImagesSaveResponse {
+    private List<CafeImageSaveResponse> cafeImagesIds;
+}

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,5 +1,6 @@
 package mocacong.server.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -303,19 +304,20 @@ public class CafeService {
     }
 
     @Transactional
-    public void saveCafeImage(Long memberId, String mapId, List<MultipartFile> cafeImages) {
+    public CafeImagesSaveResponse saveCafeImage(Long memberId, String mapId, List<MultipartFile> cafeImages) {
         Cafe cafe = cafeRepository.findByMapId(mapId)
                 .orElseThrow(NotFoundCafeException::new);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
         validateOwnedCafeImagesCounts(cafe, member, cafeImages);
-
+        List<CafeImageSaveResponse> cafeImageSaveResponses = new ArrayList<>();
         for (MultipartFile cafeImage : cafeImages) {
             String imgUrl = awsS3Uploader.uploadImage(cafeImage);
             CafeImage uploadedCafeImage = new CafeImage(imgUrl, true, cafe, member);
-            cafeImageRepository.save(uploadedCafeImage);
+            cafeImageSaveResponses.add(new CafeImageSaveResponse(cafeImageRepository.save(uploadedCafeImage).getId()));
         }
+        return new CafeImagesSaveResponse(cafeImageSaveResponses);
     }
 
     private void validateOwnedCafeImagesCounts(Cafe cafe, Member member, List<MultipartFile> requestCafeImages) {

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -6,7 +6,6 @@ import mocacong.server.dto.response.*;
 import mocacong.server.exception.badrequest.AlreadyExistsCafeReview;
 import mocacong.server.exception.badrequest.DuplicateCafeException;
 import mocacong.server.exception.badrequest.ExceedCageImagesTotalCountsException;
-import mocacong.server.exception.notfound.NotFoundCafeException;
 import mocacong.server.exception.notfound.NotFoundCafeImageException;
 import mocacong.server.exception.notfound.NotFoundReviewException;
 import mocacong.server.repository.*;
@@ -765,6 +764,27 @@ class CafeServiceTest {
         assertAll(
                 () -> assertThat(actual).hasSize(1),
                 () -> assertThat(actual.get(0).getImgUrl()).isEqualTo(expected)
+        );
+    }
+
+    @Test
+    @DisplayName("카페 이미지를 저장한 후 Response를 반환한다.")
+    void saveCafeImageWithResponse() throws IOException {
+        Cafe cafe = new Cafe("2143154352323", "케이카페");
+        cafeRepository.save(cafe);
+        Member member = new Member("dlawotn3@naver.com", "a1b2c3d4", "메리", null);
+        memberRepository.save(member);
+        String mapId = cafe.getMapId();
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + "test_img.jpg");
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg", "jpg",
+                fileInputStream);
+
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        CafeImagesSaveResponse cafeImagesSaveResponse = cafeService.saveCafeImage(member.getId(), mapId, List.of(mockMultipartFile));
+
+        assertAll(
+                () -> assertThat(cafeImagesSaveResponse.getCafeImagesIds()).hasSize(1),
+                () -> assertThat(cafeImagesSaveResponse.getCafeImagesIds().get(0).getId()).isEqualTo(1L)
         );
     }
 


### PR DESCRIPTION
## 개요
- CafeImage 등록시 등록된 id를 반환하도록 구현하였습니다.

## 작업사항
- 테스트 시 aws3 upload mocking이 필요하여 serviceTest에 테스트 작성하였습니다.
- 새로운 dto가 추가되었습니다.
- api spec이 변경되었습니다.

## 주의사항
- 크게 로직은 없지만 더 좋은 변경 구조가 있다면 알려주세요.