### PR TITLE
feat: CafeRegisterRequest DTO의 roadAddress 및 phoneNumber 필드 nullable로 수정

### DIFF
--- a/src/main/java/mocacong/server/dto/request/CafeRegisterRequest.java
+++ b/src/main/java/mocacong/server/dto/request/CafeRegisterRequest.java
@@ -15,9 +15,7 @@ public class CafeRegisterRequest {
     @NotBlank(message = "1012:공백일 수 없습니다.")
     private String name;
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
     private String roadAddress;
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
     private String phoneNumber;
 }


### PR DESCRIPTION
## 개요
- 프론트의 요청으로 카페 등록 요청 시, 카페 주소와 카페 번호의 경우 null도 가능하도록 수정하였습니다.

## 작업사항
- CafeRegisterRequest DTO의 roadAddress 및 phoneNumber 필드 nullable로 수정

## 주의사항
- 추가적으로 수정해야 할 부분이 있는지 확인해주세요.
