### PR TITLE
style: CafeRegisterRequest에서의 id 필드명 변경

### DIFF
--- a/src/main/java/mocacong/server/dto/request/CafeRegisterRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeRegisterRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotBlank;
 @ToString
 public class CafeRegisterRequest {
     @NotBlank(message = "1012:공백일 수 없습니다.")
-    private String id;
+    private String mapId;
 
     @NotBlank(message = "1012:공백일 수 없습니다.")
     private String name;

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -54,13 +54,13 @@ public class CafeService {
 
     @Transactional
     public void save(CafeRegisterRequest request) {
-        Cafe cafe = new Cafe(request.getId(), request.getName(), request.getRoadAddress(), request.getPhoneNumber());
+        Cafe cafe = new Cafe(request.getMapId(), request.getName(), request.getRoadAddress(), request.getPhoneNumber());
 
 
-        Optional<Cafe> cafeOptional = cafeRepository.findByMapId(request.getId());
+        Optional<Cafe> cafeOptional = cafeRepository.findByMapId(request.getMapId());
 
         try {
-            cafeRepository.findByMapId(request.getId())
+            cafeRepository.findByMapId(request.getMapId())
                     .ifPresentOrElse(
                             existedCafe -> existedCafe.updateCafeRoadAddress(request.getRoadAddress()),
                             () -> cafeRepository.save(cafe)


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 카페 등록 시, 사용하는 RequestBody의 id 필드를 mapId로 필드명을 변경했습니다.

## 작업사항
- CafeRegisterRequest에서의 id 필드명을 mapId로 변경

## 주의사항
- 추가적으로 변경되어야 할 부분이 있는지 확인해주세요.