### PR TITLE
feat: 마이페이지 회원 작성 댓글 목록 조회 시, 카페 별로 필터링되도록 구현

### DIFF
--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -107,4 +107,21 @@ public class Cafe extends BaseTime {
     public void addReview(Review review) {
         this.reviews.add(review);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Cafe cafe = (Cafe) o;
+        return Objects.equals(mapId, cafe.mapId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mapId);
+    }
 }

--- a/src/main/java/mocacong/server/domain/Cafe.java
+++ b/src/main/java/mocacong/server/domain/Cafe.java
@@ -113,7 +113,7 @@ public class Cafe extends BaseTime {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Cafe)) {
             return false;
         }
         Cafe cafe = (Cafe) o;

--- a/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
@@ -1,6 +1,10 @@
 package mocacong.server.dto.response;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.*;
+import mocacong.server.domain.Cafe;
+import mocacong.server.domain.Comment;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,5 +15,12 @@ public class MyCommentCafeResponse {
     private String mapId;
     private String name;
     private String studyType;
-    private String comment;
+    private List<String> comments;
+
+    public static MyCommentCafeResponse of(Cafe cafe, List<Comment> comments) {
+        List<String> contents = comments.stream()
+                .map(Comment::getContent)
+                .collect(Collectors.toList());
+        return new MyCommentCafeResponse(cafe.getMapId(), cafe.getName(), cafe.getStudyType(), contents);
+    }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -179,7 +179,7 @@ public class CafeService {
                         MyCommentCafeResponse.of(commentsGroupingByCafe.getKey(), commentsGroupingByCafe.getValue()))
                 .collect(Collectors.toList());
 
-        int toIndex = Math.min((page + 1) * count - 1, responses.size());
+        int toIndex = Math.min((page + 1) * count - 1, responses.size() - 1);
         int fromIndex = Math.min(toIndex, page * count);
 
         return new MyCommentCafesResponse(findIsEnd(page, count, responses), responses.subList(fromIndex, toIndex));

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -179,7 +179,7 @@ public class CafeService {
                         MyCommentCafeResponse.of(commentsGroupingByCafe.getKey(), commentsGroupingByCafe.getValue()))
                 .collect(Collectors.toList());
 
-        int toIndex = Math.min((page + 1) * count - 1, responses.size() - 1);
+        int toIndex = Math.min((page + 1) * count, responses.size());
         int fromIndex = Math.min(toIndex, page * count);
 
         return new MyCommentCafesResponse(findIsEnd(page, count, responses), responses.subList(fromIndex, toIndex));

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -179,7 +179,10 @@ public class CafeService {
                         MyCommentCafeResponse.of(commentsGroupingByCafe.getKey(), commentsGroupingByCafe.getValue()))
                 .collect(Collectors.toList());
 
-        return new MyCommentCafesResponse(findIsEnd(page, count, comments), responses);
+        int toIndex = Math.min((page + 1) * count - 1, responses.size());
+        int fromIndex = Math.min(toIndex, page * count);
+
+        return new MyCommentCafesResponse(findIsEnd(page, count, responses), responses.subList(fromIndex, toIndex));
     }
 
     /*
@@ -187,13 +190,11 @@ public class CafeService {
      *   comments 를 Slice 로 받아온 후 grouping 할 경우 페이지네이션 시 count 보다 적은 데이터 수가 반환될 수 있음.
      *   따라서 comments 전체를 받아온 후, mapId로 grouping 해야 한 후 페이지네이션해야 하므로 isLast 여부를 jpa Slice 로 구할 수 없음.
      *
-     *   grouping 한 결과를 페이지네이션하면 카페 종류 수만큼 페이지네이션되므로, comments 전체를 바탕으로 페이지네이션하여 isEnd 를 찾음.
-     *
-     *   또한, 현재 mapId가 동일하다면 댓글 전체를 리스트로 반환하므로 API 스펙 협의 및 로직 개선 필요.
+     *   또한, 현재 mapId가 동일한 카페의 댓글 전체를 리스트로 반환하므로 API 스펙 협의 및 로직 개선 필요.
      */
-    private boolean findIsEnd(int page, int count, List<Comment> comments) {
+    private boolean findIsEnd(int page, int count, List<MyCommentCafeResponse> responses) {
         int lastDataIndex = (page + 1) * count - 1;
-        return comments.size() - 1 <= lastDataIndex;
+        return responses.size() - 1 <= lastDataIndex;
     }
 
     @CacheEvict(key = "#mapId", value = "cafePreviewCache")

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -169,17 +169,31 @@ public class CafeService {
     public MyCommentCafesResponse findMyCommentCafes(Long memberId, int page, int count) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
-        Slice<Comment> comments = commentRepository.findByMemberId(member.getId(), PageRequest.of(page, count));
+        List<Comment> comments = commentRepository.findAllByMemberId(member.getId());
 
         List<MyCommentCafeResponse> responses = comments.stream()
-                .map(comment -> new MyCommentCafeResponse(
-                        comment.getCafe().getMapId(),
-                        comment.getCafe().getName(),
-                        comment.getCafe().getStudyType(),
-                        comment.getContent()
-                ))
+                .collect(Collectors.groupingByConcurrent(Comment::getCafe))
+                .entrySet()
+                .stream()
+                .map(commentsGroupingByCafe ->
+                        MyCommentCafeResponse.of(commentsGroupingByCafe.getKey(), commentsGroupingByCafe.getValue()))
                 .collect(Collectors.toList());
-        return new MyCommentCafesResponse(comments.isLast(), responses);
+
+        return new MyCommentCafesResponse(findIsEnd(page, count, comments), responses);
+    }
+
+    /*
+     *   TODO (23.11.11.)
+     *   comments 를 Slice 로 받아온 후 grouping 할 경우 페이지네이션 시 count 보다 적은 데이터 수가 반환될 수 있음.
+     *   따라서 comments 전체를 받아온 후, mapId로 grouping 해야 한 후 페이지네이션해야 하므로 isLast 여부를 jpa Slice 로 구할 수 없음.
+     *
+     *   grouping 한 결과를 페이지네이션하면 카페 종류 수만큼 페이지네이션되므로, comments 전체를 바탕으로 페이지네이션하여 isEnd 를 찾음.
+     *
+     *   또한, 현재 mapId가 동일하다면 댓글 전체를 리스트로 반환하므로 API 스펙 협의 및 로직 개선 필요.
+     */
+    private boolean findIsEnd(int page, int count, List<Comment> comments) {
+        int lastDataIndex = (page + 1) * count - 1;
+        return comments.size() - 1 <= lastDataIndex;
     }
 
     @CacheEvict(key = "#mapId", value = "cafePreviewCache")

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -397,7 +397,10 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .extract()
                 .as(MyCommentCafesResponse.class);
 
-        assertThat(response.getCafes()).hasSize(3);
+        assertAll(
+                ()->assertThat(response.getCafes()).hasSize(2),
+                ()->assertThat(response.getCafes().get(0).getComments()).containsExactlyInAnyOrder("댓글3")
+        );
     }
 
     @Test

