### PR TITLE
feat: 비효율적인 로그 제거 및 커넥션 관련 로깅 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,6 @@ spring:
       hibernate:
         create_empty_composites:
           enabled: true
-        show_sql: true
         format_sql: true
   servlet:
     multipart:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,6 @@ spring:
       hibernate:
         create_empty_composites:
           enabled: true
-        show_sql: true
         format_sql: true
   task:
     execution:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,6 +6,15 @@
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%C.%M:%line] - %msg%n"/>
 
+    <!-- SQL 로그 -->
+    <logger name="org.hibernate.SQL" level="DEBUG"/>
+    <!-- SQL 바인딩 파라미터 로그 -->
+    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>
+    <!-- 커넥션 풀 로그 -->
+    <logger name="com.zaxxer.hikari" level="DEBUG"/>
+    <!-- 트랜잭션 매니저 로그 -->
+    <logger name="org.springframework.orm.jpa.JpaTransactionManager" level="DEBUG"/>
+
     <springProfile name="default">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">


### PR DESCRIPTION
## 개요
- 현재 sql 로그가 `hibernate.show_sql = true` 로 인해 `System.out.print` 로 남아 느림. [참고](https://zzang9ha.tistory.com/399)
- 애플리케이션 메서드 관련 로그 외에 추가로 트랜잭션, 커넥션 관련 상황을 로그로 남기고 싶음.

## 작업사항
- `hibernate.show_sql = false`
  - 가독성을 위하여 `format_sql = true` 는 유지 
- `logback-spring.xml` 파일에 트랜잭션, 커넥션, SQL binding parameter 로거 추가

### AS-IS 로그
![image](https://github.com/mocacong/Mocacong-Backend/assets/57135043/afc012a0-619a-4290-9b86-b7015ddf0faa)

- System.out.print 이용한 SQL 로깅
- request DTO, response DTO 외에 DB에 저장되는 정보는 알 수 없음
- 애플리케이션 메서드 정보 외에는 알 수 없음.

### TO-BE 로그
![image](https://github.com/mocacong/Mocacong-Backend/assets/57135043/8952a2c4-3bbe-45bb-9669-de525de9f05e)

- SqlStatementLogger를 이용한 로깅으로 인해 I/O 비용 감소
- request DTO, response DTO 외에 DB 저장 정보 알 수 있음.
- 유휴 커넥션 정보 알 수 있음. 데드락, Connection Timeout Error 방지에 용이하리라 기대됨.
- 트랜잭션 시작과 끝을 알 수 있음. 트랜잭션 관리 생산성 증가가 기대됨.

## 주의사항
- 머지할 때 `application-prod.yml` 파일에서 `hibernate.show_sql = true`를 제거해주셔야 운영서버에도 적용이 됩니다.
- 마스킹 처리가 안되는 부분 있으면 리뷰 부탁드립니다. (마스킹 관련 이슈 있으면 binding-parameter logger는 제거할 수도 있습니다.)