### PR TITLE
fix: 카페 이미지 등록 response에서 userReportCount 제거

### DIFF
--- a/src/main/java/mocacong/server/dto/response/CafeImageSaveResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CafeImageSaveResponse.java
@@ -9,6 +9,4 @@ import lombok.*;
 public class CafeImageSaveResponse {
 
     private Long id;
-
-    private int userReportCount;
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -1,10 +1,5 @@
 package mocacong.server.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -34,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -320,8 +316,7 @@ public class CafeService {
         for (MultipartFile cafeImage : cafeImages) {
             String imgUrl = awsS3Uploader.uploadImage(cafeImage);
             CafeImage uploadedCafeImage = new CafeImage(imgUrl, true, cafe, member);
-            cafeImageSaveResponses.add(new CafeImageSaveResponse(cafeImageRepository.save(uploadedCafeImage).getId(),
-                    member.getReportCount()));
+            cafeImageSaveResponses.add(new CafeImageSaveResponse(cafeImageRepository.save(uploadedCafeImage).getId()));
         }
         return new CafeImagesSaveResponse(cafeImageSaveResponses);
     }


### PR DESCRIPTION
## 개요
- 카페 이미지 등록 response에 카페 이미지 id 리스트와 userReportCount가 동시에 추가되면서 response가 아래 사진같이 반환되고 있었습니다. 앞으로 refresh Token을 추가할 예정이기에 카페 이미지 등록 response에서 userReportCount를 리스트 뒤에 나오도록 수정하는 것보다 삭제하는 게 맞다고 생각해 해당 필드를 제거했습니다. 
<img width="342" alt="image" src="https://github.com/mocacong/Mocacong-Backend/assets/69844138/de1c15c9-dc48-4051-8ff1-cfec2bf9b067">


## 작업사항
- CafeImageSaveResponse에서 userReportCount 제거

## 주의사항
- 다른 좋은 생각이 있다면 코멘트 남겨주세요
- 해당 PR이 approve된다면 배포 1.0.1에 포함되도록 머지할 예정입니다
