### PR TITLE
fix: 소나클라우드 커버리지 대상 exclusions 범위 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java, **/config/**' +
+        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java, **/*Config.java' +
                 '**/*Response.java, **/*Exception.java, **/security/**, **/support/**, **/Q*.java'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**, **/dto/**' +
-                '**/exception/**, **/security/**, **/support/**, **/Q*.java'
+        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**'+
+                '**/*Response.java, **/*Exception.java, **/security/**, **/support/**, **/Q*.java'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ sonar {
         property 'sonar.sources', 'src'
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
-        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java ,**/config/**'+
+        property 'sonar.exclusions', '**/test/**, **/resources/**, **/*Application*.java, **/*Controller*.java, **/config/**' +
                 '**/*Response.java, **/*Exception.java, **/security/**, **/support/**, **/Q*.java'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'


### PR DESCRIPTION
## 개요
- 소나클라우드에서 커버리지 측정할 때, exception과 Response에 해당하는 부분들까지 포함하여 측정해서 해당 부분을 제대로 제외하도록 수정했습니다.

## 작업사항
- 소나클라우드 커버리지 대상 exclusions 수정

## 주의사항
- 이제 exception과 response는 측정에서 제외되는 거로 보이는데 config도 갑자기 측정돼서 이것도 다시 제외되도록 수정은 했습니다.