### PR TITLE
fix: 회원 경고 추가 기준 수정

### DIFF
--- a/src/main/java/mocacong/server/domain/CafeImage.java
+++ b/src/main/java/mocacong/server/domain/CafeImage.java
@@ -86,10 +86,6 @@ public class CafeImage extends BaseTime {
         return getReportsCount() >= REPORT_CAFE_IMAGE_THRESHOLD_COUNT;
     }
 
-    public boolean isDeletedAuthor() {
-        return isDeletedMember() && isReportThresholdExceeded();
-    }
-
     public void maskCafeImage() {
         this.isUsed = false;
         this.isMasked = true;

--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -88,10 +88,6 @@ public class Comment extends BaseTime {
         return getReportsCount() >= REPORT_COMMENT_THRESHOLD_COUNT;
     }
 
-    public boolean isDeletedCommenter() {
-        return isDeletedMember() && isReportThresholdExceeded();
-    }
-
     public boolean hasAlreadyReported(Member member) {
         return this.reports.stream()
                 .anyMatch(report -> report.getReporter().equals(member));

--- a/src/main/java/mocacong/server/domain/Member.java
+++ b/src/main/java/mocacong/server/domain/Member.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 public class Member extends BaseTime {
 
     private static final Pattern NICKNAME_REGEX = Pattern.compile("^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]{2,6}$");
-    private static final int REPORT_MEMBER_THRESHOLD_COUNT = 11;
+    private static final int REPORT_MEMBER_THRESHOLD_COUNT = 5;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -43,8 +43,10 @@ public class ReportService {
             createCommentReport(comment, reporter, reportReason);
 
             // 코멘트를 작성한 회원이 탈퇴한 경우
-            if (comment.isDeletedCommenter()) {
-                maskReportedComment(comment);
+            if (comment.isDeletedMember()) {
+                if (comment.isReportThresholdExceeded()) {
+                    maskReportedComment(comment);
+                }
             } else {
                 Member commenter = comment.getMember();
                 validateCommentReporter(reporter, comment);
@@ -99,8 +101,10 @@ public class ReportService {
             createCafeImageReport(cafeImage, reporter, reportReason);
 
             // 카페 이미지를 등록한 회원이 탈퇴한 경우
-            if (cafeImage.isDeletedAuthor()) {
-                cafeImage.maskCafeImage();
+            if (cafeImage.isDeletedMember()) {
+                if (cafeImage.isReportThresholdExceeded()) {
+                    cafeImage.maskCafeImage();
+                }
             } else {
                 Member author = cafeImage.getMember();
                 validateCafeImageReporter(reporter, cafeImage);

--- a/src/main/java/mocacong/server/service/ReportService.java
+++ b/src/main/java/mocacong/server/service/ReportService.java
@@ -48,7 +48,8 @@ public class ReportService {
             } else {
                 Member commenter = comment.getMember();
                 validateCommentReporter(reporter, comment);
-                validateCommentReportThreshold(commenter, comment);
+                validateCommentReportThreshold(comment);
+                commenter.incrementMemberReportCount();
             }
         } catch (DataIntegrityViolationException e) {
             throw new DuplicateReportCommentException();
@@ -76,9 +77,8 @@ public class ReportService {
         }
     }
 
-    private void validateCommentReportThreshold(Member commenter, Comment comment) {
+    private void validateCommentReportThreshold(Comment comment) {
         if (comment.isReportThresholdExceeded()) {
-            commenter.incrementMemberReportCount();
             maskReportedComment(comment);
         }
     }
@@ -104,7 +104,8 @@ public class ReportService {
             } else {
                 Member author = cafeImage.getMember();
                 validateCafeImageReporter(reporter, cafeImage);
-                validateCafeImageReportThreshold(author, cafeImage);
+                validateCafeImageReportThreshold(cafeImage);
+                author.incrementMemberReportCount();
             }
         } catch (DataIntegrityViolationException e) {
             throw new DuplicateReportCafeImageException();
@@ -126,9 +127,8 @@ public class ReportService {
         }
     }
 
-    private void validateCafeImageReportThreshold(Member author, CafeImage cafeImage) {
+    private void validateCafeImageReportThreshold(CafeImage cafeImage) {
         if (cafeImage.isReportThresholdExceeded()) {
-            author.incrementMemberReportCount();
             cafeImage.maskCafeImage();
         }
     }


### PR DESCRIPTION
## 개요
- 댓글/카페 이미지가 마스킹 되어야 회원 경고가 1회씩 추가되던 기존 로직에서 댓글/카페 이미지에 신고가 들어올 때마다 회원 경고가 1회씩 추가되도록 수정했습니다

## 작업사항
- 회원 경고 추가 기준 수정
- 회원 기간 정지 기준을 11회에서 5회로 수정
- 위의 변경사항에 따른 테스트 코드 수정

## 주의사항
- 신고 로직 코드를 간결화할 좋은 방법이 있다면 알려주세요
