### PR TITLE
fix: Token 객체 TTL 시간 단위 이슈 해결

### DIFF
--- a/src/main/java/mocacong/server/service/RefreshTokenService.java
+++ b/src/main/java/mocacong/server/service/RefreshTokenService.java
@@ -35,7 +35,7 @@ public class RefreshTokenService {
                 .expiration(validityRefreshTokenInMilliseconds) // 리프레시 토큰 유효기간
                 .build();
 
-        redisTemplate.opsForValue().set(refreshToken, token, validityRefreshTokenInMilliseconds, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(refreshToken, token, validityRefreshTokenInMilliseconds, TimeUnit.MILLISECONDS);
     }
 
     public Member getMemberFromRefreshToken(String refreshToken) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
 
 security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttesttest
-  access-key-expire-length: 10000
+  access-key-expire-length: 864000
   refresh-key-expire-length: 1728000
 
 springdoc:


### PR DESCRIPTION
## 개요
- 토큰 객체의 TTL은 MILLISECONDS로 설정되어 있음에도 불구하고, redisTemplate을 통해 레디스에 저장할 때 expiration 단위가 SECONDS로 설정되어 있음을 확인했습니다. 로컬에서 검토한 결과, 토큰 객체 자체는 MILLISECONDS로 ttl이 설정되어도 레디스에 저장될 때는 초 단위로 저장됨을 확인하여 이 부분을 수정했습니다.

## 작업사항
- expiration 시간 단위를 밀리세컨드 단위로 수정

## 주의사항
- 추가적으로 수정해야할 부분이 있는지 확인해주세요