--- a/src/test/java/mocacong/server/domain/CafeTest.java
+++ b/src/test/java/mocacong/server/domain/CafeTest.java
@@ -9,6 +9,16 @@ import org.junit.jupiter.api.Test;
 class CafeTest {
 
     @Test
+    @DisplayName("카페 mapId가 같으면 동일 카페로 간주한다")
+    void equals() {
+        String cafeMapId = "12345";
+        Cafe cafe1 = new Cafe(cafeMapId, "케이카페");
+        Cafe cafe2 = new Cafe(cafeMapId, "이름만다른케이카페");
+
+        assertThat(cafe1.equals(cafe2)).isTrue();
+    }
+
+    @Test
     @DisplayName("카페에 평점을 기여한 사람이 없으면 0점을 반환한다")
     void findScoreWithNoReviews() {
         Cafe cafe = new Cafe("1", "케이카페");

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -487,14 +487,14 @@ class CafeServiceTest {
         commentRepository.save(new Comment(cafe2, member1, "댓글3"));
         commentRepository.save(new Comment(cafe2, member2, "댓글4"));
 
-        MyCommentCafesResponse actual = cafeService.findMyCommentCafes(member1.getId(), 0, 5);
+        MyCommentCafesResponse actual = cafeService.findMyCommentCafes(member1.getId(), 0, 3);
 
         assertAll(
                 () -> assertThat(actual.getIsEnd()).isTrue(),
-                () -> assertThat(actual.getCafes()).hasSize(3),
-                () -> assertThat(actual.getCafes().get(0).getComment()).isEqualTo("댓글1"),
-                () -> assertThat(actual.getCafes().get(1).getComment()).isEqualTo("댓글2"),
-                () -> assertThat(actual.getCafes().get(2).getComment()).isEqualTo("댓글3")
+                // 댓글 수는 3개지만, 카페 종류가 2종류이므로 response size는 2개
+                () -> assertThat(actual.getCafes()).hasSize(2),
+                () -> assertThat(actual.getCafes().get(0).getComments()).containsExactlyInAnyOrder("댓글1", "댓글2"),
+                () -> assertThat(actual.getCafes().get(1).getComments()).containsExactlyInAnyOrder("댓글3")
         );
     }
 


### PR DESCRIPTION
## 개요
- 현재 마이페이지에서 회원이 작성한 댓글 목록을 조회할 경우, 별다른 정렬 순서 없이 댓글 목록을 보여주고 있습니다.
- 이에 따라, 카페 별로 필터링하여 조회할 수 있도록 API Spec이 아래와 같이 댓글 목록을 list로 받도록 변경됐습니다.
<img width="212" alt="image" src="https://github.com/mocacong/Mocacong-Backend/assets/57135043/565f297d-1782-4788-913a-a5035832cde0">


## 작업사항
- 필터링되도록 작업.

## 주의사항
- TODO 에도 적어놨지만, 댓글 목록을 카페 별로 필터링하기 위해 DB에서 전체를 find하도록 작업했습니다. 
  - 카페 종류 수에 따라 페이지네이션할지, 댓글 개수에 따라 페이지네이션할지 협의가 필요합니다. 
  - 댓글 개수에 따라 페이지네이션한다면? 상위 DTO(`List<MyCommentCafeResponse`)의 사이즈는 고려하지 않고, 하위 DTO (`List<String> comments`)의 사이즈는 count 개수만큼이 되도록 해야 하는데, 이 역시 Slice로 하기 힘들어보였습니다. Slice로 할 경우 상위 DTO(`List<MyCommentCafeResponse`) 개수만큼 슬라이싱되기 때문.
  - 따라서 우선은 카페 종류 수대로 페이지네이션했습니다. (카페 25군데, 댓글 80개 작성했을 경우 -> page(0, 5) 시에 카페 5군데에 작성한 댓글 전체를 보여줌.)
    - 관련 스레드: https://mocacong.slack.com/archives/C04SGLLG2MC/p1699671506353769?thread_ts=1699615459.688409&cid=C04SGLLG2MC
  
- DB에서 native query로 new map으로 필터링처리를 하게 해버리게 쿼리를 짜보려 했는데, map은 중복 key 허용을 안해서 어려웠고 또  querydsl 적용하지 않고는 매우 복잡할 거 같아 애플리케이션 단에서 작업했어요.

- 더 좋은 방안 있으면 리뷰 부탁드려요!
