### PR TITLE
feat: 코드 정적 분석을 위한 Jacoco 및 SonarCloud 도입

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -10,6 +10,9 @@ on:
       - main
       - develop
 
+env:
+  COVERAGE_PERCENT: 70
+
 jobs:
   test:
     name: Code Quality Check
@@ -52,3 +55,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info --stacktrace
+
+      - name: Upload Test Result
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: $({ always() })
+        with:
+          files: build/test-results/**/*.xml
+
+      - name: Upload Test Coverage Result to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.3
+        with:
+          paths: ${{ github.workspace }}/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: ${{ env.COVERAGE_PERCENT }}
+          debug-mode: false
+          title: Code Coverage
+          update-comment: true

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -11,7 +11,8 @@ on:
       - develop
 
 jobs:
-  build:
+  test:
+    name: Code Quality Check
     runs-on: ubuntu-latest
 
     steps:
@@ -26,5 +27,28 @@ jobs:
       - name: Grant execute permisson for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew clean build
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar --info --stacktrace

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -40,13 +40,6 @@ jobs:
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -10,9 +10,6 @@ on:
       - main
       - develop
 
-env:
-  COVERAGE_PERCENT: 70
-
 jobs:
   test:
     name: Code Quality Check
@@ -55,20 +52,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info --stacktrace
-
-      - name: Upload Test Result
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: ${{ always() }}
-        with:
-          files: build/test-results/**/*.xml
-
-      - name: Upload Test Coverage Result to PR
-        id: jacoco
-        uses: madrapps/jacoco-report@v1.3
-        with:
-          paths: ${{ github.workspace }}/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: ${{ env.COVERAGE_PERCENT }}
-          debug-mode: false
-          title: Code Coverage
-          update-comment: true

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload Test Result
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: $({ always() })
+        if: ${{ always() }}
         with:
           files: build/test-results/**/*.xml
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ sonar {
         property 'sonar.sourceEncoding', 'UTF-8'
         property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**, **/dto/**, ' +
                 '**/exception/**, **/security/**, **/support/**, **/Q*.java'
-        property 'sonar.test.inclusions', '**/*Test*.java'
+        property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**,' +
+        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**, **/dto/**' +
                 '**/exception/**, **/security/**, **/support/**, **/Q*.java'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
@@ -94,6 +94,7 @@ jacocoTestReport {
                                     "**/*Application*",
                                     "**/*Controller*",
                                     "**/config/*",
+                                    "**/dto/*",
                                     "**/exception/*",
                                     "**/security/*",
                                     "**/support/*"
@@ -127,6 +128,7 @@ jacocoTestCoverageVerification {
                     '**.*Application*',
                     '**.*Controller*',
                     '**.config.*',
+                    '**.dto.*',
                     '**.exception.*',
                     '**.security.*',
                     '**.support.*'

--- a/build.gradle
+++ b/build.gradle
@@ -34,16 +34,6 @@ for (qPattern in "**/QA" .. "**/QZ") {
     Qdomains.add(qPattern + "*")
 }
 
-def jacocoExcludePatterns = [
-        "**/*Application*",
-        "**/*Controller*",
-        "**/config/*",
-        "**/dto/*",
-        "**/exception/*",
-        "**/security/*",
-        "**/support/*"
-]
-
 sonar {
     properties {
         property 'sonar.host.url', 'https://sonarcloud.io'
@@ -53,7 +43,8 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', jacocoExcludePatterns.join(',')
+        property 'sonar.exclusions', '**/*Application*.java, **/*Controller*.java ,**/config/**, **/dto/**, ' +
+                '**/exception/**, **/security/**, **/support/**, **/Q*.java'
         property 'sonar.test.inclusions', '**/*Test*.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }
@@ -73,7 +64,16 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
-                    fileTree(dir: it, excludes: jacocoExcludePatterns + Qdomains)
+                    fileTree(dir: it, excludes:
+                            [
+                                    "**/*Application*",
+                                    "**/*Controller*",
+                                    "**/config/*",
+                                    "**/dto/*",
+                                    "**/exception/*",
+                                    "**/security/*",
+                                    "**/support/*"
+                            ]+ Qdomains)
                 })
         )
     }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/*Application*.java, **/*Controller*.java ,**/config/**, **/dto/**, ' +
+        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**, **/dto/**, ' +
                 '**/exception/**, **/security/**, **/support/**, **/Q*.java'
         property 'sonar.test.inclusions', '**/*Test*.java'
         property 'sonar.java.coveragePlugin', 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '2.7.9'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'jacoco'
+    id 'org.sonarqube' version '4.2.1.3168'
 }
 
 group = 'mocacong'
