### PR TITLE
feat: 멤버 논리적 삭제 구현

### DIFF
--- a/src/main/java/mocacong/server/config/BatchConfig.java
+++ b/src/main/java/mocacong/server/config/BatchConfig.java
@@ -26,4 +26,9 @@ public class BatchConfig {
     public void activateInactivateMembers() {
         memberService.setActiveAfter60days();
     }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 자정에 실행
+    public void deleteLogicallyDeletedMember() {
+        memberService.deleteLogicallyDeletedMemberAfter30Days();
+    }
 }

--- a/src/main/java/mocacong/server/domain/DeletedMember.java
+++ b/src/main/java/mocacong/server/domain/DeletedMember.java
@@ -1,0 +1,70 @@
+package mocacong.server.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "deleted_member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeletedMember extends BaseTime{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "deleted_member_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "nickname", unique = true)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform")
+    private Platform platform;
+
+    @Column(name = "platform_id")
+    private String platformId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private Status status;
+
+    @Column(name = "report_count")
+    private int reportCount;
+
+    private DeletedMember(String email, String password, String nickname, Platform platform, String platformId, Status status, int reportCount) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.platform = platform;
+        this.platformId = platformId;
+        this.status = status;
+        this.reportCount = reportCount;
+    }
+
+    public DeletedMember(String email, String password, String nickname) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
+    public static DeletedMember from(Member member) {
+        return new DeletedMember(
+                member.getEmail(),
+                member.getPassword(),
+                member.getNickname(),
+                member.getPlatform(),
+                member.getPlatformId(),
+                member.getStatus(),
+                member.getReportCount()
+        );
+    }
+}

--- a/src/main/java/mocacong/server/repository/DeletedMemberRepository.java
+++ b/src/main/java/mocacong/server/repository/DeletedMemberRepository.java
@@ -1,0 +1,14 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.DeletedMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Date;
+
+public interface DeletedMemberRepository extends JpaRepository<DeletedMember, Long> {
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from DeletedMember dm where dm.createdTime <= :thresholdDateTime")
+    void deleteDeletedMemberByCreatedTime(Date thresholdDateTime);
+}

--- a/src/test/java/mocacong/server/repository/DeletedMemberRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/DeletedMemberRepositoryTest.java
@@ -1,0 +1,44 @@
+package mocacong.server.repository;
+
+import mocacong.server.domain.DeletedMember;
+import mocacong.server.domain.Member;
+import mocacong.server.domain.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.persistence.EntityManager;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@RepositoryTest
+class DeletedMemberRepositoryTest {
+
+    @Autowired
+    private DeletedMemberRepository deletedMemberRepository;
+
+    @Test
+    @DisplayName("회원이 삭제된지 thresholdDateTime만큼 지났으면 모두 삭제한다.")
+    void deleteDeletedMemberByCreatedTime() {
+        DeletedMember member1 = new DeletedMember("dlawotn3@naver.com", "password1", "mery");
+        DeletedMember member2 = new DeletedMember("dlawotn2@naver.com", "password2", "케이");
+        deletedMemberRepository.save(member1);
+        deletedMemberRepository.save(member2);
+
+        LocalDate thresholdDateTime = LocalDate.now().plusDays(1);
+        Instant instant = thresholdDateTime.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Date thresholdDate = Date.from(instant);
+        deletedMemberRepository.deleteDeletedMemberByCreatedTime(thresholdDate);
+
+
+        List<DeletedMember> actual = deletedMemberRepository.findAll();
+
+        assertThat(actual).hasSize(0);
+    }
+}

--- a/src/test/java/mocacong/server/repository/MemberRepositoryTest.java
+++ b/src/test/java/mocacong/server/repository/MemberRepositoryTest.java
@@ -16,7 +16,7 @@ import java.util.Date;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@DataJpaTest
+@RepositoryTest
 class MemberRepositoryTest {
 
     @Autowired
@@ -49,7 +49,7 @@ class MemberRepositoryTest {
         memberRepository.save(member1);
         memberRepository.save(member2);
 
-        LocalDate thresholdDateTime = LocalDate.now();
+        LocalDate thresholdDateTime = LocalDate.now().plusDays(1);
         Instant instant = thresholdDateTime.atStartOfDay(ZoneId.systemDefault()).toInstant();
         Date thresholdDate = Date.from(instant);
         Status oldStatus = Status.INACTIVE;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,7 +10,6 @@ spring:
       hibernate:
         create_empty_composites:
           enabled: true
-        show_sql: true
         format_sql: true
   redis:
     host: localhost

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,6 +11,7 @@ spring:
         create_empty_composites:
           enabled: true
         format_sql: true
+        show_sql: false
   redis:
     host: localhost
     port: 16379


### PR DESCRIPTION
## 개요
- 기존의 멤버 삭제는 물리적으로 데이터 베이스에서 삭제하는 작업이었다면, 이제 논리적으로 30일 간 멤버 데이터를 유지하고 삭제합니다. 

## 작업사항
### 자잘한 버그 수정
- MemberRepositoryTest가 DataJpaTest 어노테이션을 사용하고 있어 Member의 created_at이 null로 지정되어있어 `bulkUpdateStatus`가 정상적으로 진행되지 못했습니다. 이에 어노테이션을 커스텀 RespositoryTest로 변경하고 테스트 로직을 일부 수정했습니다.
- test의 application.yml의 show_sql 속성을 false로 변경해 sql이 두번 중복해서 보이는 문제를 해결했습니다.

### 논리적 삭제 구현
- Member 삭제 시 Member 테이블에서는 여전히 물리적으로 삭제하지만, 유저의 정보를 일부 DeletedMember 테이블에 저장합니다.
  - 저장되는 정보는 복구 가능성을 배제하고 연관관계 정보를 제외한 이외의 모든 정보로 설정했습니다.
- Scheduled를 사용해 자정에 deletedMember 테이블에서 30일 이상 된 유저를 삭제합니다.

## 주의사항
- 스케줄링은 자정마다 `createdTime` 을 기준으로 30일이 지난 회원을 물리적으로 삭제하는 작업을 수행합니다. 로컬에서 테스트하려면 BatchConfig의 시간을 수정해주세요.
- `createdTime`과 `modifiedTime` 중에 고민 후 생성된 날짜 기준이니 `createdTime`으로 결정했는데, `modifiedTime`이 더 나은 것 같다면 말씀해주세요.
- `DeletedMember`테이블은 insert와 delete 작업이 주로 일어나는 테이블이기 때문에 인덱스 설정이 치명적일 수 있다고 판단해 유니크 조건을 제외했습니다. insert 작업이 지금은 Member 테이블에서 옮기기만 있기 때문에 유니크 조건은 없어도 괜찮다고 판단했는데, 혹시 있는게 더 나은 것 같다면 말씀해주세요.