### PR TITLE
fix: 카페 세부정보 콘센트, 책상 필드 @NotNull 추가

### DIFF
--- a/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
@@ -23,11 +23,11 @@ public class CafeReviewRequest {
 
     private String myToilet;
 
-    @NotNull(message = "3009:공백일 수 없습니다.")
+    @NotNull(message = "3011:콘센트 필드는 공백일 수 없습니다.")
     private String myPower;
 
     private String mySound;
 
-    @NotNull(message = "3009:공백일 수 없습니다.")
+    @NotNull(message = "3012:데스크 필드는 공백일 수 없습니다.")
     private String myDesk;
 }

--- a/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
@@ -23,11 +23,11 @@ public class CafeReviewRequest {
 
     private String myToilet;
 
-    @NotNull(message = "3011:콘센트 필드는 공백일 수 없습니다.")
+    @NotBlank(message = "3009:공백일 수 없습니다.")
     private String myPower;
 
     private String mySound;
 
-    @NotNull(message = "3012:데스크 필드는 공백일 수 없습니다.")
+    @NotBlank(message = "3009:공백일 수 없습니다.")
     private String myDesk;
 }

--- a/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewRequest.java
@@ -1,8 +1,9 @@
 package mocacong.server.dto.request;
 
+import lombok.*;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -17,9 +18,16 @@ public class CafeReviewRequest {
     private String myStudyType;
 
     private String myWifi;
+
     private String myParking;
+
     private String myToilet;
+
+    @NotNull(message = "3009:공백일 수 없습니다.")
     private String myPower;
+
     private String mySound;
+
+    @NotNull(message = "3009:공백일 수 없습니다.")
     private String myDesk;
 }

--- a/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
@@ -23,11 +23,11 @@ public class CafeReviewUpdateRequest {
 
     private String myToilet;
 
-    @NotNull(message = "3009:공백일 수 없습니다.")
+    @NotNull(message = "3011:콘센트 필드는 공백일 수 없습니다.")
     private String myPower;
 
     private String mySound;
 
-    @NotNull(message = "3009:공백일 수 없습니다.")
+    @NotNull(message = "3012:데스크 필드는 공백일 수 없습니다.")
     private String myDesk;
 }

--- a/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
@@ -1,8 +1,9 @@
 package mocacong.server.dto.request;
 
+import lombok.*;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -17,9 +18,16 @@ public class CafeReviewUpdateRequest {
     private String myStudyType;
 
     private String myWifi;
+
     private String myParking;
+
     private String myToilet;
+
+    @NotNull(message = "3009:공백일 수 없습니다.")
     private String myPower;
+
     private String mySound;
+
+    @NotNull(message = "3009:공백일 수 없습니다.")
     private String myDesk;
 }

--- a/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeReviewUpdateRequest.java
@@ -23,11 +23,11 @@ public class CafeReviewUpdateRequest {
 
     private String myToilet;
 
-    @NotNull(message = "3011:콘센트 필드는 공백일 수 없습니다.")
+    @NotBlank(message = "3009:공백일 수 없습니다.")
     private String myPower;
 
     private String mySound;
 
-    @NotNull(message = "3012:데스크 필드는 공백일 수 없습니다.")
+    @NotBlank(message = "3009:공백일 수 없습니다.")
     private String myDesk;
 }


### PR DESCRIPTION
## 개요
- 카페 리뷰 작성 및 수정 로직이 콘센트와 책상 필드 또한 필수로 입력하도록 수정되어 API를 수정했습니다.

## 작업사항
- 카페 리뷰 작성 및 수정 response에서 콘센트, 책상 필드 @Notnull 옵션 추가

## 주의사항
- 제대로 작동하는 지 포스트맨이나 스웨거로 확인해주세요
- `@NotNull` 을 requestBody 필드에 추가하였기 때문에 따로 해당 pr에 대한 테스트 코드를 작성하지 않았습니다.