@@ -21,6 +22,22 @@ configurations {
 
 jacoco {
     toolVersion = '0.8.8'
+}
+
+sonar {
+    properties {
+        property 'sonar.host.url', 'https://sonarcloud.io'
+        property 'sonar.organization', 'mocacong'
+        property 'sonar.projectKey', 'mocacong_Mocacong-Backend'
+        property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/index.xml'
+        property 'sonar.sources', 'src'
+        property 'sonar.language', 'java'
+        property 'sonar.sourceEncoding', 'UTF-8'
+        property 'sonar.exclusions', '**/*Application*.java, **/*Controller*.java, **/config/**, **/dto/**, ' +
+                '**/exception/**, **/security/**, **/support/**'
+        property 'sonar.test.inclusions', '**/*Test*.java'
+        property 'sonar.java.coveragePlugin', 'jacoco'
+    }
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -55,10 +55,8 @@ jacocoTestReport {
     reports{
         html.required.set(true)
         xml.required.set(true)
-        csv.required.set(true)
         html.destination file("$buildDir/reports/jacoco/index.html")
         xml.destination file("$buildDir/reports/jacoco/index.xml")
-        csv.destination file("$buildDir/reports/jacoco/index.csv")
     }
 
     afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.9'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'jacoco'
 }
 
 group = 'mocacong'
@@ -16,6 +17,10 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+}
+
+jacoco {
+    toolVersion = '0.8.8'
 }
 
 repositories {
@@ -47,4 +52,78 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports{
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(true)
+        html.destination file("$buildDir/reports/jacoco/index.html")
+        xml.destination file("$buildDir/reports/jacoco/index.xml")
+        csv.destination file("$buildDir/reports/jacoco/index.csv")
+    }
+
+    def Qdomains = []
+    for (qPattern in "**/QA" .. "**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            // 측정 안하고 싶은 패턴
+                            "**/*Application*",
+                            "**/*Controller*",
+                            "**/config/*",
+                            "**/dto/*",
+                            "**/exception/*",
+                            "**/security/*",
+                            "**/support/*"
+                            // Querydsl 관련 제거
+                    ] + Qdomains)
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    def Qdomains = []
+    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+        Qdomains.add(qPattern + '*')
+    }
+
+    violationRules {
+        rule {
+            failOnViolation = false
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            excludes = [
+                    "**.*Application*",
+                    "**.*Controller*",
+                    "**.config.*",
+                    "**.dto.*",
+                    "**.exception.*",
+                    "**.security.*",
+                    "**.support.*"
+            ] + Qdomains
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,26 @@ jacoco {
     toolVersion = '0.8.8'
 }
 
+test {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+def Qdomains = []
+for (qPattern in "**/QA" .. "**/QZ") {
+    Qdomains.add(qPattern + "*")
+}
+
+def jacocoExcludePatterns = [
+        "**/*Application*",
+        "**/*Controller*",
+        "**/config/*",
+        "**/dto/*",
+        "**/exception/*",
+        "**/security/*",
+        "**/support/*"
+]
+
 sonar {
     properties {
         property 'sonar.host.url', 'https://sonarcloud.io'
@@ -33,10 +53,62 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/*Application*.java, **/*Controller*.java, **/config/**, **/dto/**, ' +
-                '**/exception/**, **/security/**, **/support/**'
+        property 'sonar.exclusions', jacocoExcludePatterns.join(',')
         property 'sonar.test.inclusions', '**/*Test*.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
+    }
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports{
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(true)
+        html.destination file("$buildDir/reports/jacoco/index.html")
+        xml.destination file("$buildDir/reports/jacoco/index.xml")
+        csv.destination file("$buildDir/reports/jacoco/index.csv")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: jacocoExcludePatterns + Qdomains)
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            failOnViolation = false
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            excludes = [
+                    '**.*Application*',
+                    '**.*Controller*',
+                    '**.config.*',
+                    '**.dto.*',
+                    '**.exception.*',
+                    '**.security.*',
+                    '**.support.*'
+            ] + Qdomains
+        }
     }
 }
 
@@ -65,82 +137,4 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured'
     testImplementation 'it.ozimov:embedded-redis:0.7.2'
-}
-
-test {
-    useJUnitPlatform()
-    finalizedBy 'jacocoTestReport'
-}
-
-jacocoTestReport {
-    dependsOn test
-    reports{
-        html.required.set(true)
-        xml.required.set(true)
-        csv.required.set(true)
-        html.destination file("$buildDir/reports/jacoco/index.html")
-        xml.destination file("$buildDir/reports/jacoco/index.xml")
-        csv.destination file("$buildDir/reports/jacoco/index.csv")
-    }
-
-    def Qdomains = []
-    for (qPattern in "**/QA" .. "**/QZ") {
-        Qdomains.add(qPattern + "*")
-    }
-
-    afterEvaluate {
-        classDirectories.setFrom(
-                files(classDirectories.files.collect {
-                    fileTree(dir: it, excludes: [
-                            // 측정 안하고 싶은 패턴
-                            "**/*Application*",
-                            "**/*Controller*",
-                            "**/config/*",
-                            "**/dto/*",
-                            "**/exception/*",
-                            "**/security/*",
-                            "**/support/*"
-                            // Querydsl 관련 제거
-                    ] + Qdomains)
-                })
-        )
-    }
-    finalizedBy 'jacocoTestCoverageVerification'
-}
-
-jacocoTestCoverageVerification {
-    def Qdomains = []
-    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
-        Qdomains.add(qPattern + '*')
-    }
-
-    violationRules {
-        rule {
-            failOnViolation = false
-            enabled = true
-            element = 'CLASS'
-
-            limit {
-                counter = 'LINE'
-                value = 'COVEREDRATIO'
-                minimum = 0.70
-            }
-
-            limit {
-                counter = 'BRANCH'
-                value = 'COVEREDRATIO'
-                minimum = 0.70
-            }
-
-            excludes = [
-                    "**.*Application*",
-                    "**.*Controller*",
-                    "**.config.*",
-                    "**.dto.*",
-                    "**.exception.*",
-                    "**.security.*",
-                    "**.support.*"
-            ] + Qdomains
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,33 @@ configurations {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.amazonaws:aws-java-sdk-ses:1.12.429'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.slack.api:slack-api-client:1.29.0'
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+    implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
+}
+
 jacoco {
     toolVersion = '0.8.8'
 }
@@ -43,7 +70,7 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**, **/dto/**, ' +
+        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**,' +
                 '**/exception/**, **/security/**, **/support/**, **/Q*.java'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
@@ -67,7 +94,6 @@ jacocoTestReport {
                                     "**/*Application*",
                                     "**/*Controller*",
                                     "**/config/*",
-                                    "**/dto/*",
                                     "**/exception/*",
                                     "**/security/*",
                                     "**/support/*"
@@ -101,38 +127,10 @@ jacocoTestCoverageVerification {
                     '**.*Application*',
                     '**.*Controller*',
                     '**.config.*',
-                    '**.dto.*',
                     '**.exception.*',
                     '**.security.*',
                     '**.support.*'
             ] + Qdomains
         }
     }
-}
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-aop'
-    implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'com.amazonaws:aws-java-sdk-ses:1.12.429'
-    implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
-    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-    implementation 'com.slack.api:slack-api-client:1.29.0'
-    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
-    implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'io.rest-assured:rest-assured'
-    testImplementation 'it.ozimov:embedded-redis:0.7.2'
 }


### PR DESCRIPTION
## 개요
- 모카콩 백엔드 코드를 정적 분석하기 위해 Jacoco 및 SonarCloud를 도입했습니다. 
- 정적 분석 도구로 SonarQube를 선택할 수도 있었지만 SonarQube의 경우, 직접 세팅까지 해야하고 PR 코멘트 또한 유료 기능이라 해서 SonarCloud를 선택했습니다.

## 작업사항
- Jacoco 세팅
- SonarCloud 세팅
  - CI 스크립트 수정
  - 모카콩 QualityGate 기준 
    - <img width="300" alt="image" src="https://github.com/mocacong/Mocacong-Backend/assets/69844138/1fb33432-db83-4d1e-a5d3-9c944555adbb">
 

## 주의사항
- 추가적으로 커버리지 영역에서 제외해야 할 클래스가 있다면 알려주세요
- QualityGate 기준을 수정하고 싶은 부분이 있다면 알려주세요
