### PR TITLE
fix: 카페 이미지 3개 초과하여 저장 시 예외 반환하는 로직 버그 수정

### DIFF
--- a/src/main/java/mocacong/server/exception/badrequest/ExceedCageImagesTotalCountsException.java
+++ b/src/main/java/mocacong/server/exception/badrequest/ExceedCageImagesTotalCountsException.java
@@ -2,6 +2,6 @@ package mocacong.server.exception.badrequest;
 
 public class ExceedCageImagesTotalCountsException extends BadRequestException{
     public ExceedCageImagesTotalCountsException() {
-        super("카페 이미지는 3개 이상 등록하실 수 없습니다.", 2008);
+        super("카페 이미지는 4개 이상 등록하실 수 없습니다.", 2008);
     }
 }

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -350,11 +350,15 @@ public class CafeService {
     private void validateOwnedCafeImagesCounts(Cafe cafe, Member member, List<MultipartFile> requestCafeImages) {
         List<CafeImage> currentOwnedCafeImages = cafe.getCafeImages()
                 .stream()
-                .filter(cafeImage -> cafeImage.isOwned(member) && cafeImage.getIsUsed())
+                .filter(cafeImage -> isOwnedAndUsed(cafeImage, member))
                 .collect(Collectors.toList());
         if (currentOwnedCafeImages.size() + requestCafeImages.size() > CAFE_IMAGES_PER_MEMBER_LIMIT_COUNTS) {
             throw new ExceedCageImagesTotalCountsException();
         }
+    }
+
+    private boolean isOwnedAndUsed(CafeImage cafeImage, Member member) {
+        return cafeImage.isOwned(member) && cafeImage.getIsUsed();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -350,7 +350,7 @@ public class CafeService {
     private void validateOwnedCafeImagesCounts(Cafe cafe, Member member, List<MultipartFile> requestCafeImages) {
         List<CafeImage> currentOwnedCafeImages = cafe.getCafeImages()
                 .stream()
-                .filter(cafeImage -> cafeImage.isOwned(member))
+                .filter(cafeImage -> cafeImage.isOwned(member) && cafeImage.getIsUsed())
                 .collect(Collectors.toList());
         if (currentOwnedCafeImages.size() + requestCafeImages.size() > CAFE_IMAGES_PER_MEMBER_LIMIT_COUNTS) {
             throw new ExceedCageImagesTotalCountsException();


### PR DESCRIPTION
## 개요
- 한 카페에 대해 사용자가 4개 이상의 카페 이미지를 등록할 시, 예외를 반환해야 합니다. 기존 로직에서는 DB에서 카페 이미지가 4개 이상있는지 확인하는데 이 과정에서 `isUsed==false`인 이미지(이미지 삭제 스케줄링에 의해 삭제되지 않은 이미지)까지 카운트합니다. 현재 `isUsed==true`인 이미지만 카운트하도록 로직을 수정했습니다.

## 작업사항
- 카페 이미지 3개 초과하는지 판단하는 로직 수정

## 주의사항
- 카페 이미지를 3개 초과하여 저장할 시, 예외를 반환하는 테스트 코드가 이미 존재하고 `isUsed`까지 판별하는지 확인하는 테스트 코드가 추가로 필요하지 않다고 생각하여 생략했습니다.
- API 테스트를 통해 제대로 동작하는 지 한 번 더 확인해주세요.