### PR TITLE
fix: MyCommentCafeResponse에서의 comments 필드명 변경

### DIFF
--- a/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
+++ b/src/main/java/mocacong/server/dto/response/MyCommentCafeResponse.java
@@ -1,12 +1,11 @@
 package mocacong.server.dto.response;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import lombok.*;
-
 import mocacong.server.domain.Cafe;
 import mocacong.server.domain.Comment;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,7 +17,7 @@ public class MyCommentCafeResponse {
     private String name;
     private String studyType;
     private String roadAddress;
-    private List<String> comments;
+    private List<String> commentContents;
 
     public static MyCommentCafeResponse of(Cafe cafe, List<Comment> comments) {
         List<String> contents = comments.stream()

--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -182,7 +182,6 @@ public class CafeService {
         List<Comment> comments = commentRepository.findAllByMemberId(member.getId());
 
         List<MyCommentCafeResponse> responses = comments.stream()
-//                .map(MyCommentCafeResponse::from)
                 .collect(Collectors.groupingByConcurrent(Comment::getCafe))
                 .entrySet()
                 .stream()

--- a/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/mocacong/server/acceptance/MemberAcceptanceTest.java
@@ -1,26 +1,26 @@
 package mocacong.server.acceptance;
 
 import io.restassured.RestAssured;
-import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import mocacong.server.domain.Platform;
-import mocacong.server.domain.cafedetail.StudyType;
 import mocacong.server.dto.request.*;
 import mocacong.server.dto.response.*;
 import mocacong.server.security.auth.OAuthPlatformMemberResponse;
 import mocacong.server.security.auth.apple.AppleOAuthUserProvider;
 import mocacong.server.support.AwsSESSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static mocacong.server.acceptance.AcceptanceFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -399,7 +399,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         assertAll(
                 ()->assertThat(response.getCafes()).hasSize(2),
-                ()->assertThat(response.getCafes().get(0).getComments()).containsExactlyInAnyOrder("댓글3")
+                ()->assertThat(response.getCafes().get(0).getCommentContents()).containsExactlyInAnyOrder("댓글3")
         );
     }
 

--- a/src/test/java/mocacong/server/service/CafeServiceTest.java
+++ b/src/test/java/mocacong/server/service/CafeServiceTest.java
@@ -490,8 +490,8 @@ class CafeServiceTest {
                 () -> assertThat(actual.getIsEnd()).isTrue(),
                 // 댓글 수는 3개지만, 카페 종류가 2종류이므로 response size는 2개
                 () -> assertThat(actual.getCafes()).hasSize(2),
-                () -> assertThat(actual.getCafes().get(0).getComments()).containsExactlyInAnyOrder("댓글1", "댓글2"),
-                () -> assertThat(actual.getCafes().get(1).getComments()).containsExactlyInAnyOrder("댓글3")
+                () -> assertThat(actual.getCafes().get(0).getCommentContents()).containsExactlyInAnyOrder("댓글1", "댓글2"),
+                () -> assertThat(actual.getCafes().get(1).getCommentContents()).containsExactlyInAnyOrder("댓글3")
         );
     }
 


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 내가 남긴 댓글 조회 DTO의 comments 필드명을 commentContents로 수정했습니다.

## 작업사항
- 내가 남긴 댓글 조회 DTO comments 필드명 수정

## 주의사항
- 추가적으로 수정해야할 필드가 있는지 확인해주세요.
