### PR TITLE
feat: 댓글 조회 시 commentLike의 수 함께 조회하도록 구현

### DIFF
--- a/src/main/java/mocacong/server/domain/Comment.java
+++ b/src/main/java/mocacong/server/domain/Comment.java
@@ -38,6 +38,9 @@ public class Comment extends BaseTime {
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Report> reports = new ArrayList<>();
 
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommentLike> commentLikes = new ArrayList<>();
+
     @Column(name = "is_masked")
     private boolean isMasked;
 
@@ -112,4 +115,9 @@ public class Comment extends BaseTime {
     public void updateIsMasked(boolean isMasked) {
         this.isMasked= isMasked;
     }
+
+    public int getLikeCounts() {
+        return commentLikes.size();
+    }
+
 }

--- a/src/main/java/mocacong/server/dto/response/CommentResponse.java
+++ b/src/main/java/mocacong/server/dto/response/CommentResponse.java
@@ -12,5 +12,6 @@ public class CommentResponse {
     private String imgUrl;
     private String nickname;
     private String content;
+    private int likeCount;
     private Boolean isMe;
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
+
 import lombok.RequiredArgsConstructor;
 import mocacong.server.domain.*;
 import mocacong.server.domain.cafedetail.*;
@@ -123,10 +124,10 @@ public class CafeService {
                 .map(comment -> {
                     if (comment.isWrittenByMember(member)) {
                         return new CommentResponse(comment.getId(), member.getImgUrl(), member.getNickname(),
-                                comment.getContent(), true);
+                                comment.getContent(), comment.getLikeCounts(), true);
                     } else {
                         return new CommentResponse(comment.getId(), comment.getWriterImgUrl(),
-                                comment.getWriterNickname(), comment.getContent(), false);
+                                comment.getWriterNickname(), comment.getContent(), comment.getLikeCounts(), false);
                     }
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/mocacong/server/service/CommentService.java
+++ b/src/main/java/mocacong/server/service/CommentService.java
@@ -81,9 +81,9 @@ public class CommentService {
         return comments.stream()
                 .map(comment -> {
                     if (comment.isWrittenByMember(member)) {
-                        return new CommentResponse(comment.getId(), member.getImgUrl(), member.getNickname(), comment.getContent(), true);
+                        return new CommentResponse(comment.getId(), member.getImgUrl(), member.getNickname(), comment.getContent(), comment.getLikeCounts(), true);
                     } else {
-                        return new CommentResponse(comment.getId(), comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), false);
+                        return new CommentResponse(comment.getId(), comment.getWriterImgUrl(), comment.getWriterNickname(), comment.getContent(), comment.getLikeCounts(), false);
                     }
                 })
                 .collect(Collectors.toList());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,7 @@ spring:
           enabled: true
         show_sql: true
         format_sql: true
+        default_batch_fetch_size: 100
   servlet:
     multipart:
       max-file-size: 10MB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
           enabled: true
         show_sql: true
         format_sql: true
+        default_batch_fetch_size: 100
   task:
     execution:
       pool:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,7 @@ spring:
           enabled: true
         show_sql: true
         format_sql: true
+        default_batch_fetch_size: 100
   redis:
     host: localhost
     port: 16379


### PR DESCRIPTION
## 개요
- 댓글 조회 시 commentLike의 수를 함께 조회하도록 구현했습니다.

## 작업사항
- N+1 문제를 해결하기 위해 default_batch_fetch_size 옵션을 더해 1+1의 쿼리가 나가도록 했습니다.
- comment N개가 있어도 OneToMany관계의 CommentLike 쿼리가 1번만 나갑니다.

### 쿼리 실행결과
<img width="469" alt="image" src="https://github.com/mocacong/Mocacong-Backend/assets/76640167/f9520b64-1a4e-4b73-821c-029df77aecfd">


## 주의사항
- application-prod.yml 도 바꿔야합니다. approve되면 merge하기 전에 바꾸겠습니다.
- 컬렉션 패치 조인 시 N+1 문제를 극복하는 더 좋은 방법이 있다면 말씀해주세요.
