### PR TITLE
fix: 도로명주소와 전화번호가 존재하지 않는 카페들을 조회할 시, 500 에러 뜨는 이슈 해결

### DIFF
--- a/src/main/java/mocacong/server/service/CafeService.java
+++ b/src/main/java/mocacong/server/service/CafeService.java
@@ -84,8 +84,8 @@ public class CafeService {
                 favoriteId != null,
                 favoriteId,
                 cafe.getName(),
-                cafe.getRoadAddress(),
-                cafe.getPhoneNumber(),
+                cafe.getRoadAddress() != null ? cafe.getRoadAddress() : null,
+                cafe.getPhoneNumber() != null ? cafe.getPhoneNumber() : null,
                 cafe.findAverageScore(),
                 scoreByLoginUser != null ? scoreByLoginUser.getScore() : null,
                 cafeDetail.getStudyTypeValue(),
@@ -114,7 +114,7 @@ public class CafeService {
                 .orElse(null);
         return new PreviewCafeResponse(
                 cafe.getName(),
-                cafe.getRoadAddress(),
+                cafe.getRoadAddress() != null ? cafe.getRoadAddress() : null,
                 favoriteId != null,
                 cafe.findAverageScore(),
                 cafeDetail.getStudyTypeValue(),
@@ -159,7 +159,9 @@ public class CafeService {
         List<MyFavoriteCafeResponse> responses = myFavoriteCafes
                 .getContent()
                 .stream()
-                .map(cafe -> new MyFavoriteCafeResponse(cafe.getMapId(), cafe.getName(), cafe.getStudyType(), cafe.findAverageScore(), cafe.getRoadAddress()))
+                .map(cafe -> new MyFavoriteCafeResponse(
+                        cafe.getMapId(), cafe.getName(), cafe.getStudyType(), cafe.findAverageScore(),
+                        cafe.getRoadAddress() != null ? cafe.getRoadAddress() : null))
                 .collect(Collectors.toList());
         return new MyFavoriteCafesResponse(myFavoriteCafes.isLast(), responses);
     }


### PR DESCRIPTION
## 개요
- 카페의 도로명주소와 전화번호가 null 허용이 되면서 카페들을 조회할 때, 도로명주소 혹은 전화번호가 없는 카페의 경우, NPE가 발생합니다. 응답을 반환할 때, null인지 체크를 하고 null이라면 null 그대로 반환하도록 수정했습니다.

## 작업사항
- 카페 응답 반환할 시, 도로명주소와 전화번호에 대해 null 체크 로직 추가

## 주의사항
- 도로명주소와 전화번호 필드가 존재하는 응답들에 대해 다 처리를 했는데 빠진 곳이 있는지 확인해주세요
