### PR TITLE
feat: 카페 이미지 신고 기능 POST API 구현

### DIFF
--- a/src/main/java/mocacong/server/controller/ReportController.java
+++ b/src/main/java/mocacong/server/controller/ReportController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import mocacong.server.dto.request.CafeImageReportRequest;
 import mocacong.server.dto.request.CommentReportRequest;
+import mocacong.server.dto.response.CafeImageReportResponse;
 import mocacong.server.dto.response.CommentReportResponse;
 import mocacong.server.security.auth.LoginUserId;
 import mocacong.server.service.ReportService;
@@ -30,6 +32,18 @@ public class ReportController {
             @RequestBody @Valid CommentReportRequest request
     ) {
         CommentReportResponse response = reportService.reportComment(memberId, commentId, request.getMyReportReason());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "카페 이미지 신고")
+    @SecurityRequirement(name = "JWT")
+    @PostMapping("/img/{cafeImageId}")
+    public ResponseEntity<CafeImageReportResponse> reportCafeImage(
+            @LoginUserId Long memberId,
+            @PathVariable Long cafeImageId,
+            @RequestBody @Valid CafeImageReportRequest request
+    ) {
+        CafeImageReportResponse response = reportService.reportCafeImage(memberId, cafeImageId, request.getMyReportReason());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CafeImage extends BaseTime {
 
-    private static final int REPORT_CAFE_IMAGE_THRESHOLD_COUNT = 2;
+    private static final int REPORT_CAFE_IMAGE_THRESHOLD_COUNT = 3;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -5,12 +5,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "cafe_image")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CafeImage extends BaseTime {
+
+    private static final int REPORT_CAFE_IMAGE_THRESHOLD_COUNT = 3;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,11 +35,18 @@ public class CafeImage extends BaseTime {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToMany(mappedBy = "cafeImage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Report> reports = new ArrayList<>();
+
+    @Column(name = "is_masked")
+    private boolean isMasked;
+
     public CafeImage(String imgUrl, Boolean isUsed, Cafe cafe, Member member) {
         this.imgUrl = imgUrl;
         this.isUsed = isUsed;
         this.cafe = cafe;
         this.member = member;
+        this.isMasked = false;
     }
 
     public boolean isOwned(Member member) {
@@ -48,5 +59,42 @@ public class CafeImage extends BaseTime {
 
     public void removeMember() {
         this.member = null;
+    }
+
+    public boolean hasAlreadyReported(Member member) {
+        return this.reports.stream()
+                .anyMatch(report -> report.getReporter().equals(member));
+    }
+
+    public void addReport(Report report) {
+        reports.add(report);
+    }
+
+    public int getReportsCount() {
+        return reports.size();
+    }
+
+    public boolean isDeletedMember() {
+        return member == null;
+    }
+
+    public boolean isSavedByMember(Member member) {
+        return this.member != null && this.member.equals(member);
+    }
+
+    public boolean isReportThresholdExceeded() {
+        return getReportsCount() >= REPORT_CAFE_IMAGE_THRESHOLD_COUNT;
+    }
+
+    public boolean isDeletedAuthor() {
+        return isDeletedMember() && isReportThresholdExceeded();
+    }
+
+    public void updateIsMasked(boolean isMasked) {
+        this.isMasked = isMasked;
+    }
+
+    public void maskCafeImage() {
+        this.isUsed = false;
     }
 }

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -90,11 +90,8 @@ public class CafeImage extends BaseTime {
         return isDeletedMember() && isReportThresholdExceeded();
     }
 
-    public void updateIsMasked(boolean isMasked) {
-        this.isMasked = isMasked;
-    }
-
     public void maskCafeImage() {
         this.isUsed = false;
+        this.isMasked = true;
     }
 }

--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CafeImage extends BaseTime {
 
-    private static final int REPORT_CAFE_IMAGE_THRESHOLD_COUNT = 3;
+    private static final int REPORT_CAFE_IMAGE_THRESHOLD_COUNT = 2;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -110,6 +110,6 @@ public class Comment extends BaseTime {
     }
 
     public void updateIsMasked(boolean isMasked) {
-        this.isMasked= isMasked;
+        this.isMasked = isMasked;
     }
 }

--- a/src/main/java/mocacong/server/domain/Report.java
+++ b/src/main/java/mocacong/server/domain/Report.java
@@ -7,7 +7,8 @@ import javax.persistence.*;
 
 @Entity
 @Table(name = "report", uniqueConstraints = {
-        @UniqueConstraint(columnNames = { "comment_id", "member_id" })
+        @UniqueConstraint(columnNames = { "comment_id", "member_id" }),
+        @UniqueConstraint(columnNames = { "cafe_image_id", "member_id" })
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report {
@@ -22,6 +23,10 @@ public class Report {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_image_id")
+    private CafeImage cafeImage;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -39,6 +44,12 @@ public class Report {
         this.reporter = reporter;
         this.reportReason = reportReason;
         this.originalContent = comment.getContent();
+    }
+
+    public Report(CafeImage cafeImage, Member reporter, ReportReason reportReason) {
+        this.cafeImage = cafeImage;
+        this.reporter = reporter;
+        this.reportReason = reportReason;
     }
 
     public Member getReporter() {

--- a/src/main/java/mocacong/server/domain/Report.java
+++ b/src/main/java/mocacong/server/domain/Report.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
         @UniqueConstraint(columnNames = { "cafe_image_id", "member_id" })
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Report {
+public class Report extends BaseTime {
 
     private static final int MAXIMUM_COMMENT_LENGTH = 200;
 

--- a/src/main/java/mocacong/server/dto/request/CafeImageReportRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeImageReportRequest.java
@@ -1,0 +1,15 @@
+package mocacong.server.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class CafeImageReportRequest {
+
+    @NotBlank(message = "3009:공백일 수 없습니다.")
+    private String myReportReason;
+}

--- a/src/main/java/mocacong/server/dto/response/CafeImageReportResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeImageReportResponse.java
@@ -1,0 +1,16 @@
+package mocacong.server.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CafeImageReportResponse {
+
+    private int cafeImageReportCount;
+
+    private int userReportCount;
+}

--- a/src/main/java/mocacong/server/exception/badrequest/DuplicateReportCafeImageException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/DuplicateReportCafeImageException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class DuplicateReportCafeImageException extends BadRequestException {
+
+    public DuplicateReportCafeImageException() {
+        super("이미 신고한 카페 이미지입니다.", 7004);
+    }
+}

--- a/src/main/java/mocacong/server/exception/badrequest/InvalidCafeImageReportException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/InvalidCafeImageReportException.java
@@ -1,0 +1,8 @@
+package mocacong.server.exception.badrequest;
+
+public class InvalidCafeImageReportException extends BadRequestException {
+
+    public InvalidCafeImageReportException() {
+        super("자신이 등록한 카페 이미지는 신고할 수 없습니다.", 7003);
+    }
+}

--- a/src/main/java/mocacong/server/repository/CafeImageRepository.java
+++ b/src/main/java/mocacong/server/repository/CafeImageRepository.java
@@ -17,5 +17,5 @@ public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
 
     List<CafeImage> findAllByMemberId(Long memberId);
 
-    List<CafeImage> findAllByIsUsedFalse();
+    List<CafeImage> findAllByIsUsedFalseAndIsMaskedFalse();
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -380,8 +380,7 @@ public class CafeService {
 
     @Transactional
     public void deleteNotUsedCafeImages() {
-        //TODO: isMasked == false 조건 추가
-        List<CafeImage> cafeImages = cafeImageRepository.findAllByIsUsedFalse();
+        List<CafeImage> cafeImages = cafeImageRepository.findAllByIsUsedFalseAndIsMaskedFalse();
         List<String> imgUrls = cafeImages.stream()
                 .map(CafeImage::getImgUrl)
                 .collect(Collectors.toList());

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,10 +1,5 @@
 package mocacong.server.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -34,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -384,6 +380,7 @@ public class CafeService {
 
     @Transactional
     public void deleteNotUsedCafeImages() {
+        //TODO: isMasked == false 조건 추가
         List<CafeImage> cafeImages = cafeImageRepository.findAllByIsUsedFalse();
         List<String> imgUrls = cafeImages.stream()
                 .map(CafeImage::getImgUrl)

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -47,13 +47,8 @@ public class ReportService {
                 maskReportedComment(comment);
             } else {
                 Member commenter = comment.getMember();
-                if (comment.isWrittenByMember(reporter)) {
-                    throw new InvalidCommentReportException();
-                }
-                if (comment.isReportThresholdExceeded()) {
-                    commenter.incrementMemberReportCount();
-                    maskReportedComment(comment);
-                }
+                validateCommentReporter(reporter, comment);
+                validateCommentReportThreshold(commenter, comment);
             }
         } catch (DataIntegrityViolationException e) {
             throw new DuplicateReportCommentException();
@@ -73,6 +68,19 @@ public class ReportService {
         comment.maskComment();
         comment.maskAuthor();
         comment.updateIsMasked(true);
+    }
+
+    private void validateCommentReporter(Member reporter, Comment comment) {
+        if (comment.isWrittenByMember(reporter)) {
+            throw new InvalidCommentReportException();
+        }
+    }
+
+    private void validateCommentReportThreshold(Member commenter, Comment comment) {
+        if (comment.isReportThresholdExceeded()) {
+            commenter.incrementMemberReportCount();
+            maskReportedComment(comment);
+        }
     }
 
     @EventListener
@@ -95,13 +103,8 @@ public class ReportService {
                 cafeImage.maskCafeImage();
             } else {
                 Member author = cafeImage.getMember();
-                if (cafeImage.isSavedByMember(reporter)) {
-                    throw new InvalidCafeImageReportException();
-                }
-                if (cafeImage.isReportThresholdExceeded()) {
-                    author.incrementMemberReportCount();
-                    cafeImage.maskCafeImage();
-                }
+                validateCafeImageReporter(reporter, cafeImage);
+                validateCafeImageReportThreshold(author, cafeImage);
             }
         } catch (DataIntegrityViolationException e) {
             throw new DuplicateReportCafeImageException();
@@ -115,6 +118,19 @@ public class ReportService {
         }
         ReportReason reason = ReportReason.from(reportReason);
         cafeImage.addReport(new Report(cafeImage, reporter, reason));
+    }
+
+    private void validateCafeImageReporter(Member reporter, CafeImage cafeImage) {
+        if (cafeImage.isSavedByMember(reporter)) {
+            throw new InvalidCafeImageReportException();
+        }
+    }
+
+    private void validateCafeImageReportThreshold(Member author, CafeImage cafeImage) {
+        if (cafeImage.isReportThresholdExceeded()) {
+            author.incrementMemberReportCount();
+            cafeImage.maskCafeImage();
+        }
     }
 
     @EventListener

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -2,15 +2,17 @@ package mocacong.server.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import mocacong.server.domain.Comment;
-import mocacong.server.domain.Member;
-import mocacong.server.domain.Report;
-import mocacong.server.domain.ReportReason;
+import mocacong.server.domain.*;
+import mocacong.server.dto.response.CafeImageReportResponse;
 import mocacong.server.dto.response.CommentReportResponse;
+import mocacong.server.exception.badrequest.DuplicateReportCafeImageException;
 import mocacong.server.exception.badrequest.DuplicateReportCommentException;
+import mocacong.server.exception.badrequest.InvalidCafeImageReportException;
 import mocacong.server.exception.badrequest.InvalidCommentReportException;
+import mocacong.server.exception.notfound.NotFoundCafeImageException;
 import mocacong.server.exception.notfound.NotFoundCommentException;
 import mocacong.server.exception.notfound.NotFoundMemberException;
+import mocacong.server.repository.CafeImageRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
 import mocacong.server.repository.ReportRepository;
@@ -29,6 +31,7 @@ public class ReportService {
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
     private final ReportRepository reportRepository;
+    private final CafeImageRepository cafeImageRepository;
 
     public CommentReportResponse reportComment(Long memberId, Long commentId, String reportReason) {
         Member reporter = memberRepository.findById(memberId)
@@ -78,5 +81,42 @@ public class ReportService {
     private void maskReportedComment(Comment comment) {
         comment.maskComment();
         comment.maskAuthor();
+    }
+
+    public CafeImageReportResponse reportCafeImage(Long memberId, Long cafeImageId, String reportReason) {
+        Member reporter = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        CafeImage cafeImage = cafeImageRepository.findById(cafeImageId)
+                .orElseThrow(NotFoundCafeImageException::new);
+        try {
+            createCafeImageReport(cafeImage, reporter, reportReason);
+
+            // 카페 이미지를 등록한 회원이 탈퇴한 경우
+            if (cafeImage.isDeletedAuthor() && cafeImage.isReportThresholdExceeded()) {
+                cafeImage.maskCafeImage();
+                cafeImage.updateIsMasked(true);
+            } else {
+                Member author = cafeImage.getMember();
+                if (cafeImage.isSavedByMember(reporter)) {
+                    throw new InvalidCafeImageReportException();
+                }
+                if (cafeImage.isReportThresholdExceeded()) {
+                    author.incrementMemberReportCount();
+                    cafeImage.maskCafeImage();
+                    cafeImage.updateIsMasked(true);
+                }
+            }
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateReportCafeImageException();
+        }
+        return new CafeImageReportResponse(cafeImage.getReportsCount(), reporter.getReportCount());
+    }
+
+    private void createCafeImageReport(CafeImage cafeImage, Member reporter, String reportReason) {
+        if (cafeImage.hasAlreadyReported(reporter)) {
+            throw new DuplicateReportCommentException();
+        }
+        ReportReason reason = ReportReason.from(reportReason);
+        cafeImage.addReport(new Report(cafeImage, reporter, reason));
     }
 }

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -45,7 +45,6 @@ public class ReportService {
             // 코멘트를 작성한 회원이 탈퇴한 경우
             if (comment.isDeletedCommenter() && comment.isReportThresholdExceeded()) {
                 maskReportedComment(comment);
-                comment.updateIsMasked(true);
             } else {
                 Member commenter = comment.getMember();
                 if (comment.isWrittenByMember(reporter)) {
@@ -54,7 +53,6 @@ public class ReportService {
                 if (comment.isReportThresholdExceeded()) {
                     commenter.incrementMemberReportCount();
                     maskReportedComment(comment);
-                    comment.updateIsMasked(true);
                 }
             }
         } catch (DataIntegrityViolationException e) {
@@ -74,6 +72,7 @@ public class ReportService {
     private void maskReportedComment(Comment comment) {
         comment.maskComment();
         comment.maskAuthor();
+        comment.updateIsMasked(true);
     }
 
     @EventListener
@@ -94,7 +93,6 @@ public class ReportService {
             // 카페 이미지를 등록한 회원이 탈퇴한 경우
             if (cafeImage.isDeletedAuthor() && cafeImage.isReportThresholdExceeded()) {
                 cafeImage.maskCafeImage();
-                cafeImage.updateIsMasked(true);
             } else {
                 Member author = cafeImage.getMember();
                 if (cafeImage.isSavedByMember(reporter)) {
@@ -103,7 +101,6 @@ public class ReportService {
                 if (cafeImage.isReportThresholdExceeded()) {
                     author.incrementMemberReportCount();
                     cafeImage.maskCafeImage();
-                    cafeImage.updateIsMasked(true);
                 }
             }
         } catch (DataIntegrityViolationException e) {

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -71,16 +71,16 @@ public class ReportService {
         comment.addReport(new Report(comment, reporter, reason));
     }
 
+    private void maskReportedComment(Comment comment) {
+        comment.maskComment();
+        comment.maskAuthor();
+    }
+
     @EventListener
     public void updateCommentReportWhenMemberDelete(DeleteMemberEvent event) {
         Member member = event.getMember();
         reportRepository.findAllByReporter(member)
                 .forEach(Report::removeReporter);
-    }
-
-    private void maskReportedComment(Comment comment) {
-        comment.maskComment();
-        comment.maskAuthor();
     }
 
     public CafeImageReportResponse reportCafeImage(Long memberId, Long cafeImageId, String reportReason) {
@@ -118,5 +118,12 @@ public class ReportService {
         }
         ReportReason reason = ReportReason.from(reportReason);
         cafeImage.addReport(new Report(cafeImage, reporter, reason));
+    }
+
+    @EventListener
+    public void updateCafeImageReportWhenMemberDelete(DeleteMemberEvent event) {
+        Member member = event.getMember();
+        reportRepository.findAllByReporter(member)
+                .forEach(Report::removeReporter);
     }
 }

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -43,7 +43,7 @@ public class ReportService {
             createCommentReport(comment, reporter, reportReason);
 
             // 코멘트를 작성한 회원이 탈퇴한 경우
-            if (comment.isDeletedCommenter() && comment.isReportThresholdExceeded()) {
+            if (comment.isDeletedCommenter()) {
                 maskReportedComment(comment);
             } else {
                 Member commenter = comment.getMember();
@@ -91,7 +91,7 @@ public class ReportService {
             createCafeImageReport(cafeImage, reporter, reportReason);
 
             // 카페 이미지를 등록한 회원이 탈퇴한 경우
-            if (cafeImage.isDeletedAuthor() && cafeImage.isReportThresholdExceeded()) {
+            if (cafeImage.isDeletedAuthor()) {
                 cafeImage.maskCafeImage();
             } else {
                 Member author = cafeImage.getMember();

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -114,7 +114,7 @@ public class ReportService {
 
     private void createCafeImageReport(CafeImage cafeImage, Member reporter, String reportReason) {
         if (cafeImage.hasAlreadyReported(reporter)) {
-            throw new DuplicateReportCommentException();
+            throw new DuplicateReportCafeImageException();
         }
         ReportReason reason = ReportReason.from(reportReason);
         cafeImage.addReport(new Report(cafeImage, reporter, reason));

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -869,7 +869,6 @@ class CafeServiceTest {
         );
     }
 
-
     @Test
     @DisplayName("사용자가 카페 이미지를 총 3개 보다 많이 저장하면 예외가 발생한다.")
     void saveCafeImagesOver3() throws IOException {

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -1221,18 +1221,16 @@ class CafeServiceTest {
         CafeImage cafeImage1 = new CafeImage("test_img.jpg", true, cafe, member);
         cafeImageRepository.save(cafeImage1);
         CafeImage cafeImage2 = new CafeImage("test_img2.jpg", false, cafe, member);
-        cafeImage2.updateIsMasked(true);
+        cafeImage2.maskCafeImage();
         cafeImageRepository.save(cafeImage2);
         CafeImage cafeImage3 = new CafeImage("test_img3.jpg", false, cafe, member);
-        cafeImage3.updateIsMasked(true);
+        cafeImage3.maskCafeImage();
         cafeImageRepository.save(cafeImage3);
 
         doNothing().when(awsS3Uploader).deleteImages(new DeleteNotUsedImagesEvent(reportedImgUrls));
         cafeService.deleteNotUsedCafeImages();
-
         List<CafeImage> actual = cafeImageRepository.findAll();
-        assertAll(
-                () -> assertThat(actual).hasSize(3)
-        );
+
+        assertThat(actual).hasSize(3);
     }
 }

--- a/src/test/java/mocacong/server/service/ReportConcurrentServiceTest.java
+++ b/src/test/java/mocacong/server/service/ReportConcurrentServiceTest.java
@@ -2,14 +2,21 @@ package mocacong.server.service;
 
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Member;
+import mocacong.server.dto.response.CafeImageReportResponse;
+import mocacong.server.dto.response.CafeImagesSaveResponse;
 import mocacong.server.dto.response.CommentReportResponse;
 import mocacong.server.dto.response.CommentSaveResponse;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.MemberRepository;
+import mocacong.server.support.AwsS3Uploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +26,7 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
 public class ReportConcurrentServiceTest {
@@ -27,9 +35,14 @@ public class ReportConcurrentServiceTest {
     @Autowired
     private ReportService reportService;
     @Autowired
+    private CafeService cafeService;
+    @Autowired
     private CafeRepository cafeRepository;
     @Autowired
     private MemberRepository memberRepository;
+
+    @MockBean
+    private AwsS3Uploader awsS3Uploader;
 
     @Test
     @DisplayName("타 사용자가 작성한 댓글을 동시에 여러 번 신고하려 해도 한 번만 신고된다")
@@ -53,6 +66,50 @@ public class ReportConcurrentServiceTest {
             executorService.execute(() -> {
                 try {
                     CommentReportResponse response = reportService.reportComment(member2.getId(), saveResponse.getId(),
+                            "insult");
+                    responses.add(response);
+                } catch (Exception e) {
+                    exceptions.add(e); // 중복 예외를 리스트에 추가
+
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        assertAll(
+                () -> assertThat(responses.size()).isEqualTo(1),
+                () -> assertThat(exceptions.size()).isEqualTo(2)
+        );
+    }
+
+    @Test
+    @DisplayName("타 사용자가 등록한 카페 이미지를 동시에 여러 번 신고하려 해도 한 번만 신고된다")
+    void reportCafeImageWithConcurrent() throws InterruptedException, IOException {
+        String email1 = "kth990303@naver.com";
+        String email2 = "dlawotn3@naver.com";
+        String mapId = "2143154352323";
+        Member member1 = new Member(email1, "encodePassword", "케이");
+        Member member2 = new Member(email2, "encodePassword", "메리");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/" + "test_img.jpg");
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg", "jpg",
+                fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        CafeImagesSaveResponse cafeImagesSaveResponse = cafeService.saveCafeImage(member1.getId(), mapId, List.of(mockMultipartFile));
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        CountDownLatch latch = new CountDownLatch(3);
+        List<CafeImageReportResponse> responses = Collections.synchronizedList(new ArrayList<>());
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < 3; i++) {
+            executorService.execute(() -> {
+                try {
+                    CafeImageReportResponse response = reportService.reportCafeImage(member2.getId(), 1L,
                             "insult");
                     responses.add(response);
                 } catch (Exception e) {

--- a/src/test/java/mocacong/server/service/ReportServiceTest.java
+++ b/src/test/java/mocacong/server/service/ReportServiceTest.java
@@ -1,22 +1,24 @@
 package mocacong.server.service;
 
-import mocacong.server.domain.Cafe;
-import mocacong.server.domain.Comment;
-import mocacong.server.domain.Member;
-import mocacong.server.domain.Status;
+import mocacong.server.domain.*;
+import mocacong.server.dto.response.CafeImageReportResponse;
 import mocacong.server.dto.response.CommentReportResponse;
 import mocacong.server.dto.response.CommentSaveResponse;
 import mocacong.server.dto.response.CommentsResponse;
-import mocacong.server.exception.badrequest.DuplicateReportCommentException;
-import mocacong.server.exception.badrequest.InvalidCommentReportException;
-import mocacong.server.exception.badrequest.InvalidReportReasonException;
+import mocacong.server.exception.badrequest.*;
+import mocacong.server.repository.CafeImageRepository;
 import mocacong.server.repository.CafeRepository;
 import mocacong.server.repository.CommentRepository;
 import mocacong.server.repository.MemberRepository;
+import mocacong.server.support.AwsS3Uploader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +26,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
 public class ReportServiceTest {
@@ -34,6 +37,8 @@ public class ReportServiceTest {
     private MemberService memberService;
     @Autowired
     private CommentService commentService;
+    @Autowired
+    private CafeService cafeService;
 
     @Autowired
     private CommentRepository commentRepository;
@@ -41,6 +46,11 @@ public class ReportServiceTest {
     private MemberRepository memberRepository;
     @Autowired
     private CafeRepository cafeRepository;
+    @Autowired
+    private CafeImageRepository cafeImageRepository;
+
+    @MockBean
+    private AwsS3Uploader awsS3Uploader;
 
     @Test
     @DisplayName("타 사용자가 작성한 댓글을 신고한다")
@@ -151,6 +161,129 @@ public class ReportServiceTest {
     }
 
     @Test
+    @DisplayName("탈퇴한 회원이 작성한 코멘트를 신고한다")
+    void reportCommentPostedDeletedMember() {
+        String email1 = "kth990303@naver.com";
+        String email2 = "dlawotn3@naver.com";
+        String mapId = "2143154352323";
+        Member member1 = new Member(email1, "encodePassword", "케이");
+        Member member2 = new Member(email2, "encodePassword", "메리");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        Comment comment = new Comment(cafe, member1, "이 카페 완전 돈 아깝;;");
+        commentRepository.save(comment);
+        memberService.delete(member1.getId());
+
+        CommentReportResponse response = reportService.reportComment(member2.getId(), comment.getId(),
+                "inappropriate_content");
+
+        assertThat(response.getCommentReportCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("타 사용자가 등록한 카페 이미지를 신고한다")
+    void reportCafeImage() throws IOException {
+        String email1 = "kth990303@naver.com";
+        String email2 = "dlawotn3@naver.com";
+        String mapId = "2143154352323";
+        String reportReason = "insult";
+        Member member1 = new Member(email1, "encodePassword", "케이");
+        Member member2 = new Member(email2, "encodePassword", "메리");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/test_img.jpg");
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg",
+                "jpg", fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member1.getId(), mapId, List.of(mockMultipartFile));
+
+        CafeImageReportResponse response = reportService.reportCafeImage(member2.getId(), 1L, reportReason);
+
+        assertThat(response.getCafeImageReportCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("본인이 등록한 카페 이미지에 대해 신고를 시도할 시 예외를 반환한다")
+    void reportMyCafeImage() throws IOException {
+        String email = "kth990303@naver.com";
+        String mapId = "2143154352323";
+        Member member = new Member(email, "encodePassword", "케이");
+        memberRepository.save(member);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/test_img.jpg");
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg",
+                "jpg", fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member.getId(), mapId, List.of(mockMultipartFile));
+
+        assertThatThrownBy(() -> reportService.reportCafeImage(member.getId(), 1L, "insult"))
+                .isInstanceOf(InvalidCafeImageReportException.class);
+    }
+
+    @Test
+    @DisplayName("이미 신고한 카페 이미지에 대해 신고를 시도할 시 예외를 반환한다")
+    void reportDuplicateCafeImage() throws IOException {
+        String email1 = "kth990303@naver.com";
+        String email2 = "dlawotn3@naver.com";
+        String mapId = "2143154352323";
+        Member member1 = new Member(email1, "encodePassword", "케이");
+        Member member2 = new Member(email2, "encodePassword", "메리");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/test_img.jpg");
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg",
+                "jpg", fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(member1.getId(), mapId, List.of(mockMultipartFile));
+
+        reportService.reportCafeImage(member2.getId(), 1L, "inappropriate_content");
+
+        assertThatThrownBy(() -> reportService.reportCafeImage(member2.getId(), 1L, "insult"))
+                .isInstanceOf(DuplicateReportCafeImageException.class);
+    }
+
+    @Test
+    @DisplayName("3번 이상 신고된 카페 이미지는 마스킹되며 해당 작성자의 신고 횟수가 1씩 증가한다")
+    void maskCauseReport3timesReportedCafeImage() throws IOException {
+        String mapId = "2143154352323";
+        List<Member> members = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            Member member = new Member("dlawotn" + i + "@naver.com", "encodePassword", "메리"
+                    + (char) ('A' + i));
+            members.add(member);
+            memberRepository.save(member);
+        }
+        Cafe cafe = new Cafe(mapId, "케이카페");
+        cafeRepository.save(cafe);
+        FileInputStream fileInputStream = new FileInputStream("src/test/resources/images/test_img.jpg");
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("test_img", "test_img.jpg",
+                "jpg", fileInputStream);
+        when(awsS3Uploader.uploadImage(mockMultipartFile)).thenReturn("test_img.jpg");
+        cafeService.saveCafeImage(members.get(0).getId(), mapId, List.of(mockMultipartFile));
+        reportService.reportCafeImage(members.get(1).getId(), 1L, "inappropriate_content");
+        reportService.reportCafeImage(members.get(2).getId(), 1L, "inappropriate_content");
+
+        CafeImageReportResponse reportResponse = reportService.reportCafeImage(members.get(3).getId(),
+                1L, "inappropriate_content");
+        Optional<CafeImage> reportedCafeImage = cafeImageRepository.findById(1L);
+        Optional<Member> author = memberRepository.findById(1L);
+
+        assertAll(
+                () -> assertThat(reportResponse.getCafeImageReportCount()).isEqualTo(3),
+                () -> assertThat(reportedCafeImage.get().isMasked()).isTrue(),
+                () -> assertThat(reportedCafeImage.get().getIsUsed()).isFalse(),
+                () -> assertThat(author.get().getReportCount()).isEqualTo(1)
+        );
+    }
+
+    @Test
     @DisplayName("11번 이상 신고된 회원은 Status가 INACTIVE로 전환된다")
     void setInactiveCause11timesReportedComment() {
         List<Member> members = new ArrayList<>();
@@ -180,27 +313,5 @@ public class ReportServiceTest {
                 () -> assertThat(commenter.get().getReportCount()).isEqualTo(11),
                 () -> assertThat(commenter.get().getStatus()).isEqualTo(Status.INACTIVE)
         );
-    }
-
-    @Test
-    @DisplayName("탈퇴한 회원이 작성한 코멘트를 신고한다")
-    void reportCommentPostedDeletedMember() {
-        String email1 = "kth990303@naver.com";
-        String email2 = "dlawotn3@naver.com";
-        String mapId = "2143154352323";
-        Member member1 = new Member(email1, "encodePassword", "케이");
-        Member member2 = new Member(email2, "encodePassword", "메리");
-        memberRepository.save(member1);
-        memberRepository.save(member2);
-        Cafe cafe = new Cafe(mapId, "케이카페");
-        cafeRepository.save(cafe);
-        Comment comment = new Comment(cafe, member1, "이 카페 완전 돈 아깝;;");
-        commentRepository.save(comment);
-        memberService.delete(member1.getId());
-
-        CommentReportResponse response = reportService.reportComment(member2.getId(), comment.getId(),
-                "inappropriate_content");
-
-        assertThat(response.getCommentReportCount()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## 개요
- 카페 이미지를 신고할 수 있는 카페 이미지 신고 기능을 추가했습니다.

## 작업사항
- 카페 이미지 신고 기능 구현
  - 카페 이미지에 신고 3회가 들어온 경우, 해당 카페 이미지 노출이 안되도록 마스킹 처리 및 작성자 경고 처리
  - 기존 사용하지 않는 카페 이미지 삭제 배치 작업 로직을 `isUsed == false && isMasked == false`인 경우에만 동작하도록 수정
- 카페 이미지 신고 기능 관련 단위 테스트 및 동시성 테스트 코드 작성

## 주의사항
- 인수테스트를 한다면 테스트 환경에 S3 설정을 넣어줘야 하기 때문에 이미지 관련 API에서는 인수 테스트를 생략했습니다.
- 오타가 있는지 확인해주세요
- 스웨거 혹은 포스트맨으로 동작 확인해주세요
